### PR TITLE
fix for graticule not working with ggplot of world2 wrapping around longitude [0,360]

### DIFF
--- a/R/graticule.R
+++ b/R/graticule.R
@@ -118,17 +118,22 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 
 	bb = st_bbox(box_ll)
 	if (is.null(lon)) {
-		lon = if (bb[1] < -170 && bb[3] > 170) # "global"
-				seq(-180, 180, by = 60)
-			else
-				pretty(bb[c(1,3)], n = 6)
+	  if (bb[3] <= 180 && bb[1] < -170 && bb[3] > 170){
+	    lon = seq(-180, 180, by=60)
+	  } else {
+	    lon = pretty(bb[c(1,3)], n = 6)
+	  }
 	}
 	if (is.null(lat))
 		lat = pretty(bb[c(2,4)], n = 6)
 
 	# sanity:
 	if (isTRUE(st_is_longlat(datum))) {
-		lon = lon[lon >= -180 & lon <= 180]
+	  if (max(lon)>180){
+		  lon = lon[lon >= 0 & lon <= 360]
+	  } else {
+		  lon = lon[lon >= -180 & lon <= 180]
+	  }
 		lat = lat[lat > -90 & lat < 90]
 	}
 
@@ -183,19 +188,21 @@ graticule_attributes = function(df) {
 		function(x) { y = x[[length(x)]]; n = nrow(y); apply(y[(n-1):n,], 2, diff) } ))
 	df$angle_end = apply(dxdy, 1, function(x) atan2(x[2], x[1])*180/pi)
 	bb = st_bbox(df)
-    selE = df$type == "E" & df$y_start < min(df$y_start) + 0.001 * (bb[3] - bb[1])
+  selE = df$type == "E" & df$y_start < min(df$y_start) + 0.001 * (bb[3] - bb[1])
 	selN = df$type == "N" & df$x_start < min(df$x_start) + 0.001 * (bb[4] - bb[2])
 	df$plot12 = selE | selN
 	df
 }
 
-trim_bb = function(bb = c(-180, -90, 180, 90), margin) {
+trim_bb = function(bb = c(-180, -90, 180, 90), margin, wrap=c(-180,180)) {
 	stopifnot(margin > 0 && margin <= 1.0)
 	fr = 1.0 - margin
-	if (bb[1] < -180 * fr)
-		bb[1] = -180 * fr
-	if (bb[3] > 180 * fr)
-		bb[3] = 180 * fr
+	if (max(bb) > 180)
+	  wrap=c(0,360)
+	if (bb[1] < wrap[1] * fr)
+		bb[1] = wrap[1] * fr
+	if (bb[3] > wrap[2] * fr)
+		bb[3] = wrap[2] * fr
 	if (bb[2] < -90 * fr)
 		bb[2] = -90 * fr
 	if (bb[4] > 90 * fr)


### PR DESCRIPTION
Fix for graticule not working with ggplot of world2 wrapping around longitude [0,360] https://github.com/r-spatial/sf/issues/421.

```r
library(ggplot2)
library(maps)
devtools::install_github('bbest/sf')
library(sf)

wrld2 = st_as_sf(map('world2', plot=F, fill=T))
ggplot() +
  geom_sf(data=wrld2, fill='lightgray') +
  coord_sf(xlim=c(140,295), ylim=c(5,60))
```

![image](https://user-images.githubusercontent.com/2837257/28239044-423f962e-6917-11e7-9100-2cb284aa6662.png)

vs before...

```r
library(ggplot2)
library(maps)
devtools::install_github('r-spatial/sf')
library(sf) 

wrld2 = st_as_sf(map('world2', plot=F, fill=T))
ggplot() +
  geom_sf(data=wrld2, fill='lightgray') +
  coord_sf(xlim=c(140,295), ylim=c(5,60))
````

![image](https://user-images.githubusercontent.com/2837257/28239014-d8a3ee50-6915-11e7-9b9c-cfea8bb2e7eb.png)
