### PR TITLE
Remove trailing spaces

### DIFF
--- a/CONDUCT.md
+++ b/CONDUCT.md
@@ -1,6 +1,6 @@
 # Contributor Code of Conduct
 
-As contributors and maintainers of this project, we pledge to respect all people who 
+As contributors and maintainers of this project, we pledge to respect all people who
 contribute through reporting issues, posting feature requests, updating documentation,
 submitting pull requests or patches, and other activities.
 
@@ -13,13 +13,13 @@ imagery, derogatory comments or personal attacks, trolling, public or private ha
 insults, or other unprofessional conduct.
 
 Project maintainers have the right and responsibility to remove, edit, or reject comments,
-commits, code, wiki edits, issues, and other contributions that are not aligned to this 
-Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed 
+commits, code, wiki edits, issues, and other contributions that are not aligned to this
+Code of Conduct. Project maintainers who do not follow the Code of Conduct may be removed
 from the project team.
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by
 opening an issue or contacting one or more of the project maintainers.
 
-This Code of Conduct is adapted from the Contributor Covenant 
-(http:contributor-covenant.org), version 1.0.0, available at 
+This Code of Conduct is adapted from the Contributor Covenant
+(http:contributor-covenant.org), version 1.0.0, available at
 http://contributor-covenant.org/version/1/0/0/

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sf
 Version: 0.5-3
 Title: Simple Features for R
-Description: Support for simple features, a standardized way to encode spatial vector data. Binds 
+Description: Support for simple features, a standardized way to encode spatial vector data. Binds
     to GDAL for reading and writing data, to GEOS for geometrical operations, and to Proj.4 for projection
 	conversions and datum transformations.
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"), email = "edzer.pebesma@uni-muenster.de"),
@@ -15,20 +15,20 @@ Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"), email = "edzer.p
 	person("Etienne", "Racine", role = "ctb"))
 Depends:
     R (>= 3.3.0)
-Imports: 
-    utils, 
-    stats, 
-    tools, 
-    graphics, 
-    grDevices, 
-    grid, 
-    methods, 
-    Rcpp, 
+Imports:
+    utils,
+    stats,
+    tools,
+    graphics,
+    grDevices,
+    grid,
+    methods,
+    Rcpp,
     DBI (>= 0.5),
     units (>= 0.4),
 	magrittr
-Suggests: 
-    sp (>= 1.2-4), 
+Suggests:
+    sp (>= 1.2-4),
     rgeos,
     rgdal,
     lazyeval,
@@ -41,8 +41,8 @@ Suggests:
     testthat,
     knitr,
     tidyr,
-    geosphere (>= 1.5-5), 
-    maptools, 
+    geosphere (>= 1.5-5),
+    maptools,
     maps,
 	microbenchmark
 LinkingTo: Rcpp
@@ -75,7 +75,7 @@ Collate:
 	cast_sfc.R
 	graticule.R
 	datasets.R
-	aggregate.R 
+	aggregate.R
 	agr.R
 	maps.R
 	join.R

--- a/NEWS.md
+++ b/NEWS.md
@@ -78,11 +78,11 @@
 
 * fix bug where `geom_sf` wouldn't deal with Z and/or M geoms; #373
 
-* return more conveniently typed empty geoms; #372 
+* return more conveniently typed empty geoms; #372
 
 * fix subsetting with `[` of `sf` using `drop = TRUE`, #370
 
-* in addition to `m`, allow `rad` units to `st_segmentize` 
+* in addition to `m`, allow `rad` units to `st_segmentize`
 
 * add example how to `st_read` GeoJSON from a string; #185
 
@@ -186,13 +186,13 @@
 
 * add `st_coordinates` method, returning coordinates matrix with indexes
 
-* remove `unlist.sfg` 
+* remove `unlist.sfg`
 
 * add `as.matrix.sfg`; have as.matrix.sfg add indexes to coordinates
 
 * add `st_bind_cols` method
 
-* improve handling features that can't be projected 
+* improve handling features that can't be projected
 
 * support uniform sampling over polygons on the sphere
 

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -4,7 +4,7 @@ Applicant: [Edzer Pebesma](https://github.com/edzer/), [Institute for Geoinforma
 
 Supporting authors: Edzer Pebesma, Roger Bivand, Michael Sumner, Robert Hijmans, Virgilio Gómez-Rubio
 
-[Simple features](https://en.wikipedia.org/wiki/Simple_Features) is an open ([OGC](http://www.opengeospatial.org/standards/sfa) and [ISO](http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=40114)) interface standard for access and manipulation of spatial vector data (points, lines, polygons). It includes a standard [SQL schema](http://www.opengeospatial.org/standards/sfs) that supports storage, retrieval, query and update of feature collections via a SQL interface. All commonly used databases provide this interface. [GeoJSON](http://geojson.org/) is a standard for encoding simple features in JSON, and is used in JavaScript and MongoDB. Well-known-text ([WKT](https://en.wikipedia.org/wiki/Well-known_text)) is a text representation of simple features used often in linked data; well-known-binary ([WKB] (https://en.wikipedia.org/wiki/Well-known_text)) a standard binary representation used in databases. _Simple Feature Access_ defines coordinate reference systems, and makes it easy to move data from longitude-latitude to projections back and forth in a standardized way. 
+[Simple features](https://en.wikipedia.org/wiki/Simple_Features) is an open ([OGC](http://www.opengeospatial.org/standards/sfa) and [ISO](http://www.iso.org/iso/home/store/catalogue_tc/catalogue_detail.htm?csnumber=40114)) interface standard for access and manipulation of spatial vector data (points, lines, polygons). It includes a standard [SQL schema](http://www.opengeospatial.org/standards/sfs) that supports storage, retrieval, query and update of feature collections via a SQL interface. All commonly used databases provide this interface. [GeoJSON](http://geojson.org/) is a standard for encoding simple features in JSON, and is used in JavaScript and MongoDB. Well-known-text ([WKT](https://en.wikipedia.org/wiki/Well-known_text)) is a text representation of simple features used often in linked data; well-known-binary ([WKB] (https://en.wikipedia.org/wiki/Well-known_text)) a standard binary representation used in databases. _Simple Feature Access_ defines coordinate reference systems, and makes it easy to move data from longitude-latitude to projections back and forth in a standardized way.
 
 
 [GDAL](http://gdal.org/) is an open source C++ library for reading and writing both raster and vector data with more than 225 drivers (supported file formats, data base connectors, web service interfaces). GDAL is used by practically all open source geospatial projects and by many industry products (including ESRI's ArcGIS, ERDAS, and FME). It provides coordinate transformations (built on top of PROJ.4) and geometric operations (e.g. polygon intersections, unions, buffers and distance). Standards for coordinate transformations change over time; such changes are typically adopted directly in GDAL/PROJ.4 but do not easily find their way into R-only packages such as `mapproj`.
@@ -50,7 +50,7 @@ Failure modes and recovery plan:
 
 1. Failure mode: S3 classes are too simple to represent simple
 features class hierarchy. Recovery plan: try (i) using a list column
-with geometry, and nested lists to represent nested structures; (ii) 
+with geometry, and nested lists to represent nested structures; (ii)
 use a `WKT` character column; (iii) using a `WKB` blob column
 
 2. Migrating `sp` breaks downstream packages. Recovery plan: involve

--- a/R/agr.R
+++ b/R/agr.R
@@ -37,7 +37,7 @@ st_agr.factor = function(x, ...) {
 }
 
 #' @export
-st_agr.default = function(x = NA_character_, ...) { 
+st_agr.default = function(x = NA_character_, ...) {
 	stopifnot(all(is.na(x)))
 	structure(st_agr(as.character(x)), names = names(x))
 }
@@ -53,7 +53,7 @@ st_agr.default = function(x = NA_character_, ...) {
 	nv = setdiff(names(x), attr(x, "sf_column"))
 	if (length(value) == 0)
 		attr(x, "agr") = NA_agr_[0]
-	else if (! is.null(names(value)) && length(value) == 1) { 
+	else if (! is.null(names(value)) && length(value) == 1) {
 		# as in: st_agr(x) = c(Group.1 = "identity"): replace one particular named
 		if (!is.null(attr(x, "agr")))
 			attr(x, "agr")[names(value)] = st_agr(value)
@@ -79,7 +79,7 @@ st_agr.default = function(x = NA_character_, ...) {
 
 #' @name st_agr
 #' @export
-st_set_agr = function(x, value) { 
+st_set_agr = function(x, value) {
 	st_agr(x) = value
 	x
 }

--- a/R/arith.R
+++ b/R/arith.R
@@ -30,7 +30,7 @@ Ops.sfg <- function(e1, e2) {
 
 	if (!(prd || pm || mod))
 		stop(paste("operation", .Generic, "not supported for sfg objects"))
-	
+
 	if (is.na(st_dimension(e1))) # empty:
 		return(e1)
 
@@ -53,7 +53,7 @@ Ops.sfg <- function(e1, e2) {
 			diag(Mat) = e2
 		else
 			Mat = e2
-	} 
+	}
 
 	if_pt = function(x, y) { if(inherits(x, "POINT")) as.vector(y) else y }
 	fn = if (prd)
@@ -62,14 +62,14 @@ Ops.sfg <- function(e1, e2) {
 			function(x, Mat, Vec) structure(if_pt(x, unclass(x) + conform(Vec, x)), class = class(x))
 		else # mod:
 			function(x, Mat, Vec) structure(if_pt(x, unclass(x) %% conform(Vec, x)), class = class(x))
-		
+
 	if (is.list(e1))
 		rapply(e1, fn, how = "replace", Mat = Mat, Vec = Vec)
 	else
 		fn(e1, Mat, Vec)
 }
 
-conform = function(vec, m) { 
+conform = function(vec, m) {
 	if (is.matrix(m))
 		t(matrix(vec, ncol(m), nrow(m)))
 	else

--- a/R/bbox.R
+++ b/R/bbox.R
@@ -2,8 +2,8 @@
 #' @details
 #' \code{NA_bbox_} is the \code{bbox} object with a missing value.
 #' @export
-NA_bbox_ = structure(rep(NA_real_, 4), 
-	names = c("xmin", "ymin", "xmax", "ymax"), 
+NA_bbox_ = structure(rep(NA_real_, 4),
+	names = c("xmin", "ymin", "xmax", "ymax"),
 	crs = NA_crs_,
 	class = "bbox")
 
@@ -23,25 +23,25 @@ bbox.Set = function(obj) {
 		bb_wrap(CPL_get_bbox(unclass(obj)[sel], 0))
 }
 bbox.Mtrx = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(list(obj), 1)) # note the list()
 }
 bbox.MtrxSet = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(obj, 1))
 }
 bbox.MtrxSetSet = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(obj, 2))
 }
 bbox.MtrxSetSetSet = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(obj, 3))
@@ -55,7 +55,7 @@ bbox.MtrxSetSetSet = function(obj) {
 #' @return a numeric vector of length four, with \code{xmin}, \code{ymin}, \code{xmax}
 #' and \code{ymax} values; if \code{obj} is of class \code{sf} or \code{sfc}, the object
 #' returned has a class \code{bbox}, an attribute \code{crs} and a method to print the
-#' bbox and an \code{st_crs} method to retrieve the coordinate reference system 
+#' bbox and an \code{st_crs} method to retrieve the coordinate reference system
 #' corresponding to \code{obj} (and hence the bounding box).
 #' @name st_bbox
 st_bbox = function(obj) UseMethod("st_bbox")
@@ -84,7 +84,7 @@ bbox_list = function(obj) {
 	if (length(s) == 0 || all(is.na(s[1L,])))
 		NA_bbox_
 	else
-		bb_wrap(c(min(s[1L,], na.rm = TRUE), min(s[2L,], na.rm = TRUE), 
+		bb_wrap(c(min(s[1L,], na.rm = TRUE), min(s[2L,], na.rm = TRUE),
 		  max(s[3L,], na.rm = TRUE), max(s[4L,], na.rm = TRUE)))
 }
 #' @export
@@ -126,7 +126,7 @@ print.bbox = function(x, ...) {
 	print(unclass(x))
 }
 
-compute_bbox = function(obj) { 
+compute_bbox = function(obj) {
 	switch(class(obj)[1],
 		sfc_POINT = bb_wrap(bbox.Set(obj)),
 		sfc_MULTIPOINT = bb_wrap(bbox.MtrxSet(obj)),

--- a/R/bind.R
+++ b/R/bind.R
@@ -4,7 +4,7 @@
 #' @param ... objects to bind
 #' @param deparse.level integer; see \link[base]{rbind}
 #' @name bind
-#' @details both \code{rbind} and \code{cbind} have non-standard method dispatch (see \link[base]{cbind}): the \code{rbind} or \code{cbind} method for \code{sf} objects is only called when all arguments to be binded are of class \code{sf}. 
+#' @details both \code{rbind} and \code{cbind} have non-standard method dispatch (see \link[base]{cbind}): the \code{rbind} or \code{cbind} method for \code{sf} objects is only called when all arguments to be binded are of class \code{sf}.
 #' @export
 #' @examples
 #' crs = st_crs(3857)
@@ -12,7 +12,7 @@
 #' b = st_sf(a=1, geom = st_sfc(st_linestring(matrix(1:4,2))), crs = crs)
 #' c = st_sf(a=4, geom = st_sfc(st_multilinestring(list(matrix(1:4,2)))), crs = crs)
 #' rbind(a,b,c)
-#' rbind(a,b) 
+#' rbind(a,b)
 #' rbind(a,b)
 #' rbind(b,c)
 rbind.sf = function(..., deparse.level = 1) {
@@ -26,7 +26,7 @@ rbind.sf = function(..., deparse.level = 1) {
 	ret = st_sf(rbind.data.frame(...), crs = crs0)
 	st_geometry(ret) = st_sfc(st_geometry(ret)) # might need to reclass to GEOMETRY
 	bb = do.call(rbind, lapply(dots, st_bbox))
-	bb = bb_wrap(c(min(bb[,1L], na.rm = TRUE), min(bb[,2L], na.rm = TRUE), 
+	bb = bb_wrap(c(min(bb[,1L], na.rm = TRUE), min(bb[,2L], na.rm = TRUE),
 		  max(bb[,3L], na.rm = TRUE), max(bb[,4L], na.rm = TRUE)))
 	attr(ret[[ attr(ret, "sf_column") ]], "bbox") = bb
 	ret

--- a/R/cast_sfc.R
+++ b/R/cast_sfc.R
@@ -67,7 +67,7 @@ close_polygon_or_multipolygon = function(x, to) {
 # (vertical cast)
 reclass = function(x, to, must_close) {
 	l = if (length(x)) {
-		full_cls = c(class(x[[1]])[1], to, "sfg") 
+		full_cls = c(class(x[[1]])[1], to, "sfg")
 		if (must_close)
 			x = close_polygon_or_multipolygon(x, to)
 		lapply(x, function(g) structure(g, class = full_cls))
@@ -88,24 +88,24 @@ get_lengths = function(x) {
 }
 
 #' Coerce geometry to MULTI* geometry
-#' 
-#' Mixes of POINTS and MULTIPOINTS, LINESTRING and MULTILINESTRING, 
+#'
+#' Mixes of POINTS and MULTIPOINTS, LINESTRING and MULTILINESTRING,
 #' POLYGON and MULTIPOLYGON are returned as MULTIPOINTS, MULTILINESTRING and MULTIPOLYGONS respectively
 #' @param x list of geometries or simple features
-#' @details Geometries that are already MULTI* are left unchanged. 
-#' Features that can't be cast to a single  MULTI* geometry are return as a 
+#' @details Geometries that are already MULTI* are left unchanged.
+#' Features that can't be cast to a single  MULTI* geometry are return as a
 #' GEOMETRYCOLLECTION
 st_cast_sfc_default = function(x) {
   if (!identical(unique(vapply(x, function(w) class(w)[3L], "")), "sfg"))
     stop("list item(s) not of class sfg") # sanity check
-  
+
   a <- attributes(x)
   ids = NULL
   cls = unique(vapply(x, function(x) class(x)[2L], ""))
   if (length(cls) > 1) {
     if (all(cls %in% c("POINT", "MULTIPOINT"))) {
       x <- lapply(x, function(x) if (inherits(x, "POINT")) POINT2MULTIPOINT(x) else x)
-      class(x) <- c("sfc_MULTIPOINT", "sfc") 
+      class(x) <- c("sfc_MULTIPOINT", "sfc")
     } else if (all(cls %in% c("LINESTRING", "MULTILINESTRING"))) {
       x <- lapply(x, function(x) if (inherits(x, "LINESTRING")) LINESTRING2MULTILINESTRING(x) else x)
       class(x) <- c("sfc_MULTILINESTRING", "sfc")
@@ -127,7 +127,7 @@ st_cast_sfc_default = function(x) {
 #' @param ... ignored
 #' @export
 #' @return In case \code{to} is missing, \code{st_cast.sfc} will coerce combinations of "POINT" and "MULTIPOINT", "LINESTRING" and "MULTILINESTRING", "POLYGON" and "MULTIPOLYGON" into their "MULTI..." form, or in case all geometries are "GEOMETRYCOLLECTION" will return a list of all the contents of the "GEOMETRYCOLLECTION" objects, or else do nothing. In case \code{to} is specified, if \code{to} is "GEOMETRY", geometries are not converted, else, \code{st_cast} will try to coerce all elements into \code{to}; \code{ids} may be specified to group e.g. "POINT" objects into a "MULTIPOINT", if not specified no grouping takes place. If e.g. a "sfc_MULTIPOINT" is cast to a "sfc_POINT", the objects are split, so no information gets lost, unless \code{group_or_split} is \code{FALSE}.
-#' 
+#'
 st_cast.sfc = function(x, to, ..., ids = seq_along(x), group_or_split = TRUE) {
 	if (missing(to))
 		return(st_cast_sfc_default(x))
@@ -161,10 +161,10 @@ st_cast.sfc = function(x, to, ..., ids = seq_along(x), group_or_split = TRUE) {
 		reclass(ret, to, need_close(to))
 	} else { # "horizontal", to the left: split
 		ret = if (from_col == 1)
-				unlist(lapply(x, function(m) lapply(seq_len(nrow(m)), 
+				unlist(lapply(x, function(m) lapply(seq_len(nrow(m)),
 						function(i) structure(m[i,], class = class(m)))),
 					recursive = FALSE)
-			else 
+			else
 				lapply(do.call(c, x), function(y) structure(y, class = class(x[[1]])))
 		attributes(ret) = attributes(x)
 		structure(reclass(ret, to, need_close(to)), ids = get_lengths(x))

--- a/R/cast_sfg.R
+++ b/R/cast_sfg.R
@@ -1,6 +1,6 @@
-## utility functions, patterns that are either used elsewhere or can be 
-##  replaced by other changes 
-## 
+## utility functions, patterns that are either used elsewhere or can be
+##  replaced by other changes
+##
 ## worker functions from the internals of c.sfg
 ##  to unclass the underlying coordinates
 Paste0 <- function(lst) lapply(lst, unclass)
@@ -8,11 +8,11 @@ Paste0 <- function(lst) lapply(lst, unclass)
 ## drop the tail coordinate of a polygon ring
 Tail1 <- function(lst) lapply(lst, head, -1)
 
-ClosePol <- function(mtrx) { 
+ClosePol <- function(mtrx) {
 	stopifnot(is.matrix(mtrx))
-	if (!all(mtrx[1,] == mtrx[nrow(mtrx),])) 
-		rbind(mtrx, mtrx[1,]) 
-	else 
+	if (!all(mtrx[1,] == mtrx[nrow(mtrx),]))
+		rbind(mtrx, mtrx[1,])
+	else
 		mtrx
 }
 
@@ -39,37 +39,37 @@ ClosePol <- function(mtrx) {
 
 #' @name st_cast
 #' @export
-#' @examples 
+#' @examples
 #' example(st_read)
 #' mpl <- nc$geometry[[4]]
 #' #st_cast(x) ## error 'argument "to" is missing, with no default'
 #' cast_all <- function(xg) {
-#'   lapply(c("MULTIPOLYGON", "MULTILINESTRING", "MULTIPOINT", "POLYGON", "LINESTRING", "POINT"), 
+#'   lapply(c("MULTIPOLYGON", "MULTILINESTRING", "MULTIPOINT", "POLYGON", "LINESTRING", "POINT"),
 #'       function(x) st_cast(xg, x))
 #' }
 #' st_sfc(cast_all(mpl))
 #' ## no closing coordinates should remain for multipoint
 #' any(duplicated(unclass(st_cast(mpl, "MULTIPOINT"))))  ## should be FALSE
-#' ## number of duplicated coordinates in the linestrings should equal the number of polygon rings 
+#' ## number of duplicated coordinates in the linestrings should equal the number of polygon rings
 #' ## (... in this case, won't always be true)
 #' sum(duplicated(do.call(rbind, unclass(st_cast(mpl, "MULTILINESTRING"))))
 #'      ) == sum(unlist(lapply(mpl, length)))  ## should be TRUE
-#' 
+#'
 #' p1 <- structure(c(0, 1, 3, 2, 1, 0, 0, 0, 2, 4, 4, 0), .Dim = c(6L, 2L))
 #' p2 <- structure(c(1, 1, 2, 1, 1, 2, 2, 1), .Dim = c(4L, 2L))
 #' st_polygon(list(p1, p2))
 st_cast.MULTIPOLYGON <- function(x, to, ...) {
-	switch(to, 
-		MULTIPOLYGON = x, 
-		MULTILINESTRING = st_multilinestring(     unlist(Paste0(x), recursive = FALSE, use.names = FALSE)), 
-		MULTIPOINT = st_multipoint(do.call(rbind, Tail1(unlist(Paste0(x), recursive = FALSE, use.names = FALSE)))), 
+	switch(to,
+		MULTIPOLYGON = x,
+		MULTILINESTRING = st_multilinestring(     unlist(Paste0(x), recursive = FALSE, use.names = FALSE)),
+		MULTIPOINT = st_multipoint(do.call(rbind, Tail1(unlist(Paste0(x), recursive = FALSE, use.names = FALSE)))),
          ## loss, drop to first part
 		POLYGON = {
 		 	if (length(x) > 1)
 				warning("polygon from first part only")
 			st_polygon(x[[1L]])
-		}, 
-		LINESTRING = {warning("line from first ring only"); st_linestring(x[[1L]][[1L]])}, 
+		},
+		LINESTRING = {warning("line from first ring only"); st_linestring(x[[1L]][[1L]])},
 		## loss, drop to first coordinate of first ring of first part
 		POINT = {warning("point from first coordinate only"); st_point(x[[1L]][[1L]][1L, , drop = TRUE])},
 		GEOMETRYCOLLECTION = st_geometrycollection(list(x))
@@ -78,23 +78,23 @@ st_cast.MULTIPOLYGON <- function(x, to, ...) {
 
 #' @name st_cast
 #' @export
-#' @examples 
+#' @examples
 #' mls <- st_cast(nc$geometry[[4]], "MULTILINESTRING")
 #' st_sfc(cast_all(mls))
 st_cast.MULTILINESTRING <- function(x, to, ...) {
-	switch(to, 
-		MULTIPOLYGON = st_multipolygon(list(lapply(x, ClosePol))), 
-		MULTILINESTRING = x, 
-		MULTIPOINT = st_multipoint(do.call(rbind, Paste0(x))), 
+	switch(to,
+		MULTIPOLYGON = st_multipolygon(list(lapply(x, ClosePol))),
+		MULTILINESTRING = x,
+		MULTIPOINT = st_multipoint(do.call(rbind, Paste0(x))),
 		## loss, drop to first line
-		#POLYGON = {warning("keeping first linestring only"); st_polygon(x[1L])}, 
+		#POLYGON = {warning("keeping first linestring only"); st_polygon(x[1L])},
 		POLYGON = st_polygon(lapply(x, ClosePol)),
 		LINESTRING = {
 			if (length(x) > 1)
 				warning("keeping first linestring only")
 			st_linestring(x[[1L]])
 		},
-		## loss, drop to first coordinate of first line 
+		## loss, drop to first coordinate of first line
 		POINT = {
 			warning("keeping first coordinate only")
 			st_point(x[[1L]][1L, , drop = TRUE])
@@ -109,12 +109,12 @@ st_cast.MULTILINESTRING <- function(x, to, ...) {
 #' mpt <- st_cast(nc$geometry[[4]], "MULTIPOINT")
 #' st_sfc(cast_all(mpt))
 st_cast.MULTIPOINT <- function(x, to, ...) {
-  switch(to, 
+  switch(to,
          ## DANGER: polygon, linestring forms unlikely to be valid
-         MULTIPOLYGON = st_multipolygon(list(list(ClosePol(unclass(x))))), 
-         MULTILINESTRING = st_multilinestring(list(unclass(x))), 
-         MULTIPOINT = x, 
-         POLYGON = st_polygon(list(unclass(ClosePol(x)))), 
+         MULTIPOLYGON = st_multipolygon(list(list(ClosePol(unclass(x))))),
+         MULTILINESTRING = st_multilinestring(list(unclass(x))),
+         MULTIPOINT = x,
+         POLYGON = st_polygon(list(unclass(ClosePol(x)))),
          LINESTRING = st_linestring(unclass(x)),
          ## loss, drop to first coordinate
          POINT = {warning("point from first coordinate only"); st_point(unclass(x)[1L, , drop = TRUE])},
@@ -128,11 +128,11 @@ st_cast.MULTIPOINT <- function(x, to, ...) {
 #' pl <- st_cast(nc$geometry[[4]], "POLYGON")
 #' st_sfc(cast_all(pl))
 st_cast.POLYGON <- function(x, to, ...) {
-  switch(to, 
+  switch(to,
          MULTIPOLYGON = st_multipolygon(list(lapply(Paste0(x), ClosePol))),
-         MULTILINESTRING = st_multilinestring(unclass(x)), 
-         MULTIPOINT = st_multipoint(Tail1(unclass(x))[[1L]]), 
-         POLYGON = x, 
+         MULTILINESTRING = st_multilinestring(unclass(x)),
+         MULTIPOINT = st_multipoint(Tail1(unclass(x))[[1L]]),
+         POLYGON = x,
          LINESTRING = st_linestring(unclass(x)[[1L]]),
          POINT = {warning("point from first coordinate only"); st_point(unclass(x)[[1L]][1L, , drop = TRUE])},
 		 GEOMETRYCOLLECTION = st_geometrycollection(list(x))
@@ -145,11 +145,11 @@ st_cast.POLYGON <- function(x, to, ...) {
 #' ls <- st_cast(nc$geometry[[4]], "LINESTRING")
 #' st_sfc(cast_all(ls))
 st_cast.LINESTRING <- function(x, to, ...) {
-  switch(to, 
-         MULTIPOLYGON = st_multipolygon(list(list(ClosePol(unclass(x))))), 
-         MULTILINESTRING = st_multilinestring(list(unclass(x))), 
-         MULTIPOINT = st_multipoint(unclass(x)), 
-         POLYGON = st_polygon(list(unclass(ClosePol(x)))), 
+  switch(to,
+         MULTIPOLYGON = st_multipolygon(list(list(ClosePol(unclass(x))))),
+         MULTILINESTRING = st_multilinestring(list(unclass(x))),
+         MULTIPOINT = st_multipoint(unclass(x)),
+         POLYGON = st_polygon(list(unclass(ClosePol(x)))),
          LINESTRING = x,
          POINT = {warning("point from first coordinate only"); st_point(unclass(x)[1L, , drop = TRUE])},
 		 GEOMETRYCOLLECTION = st_geometrycollection(list(x))
@@ -160,14 +160,14 @@ st_cast.LINESTRING <- function(x, to, ...) {
 #' @export
 #' @examples
 #' pt <- st_cast(nc$geometry[[4]], "POINT")
-#' ## st_sfc(cast_all(pt))  ## Error: cannot create MULTIPOLYGON from POINT 
+#' ## st_sfc(cast_all(pt))  ## Error: cannot create MULTIPOLYGON from POINT
 #' st_sfc(lapply(c("POINT", "MULTIPOINT"), function(x) st_cast(pt, x)))
 st_cast.POINT <- function(x, to, ...) {
-  switch(to, 
-         MULTIPOLYGON = stop("cannot create MULTIPOLYGON from POINT"), 
-         MULTILINESTRING = stop("cannot create MULTILINESTRING from POINT"), 
-         MULTIPOINT = st_multipoint(matrix(unclass(x), nrow = 1L)), 
-         POLYGON = stop("cannot create POLYGON from POINT"), 
+  switch(to,
+         MULTIPOLYGON = stop("cannot create MULTIPOLYGON from POINT"),
+         MULTILINESTRING = stop("cannot create MULTILINESTRING from POINT"),
+         MULTIPOINT = st_multipoint(matrix(unclass(x), nrow = 1L)),
+         POLYGON = stop("cannot create POLYGON from POINT"),
          LINESTRING = stop("cannot create LINESTRING from POINT"),
          POINT = x,
 		 GEOMETRYCOLLECTION = st_geometrycollection(list(x))
@@ -177,7 +177,7 @@ st_cast.POINT <- function(x, to, ...) {
 #' @name st_cast
 #' @export
 st_cast.GEOMETRYCOLLECTION <- function(x, to, ...) {
-  switch(to, 
+  switch(to,
   	GEOMETRYCOLLECTION = x,
   	{
 		if (length(x) > 1)
@@ -192,7 +192,7 @@ st_cast.GEOMETRYCOLLECTION <- function(x, to, ...) {
 st_cast.CIRCULARSTRING <- function(x, to, ...) {
 	if (to != "LINESTRING")
 		stop("CIRCULARSTRING can only be converted into LINESTRING")
-	CPL_circularstring_to_linestring(structure(list(x), crs = NA_crs_, precision = 0.0, 
+	CPL_circularstring_to_linestring(structure(list(x), crs = NA_crs_, precision = 0.0,
 		class = c("sfc_CIRCULARSTRING", "sfc")))[[1]]
 }
 
@@ -201,7 +201,7 @@ st_cast.CIRCULARSTRING <- function(x, to, ...) {
 st_cast.MULTISURFACE <- function(x, to, ...) {
 	if (! missing(to) && to != "MULTIPOLYGON")
 		stop("MULTISURFACE can only be converted into MULTIPOLYGON")
-	CPL_multisurface_to_multipolygon(structure(list(x), crs = NA_crs_, precision = 0.0, 
+	CPL_multisurface_to_multipolygon(structure(list(x), crs = NA_crs_, precision = 0.0,
 		class = c("sfc_MULTISURFACE", "sfc")))[[1]]
 }
 
@@ -210,7 +210,7 @@ st_cast.MULTISURFACE <- function(x, to, ...) {
 st_cast.COMPOUNDCURVE <- function(x, to, ...) {
 	if (! missing(to))
 		stop("to should be missing")
-	CPL_compoundcurve_to_linear(structure(list(x), crs = NA_crs_, precision = 0.0, 
+	CPL_compoundcurve_to_linear(structure(list(x), crs = NA_crs_, precision = 0.0,
 		class = c("sfc_COMPOUNDCURVE", "sfc")))[[1]]
 }
 
@@ -219,16 +219,16 @@ st_cast.COMPOUNDCURVE <- function(x, to, ...) {
 st_cast.CURVE <- function(x, to, ...) { # nocov start
 	if (! missing(to) && to != "LINESTRING")
 		stop("CURVE can only be converted into LINESTRING")
-	CPL_curve_to_linestring(structure(list(x), crs = NA_crs_, precision = 0.0, 
+	CPL_curve_to_linestring(structure(list(x), crs = NA_crs_, precision = 0.0,
 		class = c("sfc_CURVE", "sfc")))[[1]]
 } # nocov end
 
 # st_cast.class <- function(x, to) {
-#   switch(to, 
-#          MULTIPOLYGON = x, 
-#          MULTILINESTRING = x, 
-#          MULTIPOINT = x, 
-#          POLYGON = x, 
+#   switch(to,
+#          MULTIPOLYGON = x,
+#          MULTILINESTRING = x,
+#          MULTIPOINT = x,
+#          POLYGON = x,
 #          LINESTRING = x,
 #          POINT = x
 #   )

--- a/R/db.R
+++ b/R/db.R
@@ -1,5 +1,5 @@
 #' Read PostGIS table directly, using DBI and binary conversion
-#' 
+#'
 #' Read PostGIS table directly through DBI and RPostgreSQL interface, converting binary
 #' @param conn open database connection
 #' @param table table name
@@ -7,7 +7,7 @@
 #' @param geom_column character or integer: indicator of name or position of the geometry column; if not provided, the last column of type character is chosen
 #' @param EWKB logical; is the WKB is of type EWKB? if missing, defaults to \code{TRUE} if \code{conn} is of class code{PostgreSQLConnection} or \code{PqConnection}, and to \code{FALSE} otherwise
 #' @details if \code{table} is not given but \code{query} is, the spatial reference system (crs) of the table queried is only available in case it has been stored into each geometry record (e.g., by PostGIS, when using EWKB)
-#' @examples 
+#' @examples
 #' \dontrun{
 #' library(RPostgreSQL)
 #' conn = dbConnect(PostgreSQL(), dbname = "postgis")
@@ -22,7 +22,7 @@ st_read_db = function(conn = NULL, table = NULL, query = NULL,
 					  geom_column = NULL, EWKB, ...) {
 	if (is.null(conn))
 		stop("no connection provided")
-	
+
 	if (!is.null(table)) {
 		table <- schema_table(table)
 		if (!db_exists(conn, table))
@@ -33,18 +33,18 @@ st_read_db = function(conn = NULL, table = NULL, query = NULL,
 	} else if(is.null(query)) {
 		stop("Provide either a table name or a query", call. = FALSE)
 	}
-	
+
 	# suppress warning about unknown type "geometry":
 	suppressWarnings(tbl <- dbGetQuery(conn, query))
 	if (is.null(tbl))
 		stop("`", query, "` returned no results.", call. = FALSE) # nocov
-	
+
 	if("row.names" %in% colnames(tbl)) {
 		row.names(tbl) = tbl[["row.names"]]
 		tbl = tbl[,setdiff(colnames(tbl), "row.names")]
 	}
 	gc = try(dbReadTable(conn, "geometry_columns"))
-	
+
 	if (is.null(geom_column)) { # try find the geometry column:
 		geom_column = if (class(gc) == "try-error" || is.null(table))
 			tail(which(vapply(tbl, is.character, TRUE)), 1) # guess it's the last character column
@@ -75,7 +75,7 @@ st_read_db = function(conn = NULL, table = NULL, query = NULL,
 }
 
 #' Write simple feature table to a spatial database
-#' 
+#'
 #' Write simple feature table to a spatial database
 #' @param conn open database connection
 #' @param table character; name for the table in the database, possibly of length 2, \code{c("schema", "name")}; default schema is \code{public}
@@ -92,12 +92,12 @@ st_read_db = function(conn = NULL, table = NULL, query = NULL,
 #'   library(sp)
 #'   data(meuse)
 #'   sf = st_as_sf(meuse, coords = c("x", "y"), crs = 28992)
-#'   library(RPostgreSQL) 
+#'   library(RPostgreSQL)
 #'   conn = dbConnect(PostgreSQL(), dbname = "postgis")
 #'   st_write_db(conn, sf, "meuse_tbl", drop = FALSE)
 #' }
 #' @details st_write_db was written with help of Josh London, see https://github.com/r-spatial/sf/issues/285
-st_write_db = function(conn = NULL, obj, table = deparse(substitute(obj)), geom_name = "wkb_geometry", 
+st_write_db = function(conn = NULL, obj, table = deparse(substitute(obj)), geom_name = "wkb_geometry",
 		..., drop = FALSE, debug = FALSE, binary = TRUE, append = FALSE) {
 
 	DEBUG = function(x) { if (debug) message(x); x }
@@ -108,11 +108,11 @@ st_write_db = function(conn = NULL, obj, table = deparse(substitute(obj)), geom_
 	if (db_exists(conn, table)) {
 		if (drop)
 			DBI::dbGetQuery(conn, DEBUG(paste("drop table if exists", paste(table, collapse = "."), ";")))
-		else 
-			stop("Table ", paste(table, collapse = "."), " exists already, use drop = TRUE", 
+		else
+			stop("Table ", paste(table, collapse = "."), " exists already, use drop = TRUE",
 					 call. = FALSE)
 	}
-  
+
 	geom = st_geometry(obj)
 	DIM = nchar(class(geom[[1]])[1]) # FIXME: is this correct? XY, XYZ, XYZM
 	crs = st_crs(geom)
@@ -126,7 +126,7 @@ st_write_db = function(conn = NULL, obj, table = deparse(substitute(obj)), geom_
 				srid
 			}
 	}
-	
+
 	sfc_name = attr(obj, "sf_column")
 	df = obj
 	st_geometry(df) = NULL # is now data.frame
@@ -134,26 +134,26 @@ st_write_db = function(conn = NULL, obj, table = deparse(substitute(obj)), geom_
 			st_as_binary(geom, EWKB = TRUE, hex = TRUE)
  		else
 			st_as_text(geom, EWKT = TRUE)
-	
+
 	dbWriteTable(conn, table, clean_columns(df, factorsAsCharacter = TRUE), ...)
-  
+
 	TYPE = class(geom[[1]])[2]
 	if (! append) {
-		query = DEBUG(paste0("SELECT AddGeometryColumn('", table[1],"','", table[2], "','", geom_name, 
+		query = DEBUG(paste0("SELECT AddGeometryColumn('", table[1],"','", table[2], "','", geom_name,
 							 "','", SRID, "','", TYPE, "',", DIM, ");"))
 		dbExecute(conn, query)
 	}
-	
+
 	# convert text column `sfc_name' into geometry column `geom_name':
 	query = if (binary)
 		DEBUG(paste0("UPDATE ", paste(table, collapse = "."),
 			" set ", geom_name," = ST_GeomFromEWKB(cast(", sfc_name, " as geometry));
-			ALTER TABLE ", paste(table, collapse = "."), 
+			ALTER TABLE ", paste(table, collapse = "."),
 			" DROP COLUMN IF EXISTS ", sfc_name))
 	  else
 		DEBUG(paste0("UPDATE ", paste(table, collapse = "."),
 			" set ", geom_name," = ST_GeomFromEWKT(", sfc_name, ");
-			ALTER TABLE ", paste(table, collapse = "."), 
+			ALTER TABLE ", paste(table, collapse = "."),
 			" DROP COLUMN IF EXISTS ", sfc_name))
 	invisible(dbExecute(conn, query))
 }
@@ -174,9 +174,9 @@ schema_table <- function(table, public = "public") {
 }
 
 db_list_tables_schema <- function(con) {
-	q <- paste("SELECT schemaname AS table_schema, tablename AS table_name", 
-			   "FROM pg_tables", 
-			   "WHERE schemaname !='information_schema'", 
+	q <- paste("SELECT schemaname AS table_schema, tablename AS table_name",
+			   "FROM pg_tables",
+			   "WHERE schemaname !='information_schema'",
 			   "AND schemaname !='pg_catalog';")
 	DBI::dbGetQuery(con, q)
 }
@@ -191,8 +191,8 @@ db_list_views_schema <- function(con) {
 
 db_list_mviews_schema <- function(con) {
 	q <- paste("SELECT nspname as table_schema, relname as table_name",
-			   "FROM pg_catalog.pg_class c", 
-			   "JOIN pg_namespace n ON n.oid = c.relnamespace", 
+			   "FROM pg_catalog.pg_class c",
+			   "JOIN pg_namespace n ON n.oid = c.relnamespace",
 			   "WHERE c.relkind = 'm'")
 	DBI::dbGetQuery(con, q)
 }

--- a/R/geohash.R
+++ b/R/geohash.R
@@ -1,7 +1,7 @@
 #' compute geohash from (average) coordinates (requires lwgeom)
 #'
 #' compute geohash from (average) coordinates (requires lwgeom)
-#' 
+#'
 #' @param x object of class \code{sf}, \code{sfc} or \code{sfg}
 #' @param precision integer; precision (length) of geohash returned; when omitted, precision 10 is taken.
 #' @export

--- a/R/graticule.R
+++ b/R/graticule.R
@@ -1,13 +1,13 @@
 #' Compute graticules and their parameters
-#' 
+#'
 #' Compute graticules and their parameters
 #'
 #' @section Use of graticules:
 #'  In cartographic visualization, the use of graticules is not advised, unless
 #'  the graphical output will be used for measurement or navigation, or the
 #'  direction of North is important for the interpretation of the content, or
-#'  the content is intended to display distortions and artefacts created by 
-#'  projection. Unnecessary use of graticules only adds visual clutter but 
+#'  the content is intended to display distortions and artefacts created by
+#'  projection. Unnecessary use of graticules only adds visual clutter but
 #'  little relevant information. Use of coastlines, administrative boundaries
 #'  or place names permits most viewers of the output to orient themselves
 #'  better than a graticule.
@@ -19,47 +19,47 @@
 #' @param lon numeric; degrees east for the meridians
 #' @param lat numeric; degrees north for the parallels
 #' @param ndiscr integer; number of points to discretize a parallel or meridian
-#' @param margin numeric; small number to trim a longlat bounding box that touches or 
+#' @param margin numeric; small number to trim a longlat bounding box that touches or
 #'  crosses +/-180 long or +/-90 latitude.
 #' @param ... ignored
-#' @return an object of class \code{sf} with additional attributes describing the type 
+#' @return an object of class \code{sf} with additional attributes describing the type
 #' (E: meridian, N: parallel) degree value, label, start and end coordinates and angle;
 #' see example.
-#' @examples 
+#' @examples
 #' library(sf)
 #' library(maps)
-#' 
+#'
 #' usa = st_as_sf(map('usa', plot = FALSE, fill = TRUE))
 #' laea = st_crs("+proj=laea +lat_0=30 +lon_0=-95") # Lambert equal area
 #' usa <- st_transform(usa, laea)
-#' 
+#'
 #' bb = st_bbox(usa)
 #' bbox = st_linestring(rbind(c( bb[1],bb[2]),c( bb[3],bb[2]),
 #'    c( bb[3],bb[4]),c( bb[1],bb[4]),c( bb[1],bb[2])))
-#' 
+#'
 #' g = st_graticule(usa)
 #' plot(usa, xlim = 1.2 * c(-2450853.4, 2186391.9))
 #' plot(g[1], add = TRUE, col = 'grey')
 #' plot(bbox, add = TRUE)
 #' points(g$x_start, g$y_start, col = 'red')
 #' points(g$x_end, g$y_end, col = 'blue')
-#' 
+#'
 #' invisible(lapply(seq_len(nrow(g)), function(i) {
 #'	if (g$type[i] == "N" && g$x_start[i] - min(g$x_start) < 1000)
-#'		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]), 
+#'		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]),
 #'			srt = g$angle_start[i], pos = 2, cex = .7)
 #'	if (g$type[i] == "E" && g$y_start[i] - min(g$y_start) < 1000)
-#'		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]), 
+#'		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]),
 #'			srt = g$angle_start[i] - 90, pos = 1, cex = .7)
 #'	if (g$type[i] == "N" && g$x_end[i] - max(g$x_end) > -1000)
-#'		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]), 
+#'		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]),
 #'			srt = g$angle_end[i], pos = 4, cex = .7)
 #'	if (g$type[i] == "E" && g$y_end[i] - max(g$y_end) > -1000)
-#'		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]), 
+#'		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]),
 #'			srt = g$angle_end[i] - 90, pos = 3, cex = .7)
 #' }))
 #' plot(usa, graticule = st_crs(4326), axes = TRUE, lon = seq(-60,-130,by=-10))
-st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x), 
+st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 	datum = st_crs(4326), ..., lon = NULL, lat = NULL, ndiscr = 100,
 	margin = 0.001)
 {
@@ -73,7 +73,7 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 
 	if (is.null(crs))
 		crs = NA_crs_
-	
+
 	if (is.null(datum) || is.na(datum))
 		datum = crs
 
@@ -87,15 +87,15 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 	if (isTRUE(st_is_longlat(crs)))
 		bb = trim_bb(bb, margin)
 
-	ls1 = st_linestring(rbind(c(bb[1],bb[2]), c(bb[3],bb[2]), c(bb[3],bb[4]), 
+	ls1 = st_linestring(rbind(c(bb[1],bb[2]), c(bb[3],bb[2]), c(bb[3],bb[4]),
 		c(bb[1],bb[4]), c(bb[1],bb[2])))
-	ls2 = st_linestring(rbind(c(bb[1],bb[2]), c(bb[3],bb[4]), c(bb[1],bb[4]), 
+	ls2 = st_linestring(rbind(c(bb[1],bb[2]), c(bb[3],bb[4]), c(bb[1],bb[4]),
 		c(bb[3],bb[2]), c(bb[1],bb[2])))
 	box = st_sfc(ls1, ls2)
 
 	# without crs, we segmentize in planar coordinates --
 	# segmentizing along great circles doesn't give parallels:
-	box = st_segmentize(box, st_length(box)[1] / ndiscr) 
+	box = st_segmentize(box, st_length(box)[1] / ndiscr)
 
 	# and only now set the crs:
 	st_crs(box) = crs
@@ -107,8 +107,8 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 		datum = NA_crs_ # nocov - remove when geom_sf is on CRAN
 		box             # nocov
 	}
-	
-	# as in https://github.com/r-spatial/sf/issues/198 : 
+
+	# as in https://github.com/r-spatial/sf/issues/198 :
 	# recreate, and ignore bbox_ll:
 	if (any(!is.finite(st_bbox(box_ll)))) { # nocov start -- checked manually
 		x = st_transform(st_graticule(datum = datum, ndiscr = ndiscr), crs)
@@ -145,13 +145,13 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 	lat_list <- vector(mode="list", length=length(lat))
 	for (i in seq_along(lat_list))
 		lat_list[[i]] <- st_linestring(cbind(seq(bb[1], bb[3], length.out=ndiscr), rep(lat[i], ndiscr)))
-	
+
 	df = data.frame(degree = c(lon, lat))
 	df$type = c(rep("E", length(lon)), rep("N", length(lat)))
 	df$degree_label = if (is.na(crs) || !isTRUE(st_is_longlat(datum)))
 			c(format(lon), format(lat))
 		else
-			c(degreeLabelsEW(lon), degreeLabelsNS(lat)) 
+			c(degreeLabelsEW(lon), degreeLabelsNS(lat))
 
 	geom = st_sfc(c(long_list, lat_list), crs = datum)
 
@@ -184,7 +184,7 @@ graticule_attributes = function(df) {
 	df$y_end   = xy[,4]
 	dxdy = do.call(rbind, lapply(object, function(x) { y = x[[1]]; apply(y[1:2,], 2, diff) } ))
 	df$angle_start = apply(dxdy, 1, function(x) atan2(x[2], x[1])*180/pi)
-	dxdy = do.call(rbind, lapply(object, 
+	dxdy = do.call(rbind, lapply(object,
 		function(x) { y = x[[length(x)]]; n = nrow(y); apply(y[(n-1):n,], 2, diff) } ))
 	df$angle_end = apply(dxdy, 1, function(x) atan2(x[2], x[1])*180/pi)
 	bb = st_bbox(df)

--- a/R/grid.R
+++ b/R/grid.R
@@ -45,7 +45,7 @@ st_as_grob.MULTILINESTRING = function(x, ..., default.units = "native") {
 	else {
 		get_x = function(x) unlist(sapply(x, function(y) y[,1]))
 		get_y = function(x) unlist(sapply(x, function(y) y[,2]))
-		polylineGrob(get_x(x), get_y(x), id.lengths = vapply(x, nrow, 0L), ..., 
+		polylineGrob(get_x(x), get_y(x), id.lengths = vapply(x, nrow, 0L), ...,
 			default.units = default.units)
 	}
 }
@@ -92,7 +92,7 @@ st_as_grob.COMPOUNDCURVE = st_as_grob.GEOMETRYCOLLECTION
 
 
 #' Create viewport from sf, sfc or sfg object
-#' 
+#'
 #' Create viewport from sf, sfc or sfg object
 #' @param x object of class sf, sfc or sfg object
 #' @param bbox the bounding box used for aspect ratio
@@ -130,7 +130,7 @@ st_viewport = function(x, ..., bbox = st_bbox(x), asp) {
 			1.0 / cos((mean(yscale) * pi)/180)
 		else
 			1.0
-	
+
    	obj.asp = asp * diff(yscale) / diff(xscale)
 	height = obj.asp / vp.asp
    	width = 1

--- a/R/init.R
+++ b/R/init.R
@@ -59,7 +59,7 @@ setOldClass("sfg")
 }
 
 #' Provide the external dependencies versions of the libraries linked to sf
-#' 
+#'
 #' Provide the external dependencies versions of the libraries linked to sf
 #' @export
 sf_extSoftVersion = function() {

--- a/R/join.R
+++ b/R/join.R
@@ -66,7 +66,7 @@ anti_join.sf = function(x, y, by = NULL, copy = FALSE, ...) {
 #' @param FUN deprecated;
 #' @param suffix length 2 character vector; see \link[base]{merge}
 #' @param prepared logical; see \link{st_intersects}
-#' @param left logical; if \code{TRUE} carry out left join, else inner join; 
+#' @param left logical; if \code{TRUE} carry out left join, else inner join;
 #' see also \link[dplyr]{left_join}
 #' @param ... arguments passed on to the \code{join} function (e.g. a pattern for \link{st_relate})
 #' @details alternative values for argument \code{join} are: \link{st_disjoint}
@@ -86,7 +86,7 @@ anti_join.sf = function(x, y, by = NULL, copy = FALSE, ...) {
 #' library(dplyr)
 #' st_join(a, b) %>% group_by(a.x) %>% summarise(mean(a.y))
 #' @export
-st_join = function(x, y, join = st_intersects, FUN, suffix = c(".x", ".y"), 
+st_join = function(x, y, join = st_intersects, FUN, suffix = c(".x", ".y"),
 		prepared = TRUE, left = TRUE, ...) {
 	stopifnot(inherits(x, "sf") && inherits(y, "sf"))
 	if (!missing(FUN)) {

--- a/R/maps.R
+++ b/R/maps.R
@@ -7,7 +7,7 @@ st_as_sf.map = function(x, ...) {
 		stop("package sp required, please install it first")
 
 	ID0 = vapply(strsplit(x$names, ":"), function(y) y[1], "")
-	m.sp = maptools::map2SpatialPolygons(x, IDs = ID0, 
+	m.sp = maptools::map2SpatialPolygons(x, IDs = ID0,
 		proj4string = sp::CRS("+init=epsg:4326"))
 	m = st_as_sf(m.sp)
 	m$ID = vapply(m.sp@polygons, function(x) slot(x, "ID"), "")

--- a/R/plot.R
+++ b/R/plot.R
@@ -16,10 +16,10 @@
 #' @param type plot type: 'p' for points, 'l' for lines, 'b' for both
 #' @method plot sf
 #' @name plot
-#' @details \code{plot.sf} maximally plots \code{max.plot} maps with colors following from attribute columns, 
+#' @details \code{plot.sf} maximally plots \code{max.plot} maps with colors following from attribute columns,
 #' one map per attribute. It uses \code{sf.colors} for default colors. For more control over individual maps,
 #' set parameter \code{mfrow} with \code{par} prior to plotting,  and plot single maps one by one.
-#' 
+#'
 #' \code{plot.sfc} plots the geometry, additional parameters can be passed on
 #' to control color, lines or symbols.
 #' @examples
@@ -99,7 +99,7 @@ plot.sf <- function(x, y, ..., ncol = 10, col = NULL, max.plot = 9) {
 
 		if (isTRUE(is.finite(max.plot)) && ncol(x) - 1 > max.plot) {
 			if (max_plot_missing)
-				warning(paste("plotting the first", max.plot, "out of", ncol(x)-1, 
+				warning(paste("plotting the first", max.plot, "out of", ncol(x)-1,
 					"attributes; use max.plot =", ncol(x) - 1, "to plot all"), call. = FALSE)
 			x = x[, 1:max.plot]
 		}
@@ -111,7 +111,7 @@ plot.sf <- function(x, y, ..., ncol = 10, col = NULL, max.plot = 9) {
 			col = sf.colors(ncol, x[[setdiff(names(x), attr(x, "sf_column"))]])
 		if (is.null(col))
 			plot(st_geometry(x), ...)
-		else 
+		else
 			plot(st_geometry(x), col = col, ...)
 		if (is.null(dots$main) && !isTRUE(dots$add))
 			title(names(x)[names(x) != attr(x, "sf_column")])
@@ -134,7 +134,7 @@ plot.sfc_POINT = function(x, y, ..., pch = 1, cex = 1, col = 1, bg = 0, lwd = 1,
 	mat = do.call(rbind, x)
 	if (!is.null(mat)) {
 		ne = apply(mat, 1, function(x) all(is.finite(x))) # ne: not empty
-		points(mat[ne,, drop = FALSE], pch = pch[ne], col = col[ne], bg = bg[ne], 
+		points(mat[ne,, drop = FALSE], pch = pch[ne], col = col[ne], bg = bg[ne],
 			cex = cex[ne], lwd = lwd, lty = lty, type = type)
 	}
 }
@@ -155,9 +155,9 @@ plot.sfc_MULTIPOINT = function(x, y, ..., pch = 1, cex = 1, col = 1, bg = 0, lwd
 	lwd = rep(lwd, length.out = n)
 	lty = rep(lty, length.out = n)
 	non_empty = !is.na(st_dimension(x))
-	lapply(seq_along(x), function(i) 
+	lapply(seq_along(x), function(i)
 	  if (non_empty[i])
-		points(x[[i]], pch = pch[i], col = col[i], bg = bg[i], 
+		points(x[[i]], pch = pch[i], col = col[i], bg = bg[i],
 			cex = cex[i], lwd = lwd[i], lty = lty[i], type = type))
 	invisible(NULL)
 }
@@ -165,7 +165,7 @@ plot.sfc_MULTIPOINT = function(x, y, ..., pch = 1, cex = 1, col = 1, bg = 0, lwd
 #' @name plot
 #' @method plot sfc_LINESTRING
 #' @export
-plot.sfc_LINESTRING = function(x, y, ..., lty = 1, lwd = 1, col = 1, pch = 1, type = 'l', 
+plot.sfc_LINESTRING = function(x, y, ..., lty = 1, lwd = 1, col = 1, pch = 1, type = 'l',
 		add = FALSE) {
 # FIXME: take care of lend, ljoin, and lmitre
 	stopifnot(missing(y))
@@ -225,7 +225,7 @@ p_bind = function(lst) {
 #' @name plot
 #' @param rule see \link[graphics]{polypath}
 #' @export
-plot.sfc_POLYGON = function(x, y, ..., lty = 1, lwd = 1, col = NA, cex = 1, pch = NA, border = 1, 
+plot.sfc_POLYGON = function(x, y, ..., lty = 1, lwd = 1, col = NA, cex = 1, pch = NA, border = 1,
 		add = FALSE, rule = "winding") {
 # FIXME: take care of lend, ljoin, xpd, and lmitre
 	stopifnot(missing(y))
@@ -242,7 +242,7 @@ plot.sfc_POLYGON = function(x, y, ..., lty = 1, lwd = 1, col = NA, cex = 1, pch 
 #	if (any(!is.na(pch))) {
 #		pch = rep(pch, length.out = length(x))
 #		cex = rep(cex, length.out = length(x))
-#		lapply(seq_along(x), function(i) 
+#		lapply(seq_along(x), function(i)
 #		  if (non_empty[i])
 #			points(p_bind(x[[i]]), pch = pch[i], cex = cex[i], type = 'p'))
 #	}
@@ -272,7 +272,7 @@ plot.sfc_MULTIPOLYGON = function(x, y, ..., lty = 1, lwd = 1, col = NA, border =
 # plot single geometrycollection:
 plot_gc = function(x, pch, cex, bg, border = 1, lty, lwd, col, add) {
 	lapply(x, function(subx) {
-		args = list(st_sfc(subx), pch = pch, cex = cex, bg = bg, border = border, 
+		args = list(st_sfc(subx), pch = pch, cex = cex, bg = bg, border = border,
 			lty = lty, lwd = lwd, col = col, add = TRUE)
 		fn = switch(class(subx)[2],
 			POINT = plot.sfc_POINT,
@@ -296,7 +296,7 @@ plot_gc = function(x, pch, cex, bg, border = 1, lty, lwd, col, add) {
 #' @name plot
 #' @method plot sfc_GEOMETRYCOLLECTION
 #' @export
-plot.sfc_GEOMETRYCOLLECTION = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty = 1, lwd = 1, 
+plot.sfc_GEOMETRYCOLLECTION = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty = 1, lwd = 1,
 	col = 1, border = 1, add = FALSE) {
 # FIXME: take care of lend, ljoin, xpd, and lmitre
 	stopifnot(missing(y))
@@ -308,8 +308,8 @@ plot.sfc_GEOMETRYCOLLECTION = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty 
 	lwd = rep(lwd, length.out = length(x))
 	col = rep(col, length.out = length(x))
 	border = rep(border, length.out = length(x))
-	lapply(seq_along(x), function(i) plot_gc(x[[i]], 
-			pch = pch[i], cex = cex[i], bg = bg[i], border = border[i], lty = lty[i], 
+	lapply(seq_along(x), function(i) plot_gc(x[[i]],
+			pch = pch[i], cex = cex[i], bg = bg[i], border = border[i], lty = lty[i],
 			lwd = lwd[i], col = col[i]))
 	invisible(NULL)
 }
@@ -317,7 +317,7 @@ plot.sfc_GEOMETRYCOLLECTION = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty 
 #' @name plot
 #' @method plot sfc_GEOMETRY
 #' @export
-plot.sfc_GEOMETRY = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty = 1, lwd = 1, 
+plot.sfc_GEOMETRY = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty = 1, lwd = 1,
 	col = 1, border = 1, add = FALSE) {
 	stopifnot(missing(y))
 	if (! add)
@@ -328,8 +328,8 @@ plot.sfc_GEOMETRY = function(x, y, ..., pch = 1, cex = 1, bg = 0, lty = 1, lwd =
 	lwd = rep(lwd, length.out = length(x))
 	col = rep(col, length.out = length(x))
 	border = rep(border, length.out = length(x))
-	lapply(seq_along(x), function(i) plot_gc(st_sfc(x[[i]]), 
-			pch = pch[i], cex = cex[i], bg = bg[i], border = border[i], lty = lty[i], 
+	lapply(seq_along(x), function(i) plot_gc(st_sfc(x[[i]]),
+			pch = pch[i], cex = cex[i], bg = bg[i], border = border[i], lty = lty[i],
 			lwd = lwd[i], col = col[i]))
 	invisible(NULL)
 }
@@ -353,24 +353,24 @@ plot.sfg = function(x, ...) {
 #' @param lab see \link{par}
 #' @param setParUsrBB default FALSE; set the \code{par} \dQuote{usr} bounding box; see below
 #' @param bgMap object of class \code{ggmap}, or returned by function \code{RgoogleMaps::GetMap}
-#' @param expandBB numeric; fractional values to expand the bounding box with, 
+#' @param expandBB numeric; fractional values to expand the bounding box with,
 #' in each direction (bottom, left, top, right)
-#' @param graticule logical, or object of class \code{crs} (e.g., \code{st_crs(4326)} for a WGS84 graticule), or object created by \link{st_graticule}; \code{TRUE} will give the WGS84 graticule 
+#' @param graticule logical, or object of class \code{crs} (e.g., \code{st_crs(4326)} for a WGS84 graticule), or object created by \link{st_graticule}; \code{TRUE} will give the WGS84 graticule
 #' or object returned by \link{st_graticule}
 #' @param col_graticule color to used for the graticule (if present)
 #' @export
 #' @details \code{plot_sf} sets up the plotting area, axes, graticule, or webmap background; it
 #' is called by all \code{plot} methods before anything is drawn.
-#' 
+#'
 #' The argument \code{setParUsrBB} may be used to pass the logical value \code{TRUE} to functions within \code{plot.Spatial}. When set to \code{TRUE}, par(\dQuote{usr}) will be overwritten with \code{c(xlim, ylim)}, which defaults to the bounding box of the spatial object. This is only needed in the particular context of graphic output to a specified device with given width and height, to be matched to the spatial object, when using par(\dQuote{xaxs}) and par(\dQuote{yaxs}) in addition to \code{par(mar=c(0,0,0,0))}.
-#' 
+#'
 #' The default aspect for map plots is 1; if however data are not
 #' projected (coordinates are long/lat), the aspect is by default set to
 #' 1/cos(My * pi)/180) with My the y coordinate of the middle of the map
 #' (the mean of ylim, which defaults to the y range of bounding box). This
 #' implies an \href{https://en.wikipedia.org/wiki/Equirectangular_projection}{Equirectangular projection}.
 #'
-plot_sf = function(x, xlim = NULL, ylim = NULL, asp = NA, axes = FALSE, bgc = par("bg"), ..., 
+plot_sf = function(x, xlim = NULL, ylim = NULL, asp = NA, axes = FALSE, bgc = par("bg"), ...,
     xaxs, yaxs, lab, setParUsrBB = FALSE, bgMap = NULL, expandBB = c(0,0,0,0), graticule = NA_crs_,
 	col_graticule = 'grey') {
 
@@ -381,9 +381,9 @@ plot_sf = function(x, xlim = NULL, ylim = NULL, asp = NA, axes = FALSE, bgc = pa
 	bbox = matrix(st_bbox(x), 2, dimnames = list(c("x", "y"), c("min", "max")))
 	# expandBB: 1=below, 2=left, 3=above and 4=right.
 	expBB = function(lim, expand) c(lim[1] - expand[1] * diff(lim), lim[2] + expand[2] * diff(lim))
-	if (is.null(xlim)) 
+	if (is.null(xlim))
 		xlim <- expBB(bbox[1,], expandBB[c(2,4)])
-	if (is.null(ylim)) 
+	if (is.null(ylim))
 		ylim <- expBB(bbox[2,], expandBB[c(1,3)])
 	if (is.na(asp))
 		asp <- ifelse(isTRUE(st_is_longlat(x)), 1/cos((mean(ylim) * pi)/180), 1.0)
@@ -396,10 +396,10 @@ plot_sf = function(x, xlim = NULL, ylim = NULL, asp = NA, axes = FALSE, bgc = pa
 	if (!missing(lab)) args$lab = lab
 	do.call(plot.window, args)
 
-	if (setParUsrBB) 
+	if (setParUsrBB)
 		par(usr=c(xlim, ylim))
 	pl_reg <- par("usr")
-	rect(xleft = pl_reg[1], ybottom = pl_reg[3], xright = pl_reg[2], 
+	rect(xleft = pl_reg[1], ybottom = pl_reg[3], xright = pl_reg[2],
 		ytop = pl_reg[4], col = bgc, border = FALSE)
 	linAxis = function(side, ..., lon, lat, ndiscr) axis(side = side, ...)
 	if (! missing(graticule)) {
@@ -491,7 +491,7 @@ sf.colors = function (n = 10, xc, cutoff.tails = c(0.35, 0.2), alpha = 1, catego
 		if (is.factor(xc))
 			sf.colors(nlevels(xc), categorical = TRUE)[as.numeric(xc)]
 		else {
-			safe_cut = function(x,n) { 
+			safe_cut = function(x,n) {
 				if (all(is.na(x)) || all(range(x, na.rm = TRUE) == 0))
 					rep(1, length(x))
 				else
@@ -543,6 +543,6 @@ degAxis = function (side, at, labels, ..., lon, lat, ndiscr) {
 			labels = parse(text = degreeLabelsEW(at))
 		else if (side == 2 || side == 4)
 			labels = parse(text = degreeLabelsNS(at))
-	} 
+	}
 	axis(side, at = at, labels = labels, ...)
 }

--- a/R/sample.R
+++ b/R/sample.R
@@ -1,5 +1,5 @@
 #' sample points on or in (sets of) spatial features
-#' 
+#'
 #' sample points on or in (sets of) spatial features
 #' @param x object of class \code{sf} or \code{sfc}
 #' @param size sample size(s) requested; either total size, or a numeric vector with sample sizes for each feature geometry. When sampling polygons, the returned sampling size may differ from the requested size, as the bounding box is sampled, and sampled points intersecting the polygon are returned.
@@ -33,7 +33,7 @@ st_sample = function(x, size, ..., type = "random") {
 	x = st_geometry(x)
 	if (length(size) > 1) {
 		size = rep(size, length.out = length(x))
-		st_set_crs(do.call(c, lapply(1:length(x), 
+		st_set_crs(do.call(c, lapply(1:length(x),
 			function(i) st_sample(x[i], size[i], type = type))),
 			st_crs(x))
 	} else {
@@ -52,7 +52,7 @@ st_sample = function(x, size, ..., type = "random") {
 st_poly_sample = function(x, size, ..., type = "random") {
 	toRad = pi/180
 	bb = st_bbox(x)
-	a0 = st_area(st_make_grid(x, n = c(1,1))) 
+	a0 = st_area(st_make_grid(x, n = c(1,1)))
 	a1 = sum(st_area(x))
 	# st_polygon(list(rbind(c(-180,-90),c(180,-90),c(180,90),c(-180,90),c(-180,-90))))
 	# for instance has 0 st_area
@@ -64,7 +64,7 @@ st_poly_sample = function(x, size, ..., type = "random") {
 		lat1 = (sin(bb[4] * toRad) + 1)/2
 		y = runif(size, lat0, lat1)
 		asin(2 * y - 1) / toRad # http://mathworld.wolfram.com/SpherePointPicking.html
-	} else 
+	} else
 		runif(size, bb[2], bb[4])
 	m = cbind(lon, lat)
 	pts = st_sfc(lapply(seq_len(nrow(m)), function(i) st_point(m[i,])), crs = st_crs(x))

--- a/R/sf.R
+++ b/R/sf.R
@@ -15,7 +15,7 @@ st_as_sf = function(x, ...) UseMethod("st_as_sf")
 #' @param na.fail logical; if \code{TRUE}, raise an error if coordinates contain missing values
 #' @param ... passed on to \link{st_sf}, might included crs
 #' @details setting argument \code{wkt} annihilates the use of argument \code{coords}. If \code{x} contains a column called "geometry", \code{coords} will result in overwriting of this column by the \link{sfc} geometry list-column.  Setting \code{wkt} will replace this column with the geometry list-column, unless \code{remove_coordinates} is \code{FALSE}.
-#' 
+#'
 #' @examples
 #' pt1 = st_point(c(0,1))
 #' pt2 = st_point(c(1,1))
@@ -32,10 +32,10 @@ st_as_sf = function(x, ...) UseMethod("st_as_sf")
 #' meuse_sf[1:3,]
 #' summary(meuse_sf)
 #' @export
-st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt, 
+st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 		dim = "XYZ", remove = TRUE, na.fail = TRUE) {
 	if (! missing(wkt)) {
-		if (remove) 
+		if (remove)
 			x[[wkt]] = st_as_sfc(as.character(x[[wkt]]))
 		else
 			x$geometry = st_as_sfc(as.character(x[[wkt]]))
@@ -43,13 +43,13 @@ st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 		if (na.fail && any(is.na(x[coords])))
 			stop("missing values in coordinates not allowed")
 		classdim = getClassDim(rep(0, length(coords)), length(coords), dim, "POINT")
-		x$geometry = structure( lapply(split(as.vector(t(as.matrix(x[, coords]))), 
-				rep(seq_len(nrow(x)), each = length(coords))), 
-				function(vec) structure(vec, class = classdim)), 
-			n_empty = 0L, precision = 0, crs = NA_crs_, 
+		x$geometry = structure( lapply(split(as.vector(t(as.matrix(x[, coords]))),
+				rep(seq_len(nrow(x)), each = length(coords))),
+				function(vec) structure(vec, class = classdim)),
+			n_empty = 0L, precision = 0, crs = NA_crs_,
 			bbox = structure(
-				c(xmin = min(x[[coords[1]]], na.rm = TRUE), 
-				ymin = min(x[[coords[2]]], na.rm = TRUE), 
+				c(xmin = min(x[[coords[1]]], na.rm = TRUE),
+				ymin = min(x[[coords[2]]], na.rm = TRUE),
 				xmax = max(x[[coords[1]]], na.rm = TRUE),
 				ymax = max(x[[coords[2]]], na.rm = TRUE)), class = "bbox"),
 			class =  c("sfc_POINT", "sfc" ))
@@ -68,7 +68,7 @@ st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 st_as_sf.sf = function(x, ...) x
 
 #' Get, set, or replace geometry from an sf object
-#' 
+#'
 #' Get, set, or replace geometry from an sf object
 #' @param obj object of class \code{sf} or \code{sfc}
 #' @param ... ignored
@@ -93,10 +93,10 @@ st_geometry.sfg = function(obj, ...) st_sfc(obj)
 #' @param value object of class \code{sfc}, or \code{character}
 #' @export
 #' @return \code{st_geometry} returns an object of class \link{sfc}. Assigning geometry to a \code{data.frame} creates an \link{sf} object, assigning it to an \link{sf} object replaces the geometry list-column.
-#' @details when applied to a \code{data.frame} and when \code{value} is an object of class \code{sfc}, \code{st_set_geometry} and \code{st_geomtry<-} will first check for the existance of an attribute \code{sf_column} and overwrite that, or else look for list-columns of class \code{sfc} and overwrite the first of that, or else write the geometry list-column to a column named \code{geometry}.  In case \code{value} is character and \code{x} is of class \code{sf}, the "active" geometry column is set to \code{x[[value]]}. 
-#' 
+#' @details when applied to a \code{data.frame} and when \code{value} is an object of class \code{sfc}, \code{st_set_geometry} and \code{st_geomtry<-} will first check for the existance of an attribute \code{sf_column} and overwrite that, or else look for list-columns of class \code{sfc} and overwrite the first of that, or else write the geometry list-column to a column named \code{geometry}.  In case \code{value} is character and \code{x} is of class \code{sf}, the "active" geometry column is set to \code{x[[value]]}.
+#'
 #' the replacement function applied to \code{sf} objects will overwrite the geometry list-column, if \code{value} is \code{NULL}, it will remove it and coerce \code{x} to a \code{data.frame}.
-#' @examples 
+#' @examples
 #' df = data.frame(a = 1:2)
 #' sfc = st_sfc(st_point(c(3,4)), st_point(c(10,11)))
 #' st_geometry(sfc)
@@ -170,24 +170,24 @@ list_column_to_sfc = function(x) {
 			x
 		else
 			y
-	} else 
+	} else
 		x
 }
 
 #' Create sf object
-#' 
+#'
 #' Create sf, which extends data.frame-like objects with a simple feature list column
 #' @name sf
 #' @param ... column elements to be binded into an \code{sf} object or a single \code{list} or \code{data.frame} with such columns; at least one of these columns shall be a geometry list-column of class \code{sfc} or be a list-column that can be converted into an \code{sfc} by \link{st_as_sfc}.
 #' @param crs coordinate reference system: integer with the epsg code, or character with proj4string
 #' @param agr character vector; see details below.
 #' @param row.names row.names for the created \code{sf} object
-#' @param stringsAsFactors logical; logical: should character vectors be converted to factors?  The `factory-fresh' default is \code{TRUE}, but this can be changed by setting \code{options(stringsAsFactors = FALSE)}.  
+#' @param stringsAsFactors logical; logical: should character vectors be converted to factors?  The `factory-fresh' default is \code{TRUE}, but this can be changed by setting \code{options(stringsAsFactors = FALSE)}.
 #' @param precision numeric; see \link{st_as_binary}
-#' @param sf_column_name character; name of the active list-column with simple feature geometries; in case 
+#' @param sf_column_name character; name of the active list-column with simple feature geometries; in case
 #' there are more than one and \code{sf_column_name} is not given, the first one is taken.
-#' @details \code{agr}, attribute-geometry-relationship, specifies for each non-geometry attribute column how it relates to the geometry, and can have one of following values: "constant", "aggregate", "identity". "constant" is used for attributes that are constant throughout the geometry (e.g. land use), "aggregate" where the attribute is an aggregate value over the geometry (e.g. population density or population count), "identity" when the attributes uniquely identifies the geometry of particular "thing", such as a building ID or a city name. The default value, \code{NA_agr_}, implies we don't know.  
-#' 
+#' @details \code{agr}, attribute-geometry-relationship, specifies for each non-geometry attribute column how it relates to the geometry, and can have one of following values: "constant", "aggregate", "identity". "constant" is used for attributes that are constant throughout the geometry (e.g. land use), "aggregate" where the attribute is an aggregate value over the geometry (e.g. population density or population count), "identity" when the attributes uniquely identifies the geometry of particular "thing", such as a building ID or a city name. The default value, \code{NA_agr_}, implies we don't know.
+#'
 #' When confronted with a data.frame-like object, `st_sf` will try to find a geometry column of class `sfc`, and otherwise try to convert list-columns when available into a geometry column, using \link{st_as_sfc}.
 #' @examples
 #' g = st_sfc(st_point(1:2))
@@ -199,7 +199,7 @@ list_column_to_sfc = function(x) {
 #' geometry = st_sfc(lapply(1:nrows, function(x) st_geometrycollection()))
 #' df <- st_sf(id = 1:nrows, geometry = geometry)
 #' @export
-st_sf = function(..., agr = NA_agr_, row.names, 
+st_sf = function(..., agr = NA_agr_, row.names,
 		stringsAsFactors = default.stringsAsFactors(), crs, precision, sf_column_name = NULL) {
 	x = list(...)
 	if (length(x) == 1L && (inherits(x[[1L]], "data.frame") || (is.list(x) && !inherits(x[[1L]], "sfc"))))
@@ -213,14 +213,14 @@ st_sf = function(..., agr = NA_agr_, row.names,
 		if (! any(all_sfc_columns))
 			stop("no simple features geometry column present")
 	}
-	
+
 	all_sfc_columns = which(unlist(all_sfc_columns))
 
 	# set names if not present:
 	all_sfc_names = if (!is.null(names(x)) && nzchar(names(x)[all_sfc_columns]))
 		names(x)[all_sfc_columns]
 	else {
-		object = as.list(substitute(list(...)))[-1L] 
+		object = as.list(substitute(list(...)))[-1L]
 		arg_nm = sapply(object, function(x) deparse(x))
 		make.names(arg_nm[all_sfc_columns])
 	}
@@ -243,7 +243,7 @@ st_sf = function(..., agr = NA_agr_, row.names,
 			if (inherits(x, "data.frame"))
 				x[-all_sfc_columns]
 			else # create a data.frame from list:
-				data.frame(x[-all_sfc_columns], row.names = row.names, 
+				data.frame(x[-all_sfc_columns], row.names = row.names,
 					stringsAsFactors = stringsAsFactors)
 		}
 
@@ -350,8 +350,8 @@ st_sf = function(..., agr = NA_agr_, row.names,
 }
 
 #' @export
-print.sf = function(x, ..., n = 
-		ifelse(options("max.print")[[1]] == 99999, 20, options("max.print")[[1]])) { 
+print.sf = function(x, ..., n =
+		ifelse(options("max.print")[[1]] == 99999, 20, options("max.print")[[1]])) {
 
 	geoms = which(vapply(x, function(col) inherits(col, "sfc"), TRUE))
 	nf = length(x) - length(geoms)
@@ -377,7 +377,7 @@ print.sf = function(x, ..., n =
 }
 
 #' merge method for sf and data.frame object
-#' 
+#'
 #' merge method for sf and data.frame object
 #' @param x object of class \code{sf}
 #' @param y object of class \code{data.frame}

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -14,18 +14,18 @@ format.sfc = function(x, ..., digits = 30) {
 }
 
 #' Create simple feature collection object of class sfc from list
-#' 
+#'
 #' Create simple feature list column, set class, and add coordinate reference system
-#' 
+#'
 #' @name sfc
 #' @param ... one or more simple feature geometries
 #' @param crs coordinate reference system: integer with the epsg code, or character with proj4string
 #' @param precision numeric; see \link{st_as_binary}
-#' 
-#' @details a simple feature collection object is a list of class 
-#' \code{c("stc_TYPE", "sfc")} which contains objects of identical type. This 
-#' function creates such an object from a list of simple feature geometries (of 
-#' class \code{sfg}). 
+#'
+#' @details a simple feature collection object is a list of class
+#' \code{c("stc_TYPE", "sfc")} which contains objects of identical type. This
+#' function creates such an object from a list of simple feature geometries (of
+#' class \code{sfg}).
 #' @examples
 #' pt1 = st_point(c(0,1))
 #' pt2 = st_point(c(1,1))
@@ -37,7 +37,7 @@ st_sfc = function(..., crs = NA_crs_, precision = 0.0) {
 	# if we have only one arg, which is already a list with sfg's, but NOT a geometrycollection:
 	# (this is the old form of calling st_sfc; it is way faster to call st_sfc(lst) if lst
 	# already contains a zillion sfg objects, than do.call(st_sfc, lst) ...
-	if (length(lst) == 1 && is.list(lst[[1]]) && !inherits(lst[[1]], "sfg") 
+	if (length(lst) == 1 && is.list(lst[[1]]) && !inherits(lst[[1]], "sfg")
 			&& (length(lst[[1]]) == 0 || inherits(lst[[1]][[1]], "sfg")))
 		lst = lst[[1]]
 	stopifnot(is.numeric(crs) || is.character(crs) || inherits(crs, "crs"))
@@ -50,7 +50,7 @@ st_sfc = function(..., crs = NA_crs_, precision = 0.0) {
 			u = unique(vapply(lst, class, rep("", 3))[1,])
 			if (length(u) > 1)
 				stop(paste("found multiple dimensions:", paste(u, collapse = " ")))
-		} 
+		}
 
 		# class: do we have a mix of geometry types?
 		single = if (!is.null(attr(lst, "single_type"))) # set by CPL_read_wkb:
@@ -131,7 +131,7 @@ c.sfc = function(..., recursive = FALSE) {
 }
 
 #' @export
-print.sfc = function(x, ..., n = 5L, what = "Geometry set for", append = "") { 
+print.sfc = function(x, ..., n = 5L, what = "Geometry set for", append = "") {
 	sep = if (length(x) != 1) "s" else ""
 	cls = substr(class(x)[1], 5, nchar(class(x)[1]))
 	cat(paste0(what, " ", length(x), " feature", sep, " ", append))
@@ -183,10 +183,10 @@ summary.sfc = function(object, ..., maxsum = 7L, maxp4s = 10L) {
     epsg = paste0("epsg:", attr(object, "crs")$epsg)
 	levels(u) = c(levels(u), epsg)
     p4s = attr(object, "crs")$proj4string
-	if (!is.na(p4s)) { 
+	if (!is.na(p4s)) {
 		if (nchar(p4s) > maxp4s)
 			p4s = paste0(substr(p4s, 1L, maxp4s), "...")
-		levels(u) = c(levels(u), p4s)	
+		levels(u) = c(levels(u), p4s)
 	}
     summary(u, maxsum = maxsum, ...)
 }
@@ -204,7 +204,7 @@ as.data.frame.sfc = function(x, ...) {
 st_geometry.sfc = function(obj, ...) obj
 
 #' Return geometry type of an object
-#' 
+#'
 #' Return geometry type of an object, as a factor
 #' @param x object of class \link{sf} or \link{sfc}
 #' @return a factor with the geometry type of each simple feature in x
@@ -280,12 +280,12 @@ st_zm.sfg <- function(x, ..., drop = TRUE, what = "ZM") {
 		else
 			c(unclass(x), 0)
 		structure(ret, class = c("XYZ", class(x)[2:3]))
-	} else 
+	} else
 		stop("this combination of `x', `drop' and `what' is not implemented")
 }
 
 #' @export
-st_zm.list <- function(x, ..., drop = TRUE, what = "ZM") 
+st_zm.list <- function(x, ..., drop = TRUE, what = "ZM")
 	lapply(x, st_zm, drop = drop, what = what)
 
 #' @export
@@ -294,12 +294,12 @@ st_zm.matrix <- function(x, ..., drop = TRUE, what = "ZM")  {
 		x[,1:2]
 	} else if (!drop && what == "Z") {
 		cbind(unclass(x), 0)
-	} else 
+	} else
 		stop("this combination of drop and what is not implemented")
 }
 
 #' Get precision
-#' 
+#'
 #' @param x object of class \code{sfc} or \code{sf}
 #' @export
 st_precision <- function(x) {
@@ -318,13 +318,13 @@ st_precision.sfc <- function(x) {
 }
 
 #' Set precision
-#' 
+#'
 #' @name st_precision
 #' @param precision numeric; see \link{st_as_binary} for how to do this.
 #' @details setting a precision has no direct effect on coordinates of geometries, but merely set an attribute tag to an \code{sfc} object. The effect takes place in \link{st_as_binary} or, more precise, in the C++ function \code{CPL_write_wkb}, where simple feature geometries are being serialized to well-known-binary (WKB). This happens always when routines are called in GEOS library (geometrical operations or predicates), for writing geometries using \link{st_write}, \link{write_sf} or \link{st_write_db}, and (if present) for liblwgeom (\link{st_make_valid}); also \link{aggregate} and \link{summarise} by default union geometries, which calls a GEOS library function. Routines in these libraries receive rounded coordinates, and possibly return results based on them. \link{st_as_binary} contains an example of a roundtrip of \code{sfc} geometries through WKB, in order to see the rounding happening to R data.
 #'
 #' The reason to support precision is that geometrical operations in GEOS or liblwgeom may work better at reduced precision. For writing data from R to external resources it is harder to think of a good reason to limiting precision.
-#' @examples 
+#' @examples
 #' x <- st_sfc(st_point(c(pi, pi)))
 #' st_precision(x)
 #' st_precision(x) <- 0.01
@@ -378,11 +378,11 @@ fix_NULL_values = function(g, cls = class(g)[1]) {
 }
 
 #' retrieve coordinates in matrix form
-#' 
+#'
 #' retrieve coordinates in matrix form
 #' @param x object of class sf, sfc or sfg
 #' @param ... ignored
-#' @return matrix with coordinates (X, Y, possibly Z and/or M) in rows, possibly followed by integer indicators \code{L1},...,\code{L3} that point out to which structure the coordinate belongs; for \code{POINT} this is absent (each coordinate is a feature), for \code{LINESTRING} \code{L1} refers to the feature, for \code{MULTIPOLYGON} \code{L1} refers to the main ring or holes, \code{L2} to the ring id in the \code{MULTIPOLYGON}, and \code{L3} to the simple feature. 
+#' @return matrix with coordinates (X, Y, possibly Z and/or M) in rows, possibly followed by integer indicators \code{L1},...,\code{L3} that point out to which structure the coordinate belongs; for \code{POINT} this is absent (each coordinate is a feature), for \code{LINESTRING} \code{L1} refers to the feature, for \code{MULTIPOLYGON} \code{L1} refers to the main ring or holes, \code{L2} to the ring id in the \code{MULTIPOLYGON}, and \code{L3} to the simple feature.
 #' @export
 st_coordinates = function(x, ...) UseMethod("st_coordinates")
 

--- a/R/sfg.R
+++ b/R/sfg.R
@@ -48,20 +48,20 @@ MtrxSetSet = function(x, dim = "XYZ", type, needClosed = FALSE) {
 }
 
 #return "XY", "XYZ", "XYM", or "XYZM"
-Dimension = function(x) { 
+Dimension = function(x) {
 	stopifnot(inherits(x, "sfg"))
 	class(x)[1]
 }
 
 #' Create simple feature from a numeric vector, matrix or list
-#' 
+#'
 #' Create simple feature from a numeric vector, matrix or list
 #' @param x for \code{st_point}, numeric vector (or one-row-matrix) of length 2, 3 or 4; for \code{st_linestring} and \code{st_multipoint}, numeric matrix with points in rows; for \code{st_polygon} and \code{st_multilinestring}, list with numeric matrices with points in rows; for \code{st_multipolygon}, list of lists with numeric matrices; for \code{st_geometrycollection} list with (non-geometrycollection) simple feature objects
 #' @param dim character, indicating dimensions: "XY", "XYZ", "XYM", or "XYZM"; only really needed for three-dimensional points (which can be either XYZ or XYM) or empty geometries; see details
 #' @name st
 #' @details "XYZ" refers to coordinates where the third dimension represents altitude, "XYM" refers to three-dimensional coordinates where the third dimension refers to something else ("M" for measure); checking of the sanity of \code{x} may be only partial.
 #' @return object of the same nature as \code{x}, but with appropriate class attribute set
-#' @examples 
+#' @examples
 #' (p1 = st_point(c(1,2)))
 #' class(p1)
 #' st_bbox(p1)
@@ -156,7 +156,7 @@ st_geometrycollection = function(x = list(), dims = "XY") {
 		dims = unique(cls[1,])
 		if (length(dims) > 1)
 			stop(paste("multiple dimensions found:", paste(dims, collapse = ", ")))
-	} 
+	}
 	structure(x, class = c(dims, "GEOMETRYCOLLECTION", "sfg")) # TODO: no Z/M/ZM modifier here??
 }
 
@@ -195,7 +195,7 @@ head.sfg = function(x, n = 10L, ...) {
 #' @name st
 #' @export
 format.sfg = function(x, ..., digits = 30) {
-	if (is.null(digits)) 
+	if (is.null(digits))
 		digits = 30
 	if (object.size(x) > 1000)
 		x = head(x, 10)
@@ -224,9 +224,9 @@ format.sfg = function(x, ..., digits = 30) {
 #' c(st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:6,3)))),
 #'   st_geometrycollection(list(st_multilinestring(list(matrix(11:16,3))))))
 #' c(st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:6,3)))),
-#'   st_multilinestring(list(matrix(11:16,3))), st_point(5:6), 
+#'   st_multilinestring(list(matrix(11:16,3))), st_point(5:6),
 #'   st_geometrycollection(list(st_point(10:11))))
-#' @details when \code{flatten=TRUE}, this method may merge points into a multipoint structure, and may not preserve order, and hence cannot be reverted. When given fish, it returns fish soup. 
+#' @details when \code{flatten=TRUE}, this method may merge points into a multipoint structure, and may not preserve order, and hence cannot be reverted. When given fish, it returns fish soup.
 c.sfg = function(..., recursive = FALSE, flatten = TRUE) {
 
 	stopifnot(! recursive)
@@ -237,7 +237,7 @@ c.sfg = function(..., recursive = FALSE, flatten = TRUE) {
 		cls = vapply(lst, function(x) class(x)[2], "")
 		ucls = unique(cls)
 		if (length(ucls) == 1) {
-			switch(ucls, 
+			switch(ucls,
 				POINT = st_multipoint(do.call(rbind, lst)),
 				# CURVE = st_multicurve(Paste0(lst))
 				# CIRCULARSTRING = st_geometrycollection(lst), # FIXME??
@@ -275,7 +275,7 @@ c.sfg = function(..., recursive = FALSE, flatten = TRUE) {
 					ret = append(ret, lst[[wgc[i]]])
 			}
 			st_geometrycollection(ret)
-		} 
+		}
 	} else # !flatten:
 		st_geometrycollection(lst) # breaks if one of them is a GC
 }

--- a/R/sp.R
+++ b/R/sp.R
@@ -36,7 +36,7 @@
 #' z1 = x1 + m
 #' z2 = x2 + m
 #' z3 = x3 + m
-#' p1 = Polygons(list( Polygon(x[5:1,]), Polygon(x2), Polygon(x3), 
+#' p1 = Polygons(list( Polygon(x[5:1,]), Polygon(x2), Polygon(x3),
 #'    Polygon(y[5:1,]), Polygon(y1), Polygon(x1), Polygon(y3)), "ID1")
 #' p2 = Polygons(list( Polygon(z[5:1,]), Polygon(z2), Polygon(z3), Polygon(z1)),
 #'   "ID2")
@@ -62,7 +62,7 @@
 st_as_sf.Spatial = function(x, ...) {
 	if ("data" %in% slotNames(x))
 		df = x@data
-	else 
+	else
 		df = data.frame(row.names = row.names(x)) # empty
 	if ("geometry" %in% names(df))
 		warning("column \"geometry\" will be overwritten by geometry column")
@@ -109,7 +109,7 @@ st_as_sfc.SpatialMultiPoints = function(x,...) {
 #' @export
 st_as_sfc.SpatialLines = function(x, ..., forceMulti = FALSE) {
 	lst = if (forceMulti || any(sapply(x@lines, function(x) length(x@Lines)) != 1))
-		lapply(x@lines, 
+		lapply(x@lines,
 			function(y) st_multilinestring(lapply(y@Lines, function(z) z@coords)))
 	else
 		lapply(x@lines, function(y) st_linestring(y@Lines[[1]]@coords))
@@ -125,7 +125,7 @@ st_as_sfc.SpatialPolygons = function(x, ..., forceMulti = FALSE) {
 				stop("package rgeos required for finding out which hole belongs to which exterior ring")
 			x = rgeos::createSPComment(x)
 		}
-		lapply(x@polygons, function(y) 
+		lapply(x@polygons, function(y)
 			st_multipolygon(Polygons2MULTIPOLYGON(y@Polygons, comment(y))))
 	} else
 		lapply(x@polygons, function(y) st_polygon(Polygons2POLYGON(y@Polygons)))
@@ -185,7 +185,7 @@ as_Spatial = function(from, cast = TRUE, IDs = paste0("ID", 1:length(from))) {
 	zm = class(from[[1]])[1]
 	if (zm %in% c("XYM", "XYZM"))
 		stop("geometries containing M not supported by sp")
-	StopZ = function(zm) { if (zm %in% c("XYZ", "XYZM")) 
+	StopZ = function(zm) { if (zm %in% c("XYZ", "XYZM"))
 		stop("Z not supported: use st_zm first to drop Z?") }
 	switch(class(from)[1],
 		"sfc_POINT" = sfc2SpatialPoints(from),
@@ -205,7 +205,7 @@ sfc2SpatialPoints = function(from) {
 sfc2SpatialMultiPoints = function(from) {
 	if (!requireNamespace("sp", quietly = TRUE))
 		stop("package sp required, please install it first")
-	sp::SpatialMultiPoints(lapply(from, unclass), proj4string = 
+	sp::SpatialMultiPoints(lapply(from, unclass), proj4string =
 		sp::CRS(attr(from, "crs")$proj4string))
 }
 
@@ -214,7 +214,7 @@ sfc2SpatialLines = function(from, IDs = paste0("ID", 1:length(from))) {
 		stop("package sp required, please install it first")
 	l = if (class(from)[1]  == "sfc_MULTILINESTRING")
 		lapply(from, function(x) sp::Lines(lapply(x, function(y) sp::Line(unclass(y))), "ID"))
-	else 
+	else
 		lapply(from, function(x) sp::Lines(list(sp::Line(unclass(x))), "ID"))
 	for (i in 1:length(from))
 		l[[i]]@ID = IDs[i]
@@ -227,12 +227,12 @@ sfc2SpatialPolygons = function(from, IDs = paste0("ID", 1:length(from))) {
 	l = if (class(from)[1] == "sfc_MULTIPOLYGON")
 		lapply(from, function(x)  # for each sfc item, return a Polygons
 				sp::Polygons(unlist(lapply(x, function(y) # to each sub-polygon,
-					lapply(seq_along(y), function(i) sp::Polygon(y[[i]], i > 1))), 
+					lapply(seq_along(y), function(i) sp::Polygon(y[[i]], i > 1))),
 						recursive = FALSE), "ID"))
-	else lapply(from, function(x) 
+	else lapply(from, function(x)
 		sp::Polygons(lapply(seq_along(x), function(i) sp::Polygon(x[[i]], i > 1)), "ID"))
 
-	# set comment: ?Polygons: "Exterior rings are coded zero, while interior rings are 
+	# set comment: ?Polygons: "Exterior rings are coded zero, while interior rings are
 	# coded with the 1-based index of the exterior ring to which they belong.":
 	for (i in 1:length(from)) {
 		l[[i]]@ID = IDs[i]

--- a/R/split.R
+++ b/R/split.R
@@ -1,5 +1,5 @@
 #' Return a collection of geometries resulting by splitting a geometry
-#' 
+#'
 #' @name st_split
 #' @param x object with geometries to be splitted
 #' @param y object split with (blade); if \code{y} contains more than one feature geometry, the geometries are \link{st_combine}d

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -1,7 +1,7 @@
 ## dplyr methods:
 
 #' Dplyr verb methods for sf objects
-#' 
+#'
 #' Dplyr verb methods for sf objects. Geometries are sticky, use \link{as.data.frame} to let code{dplyr}'s own methods drop them.
 #' @param .data data object of class \link{sf}
 #' @param .dots see corresponding function in package \code{dplyr}
@@ -108,7 +108,7 @@ transmute.sf <- transmute_.sf
 #' nc %>% select(SID74, SID79) %>% class()
 #' nc %>% select(SID74, SID79, geometry) %>% class()
 select_.sf <- function(.data, ..., .dots = NULL) {
-  .dots <- c(.dots, attr(.data, "sf_column")) 
+  .dots <- c(.dots, attr(.data, "sf_column"))
   ret = NextMethod()
   structure(ret, agr = st_agr(ret))
 }
@@ -129,7 +129,7 @@ select.sf <- function(.data, ...) {
 
 	ret <- dplyr::select(.data, ..., !! rlang::sym(sf_column))
 	st_as_sf(ret)
-} 
+}
 
 
 #' @name dplyr
@@ -211,10 +211,10 @@ summarise_.sf = summarise.sf
 #' @param gather_cols see original function docs
 #' @param na.rm see original function docs
 #' @param factor_key see original function docs
-#' @examples 
+#' @examples
 #' library(tidyr)
 #' nc %>% select(SID74, SID79, geometry) %>% gather(VAR, SID, -geometry) %>% summary()
-gather_.sf <- function(data, key_col, value_col, gather_cols, na.rm = FALSE, 
+gather_.sf <- function(data, key_col, value_col, gather_cols, na.rm = FALSE,
 		convert = FALSE, factor_key = FALSE) {
 	st_as_sf(NextMethod())
 }
@@ -228,10 +228,10 @@ gather_.sf <- function(data, key_col, value_col, gather_cols, na.rm = FALSE,
 #' @examples
 #' library(tidyr)
 #' nc$row = 1:100 # needed for spread to work
-#' nc %>% select(SID74, SID79, geometry, row) %>% 
-#'		gather(VAR, SID, -geometry, -row) %>% 
+#' nc %>% select(SID74, SID79, geometry, row) %>%
+#'		gather(VAR, SID, -geometry, -row) %>%
 #'		spread(VAR, SID) %>% head()
-spread_.sf <- function(data, key_col, value_col, fill = NA, 
+spread_.sf <- function(data, key_col, value_col, fill = NA,
 		convert = FALSE, drop = TRUE, sep = NULL) {
 	data <- as.data.frame(data)
 	st_as_sf(NextMethod())

--- a/R/transform.R
+++ b/R/transform.R
@@ -1,7 +1,7 @@
 #' Transform or convert coordinates of simple feature
-#' 
+#'
 #' Transform or convert coordinates of simple feature
-#' 
+#'
 #' @param x object of class sf, sfc or sfg
 #' @param crs coordinate reference system: integer with the epsg code, or character with proj4string
 #' @param ... ignored
@@ -23,14 +23,14 @@ chk_pol = function(x, dim = class(x)[1]) {
 			y[[1]] = rbind(y[[1]], head(y[[1]], 1))
 		y
 	}
-	if (length(x) > 0 && nrow(x[[1]]) > 2) 
+	if (length(x) > 0 && nrow(x[[1]]) > 2)
 		PolClose(x)
 	else
 		st_polygon(dim = dim)
 }
 
 chk_mpol = function(x) {
-	cln = lapply(x, function(y) unclass(chk_pol(y, class(x)[1]))) 
+	cln = lapply(x, function(y) unclass(chk_pol(y, class(x)[1])))
 	empty = if (length(cln))
 			lengths(cln) == 0
 		else
@@ -102,7 +102,7 @@ st_transform.sf = function(x, crs, ...) {
 #' @name st_transform
 #' @export
 #' @details the st_transform method for sfg objects assumes that the crs of the object is available as an attribute of that name.
-#' @examples 
+#' @examples
 #' st_transform(structure(p1, proj4string = "+init=epsg:4326"), "+init=epsg:3857")
 st_transform.sfg = function(x, crs , ...) {
 	x = st_sfc(x, crs = attr(x, "proj4string"))
@@ -116,14 +116,14 @@ st_transform.sfg = function(x, crs , ...) {
 #' @param type character; one of \code{proj}, \code{ellps}, \code{datum} or \code{units}
 #' @export
 #' @details \code{st_proj_info} lists the available projections, ellipses, datums or units supported by the Proj.4 library
-#' @examples 
+#' @examples
 #' st_proj_info("datum")
 st_proj_info = function(type = "proj") {
     opts <- c("proj", "ellps", "datum", "units")
     if (!(type %in% opts)) stop("unknown type")
     t <- as.integer(match(type[1], opts) - 1)
 	res = CPL_proj_info(as.integer(t))
-    if (type == "proj") 
+    if (type == "proj")
 		res$description <- sapply(strsplit(as.character(res$description), "\n"),
 			function(x) x[1])
     data.frame(res)

--- a/R/valid.R
+++ b/R/valid.R
@@ -15,9 +15,9 @@ st_is_valid = function(x, NA_on_exception = TRUE, reason = FALSE) {
 			not_na = !is.na(st_is_valid(g))
 			ret[not_na] = st_is_valid(g[not_na], FALSE, TRUE)
 			ret
-		} else 
+		} else
 			CPL_geos_is_valid_reason(st_geometry(x))
-	} else if (! NA_on_exception) 
+	} else if (! NA_on_exception)
 		CPL_geos_is_valid(st_geometry(x), as.logical(NA_on_exception))
 	else {
 		x = st_geometry(x)

--- a/R/wkb.R
+++ b/R/wkb.R
@@ -1,14 +1,14 @@
 # convert character string, as typically PostgreSQL returned blobs, to raw vector;
-# skips a leading "0x", as this is created by PostGIS when using ST_asBinary() 
+# skips a leading "0x", as this is created by PostGIS when using ST_asBinary()
 #
-# most wkb read/write stuff was modified & extended from Ian Cook's wkb package, 
+# most wkb read/write stuff was modified & extended from Ian Cook's wkb package,
 # https://cran.r-project.org/web/packages/wkb/index.html
 #
 hex_to_raw = function(y) {
 	stopifnot((nchar(y) %% 2) == 0)
 	if (substr(y, 1, 2) == "0x")
 		y = substr(y, 3, nchar(y))
-	as.raw(as.numeric(paste0("0x", vapply(seq_len(nchar(y)/2), 
+	as.raw(as.numeric(paste0("0x", vapply(seq_len(nchar(y)/2),
 		function(x) substr(y, (x-1)*2+1, x*2), "")))) # SLOW, hence the Rcpp implementation
 }
 
@@ -40,7 +40,7 @@ st_as_sfc.WKB = function(x, ..., EWKB = FALSE, spatialite = FALSE, pureR = FALSE
     if (all(vapply(x, is.character, TRUE))) {
 		x <- if (pureR)
 				structure(lapply(x, hex_to_raw), class = "WKB")
-			else 
+			else
 				structure(CPL_hex_to_raw(vapply(x, skip0x, USE.NAMES = FALSE, "")), class = "WKB")
 	} else # direct call with raw:
 		stopifnot(inherits(x, "WKB") && all(vapply(x, is.raw, TRUE))) # WKB as raw
@@ -100,7 +100,7 @@ readWKB = function(x, EWKB = FALSE) {
 }
 
 parseTypeEWKB = function(wkbType, endian) {
-	# following the OGC doc, 3001 is POINT with ZM; turns out, PostGIS does sth else - 
+	# following the OGC doc, 3001 is POINT with ZM; turns out, PostGIS does sth else -
 	# read WKB, as well as EWKB; this post is more inormative of what is going on:
 	# https://lists.osgeo.org/pipermail/postgis-devel/2004-December/000710.html
 	# (without SRID, Z, M and ZM this all doesn't matter)
@@ -114,7 +114,7 @@ parseTypeEWKB = function(wkbType, endian) {
 		sf_type = as.numeric(wkbType[4])
 		info = as.raw(as.integer(wkbType[1]) %/% 2^4)
 	}
-	tp = sf.tp[sf_type] 
+	tp = sf.tp[sf_type]
 	stopifnot(!is.na(tp))
 	has_srid = as.logical(info & as.raw(2)) # 2-bit is "on"?
 	zm = if ((info & as.raw(12)) == as.raw(12))
@@ -125,13 +125,13 @@ parseTypeEWKB = function(wkbType, endian) {
 		"XYM"
 	else if (info == as.raw(0) || info == as.raw(2))
 		"XY"
-	else 
+	else
 		stop(paste("unknown value for info:", info))
 	list(dims = nchar(zm), zm = zm, tp = tp, has_srid = has_srid)
 }
 
 parseTypeISO = function(wkbType) {
-	tp = sf.tp[wkbType %% 1000] 
+	tp = sf.tp[wkbType %% 1000]
 	stopifnot(!is.na(tp))
 	dd = wkbType %/% 1000
 	zm = if (dd == 0)
@@ -170,14 +170,14 @@ readData = function(rc, EWKB = FALSE) {
 		CIRCULARSTRING = ,
 		LINESTRING = readMatrix(rc, pt$dims, endian),
 		SURFACE = ,
-		POLYGON = , 
+		POLYGON = ,
 		TRIANGLE = readMatrixList(rc, pt$dims, endian),
 		MULTIPOINT = readMPoints(rc, pt$dims, endian, EWKB),
-		MULTILINESTRING = , 
+		MULTILINESTRING = ,
 		MULTICURVE = ,
-		MULTIPOLYGON = , 
+		MULTIPOLYGON = ,
 		MULTISURFACE = ,
-		POLYHEDRALSURFACE = , 
+		POLYHEDRALSURFACE = ,
 		TIN = lapply(readGC(rc, pt$dims, endian, EWKB), unclass),
 		GEOMETRYCOLLECTION = readGC(rc, pt$dims, endian, EWKB),
 		CURVEPOLYGON = readGC(rc, pt$dims, endian, EWKB),
@@ -229,7 +229,7 @@ st_as_binary = function(x, ...) UseMethod("st_as_binary")
 #' @param precision numeric; if zero, do not modify; to reduce precision: negative values convert to float (4-byte real); positive values convert to round(x*precision)/precision. See details.
 #' @param hex logical; return as (unclassed) hexadecimal encoded character vector?
 #' @details \code{st_as_binary} is called on sfc objects on their way to the GDAL or GEOS libraries, and hence does rounding (if requested) on the fly before e.g. computing spatial predicates like \link{st_intersects}. The examples show a round-trip of an \code{sfc} to and from binary.
-#' 
+#'
 #' For the precision model used, see also \url{https://locationtech.github.io/jts/javadoc/org/locationtech/jts/geom/PrecisionModel.html}. There, it is written that: ``... to specify 3 decimal places of precision, use a scale factor of 1000. To specify -3 decimal places of precision (i.e. rounding to the nearest 1000), use a scale factor of 0.001.''. Note that ALL coordinates, so also Z or M values (if present) are affected.
 #' @export
 #' @examples
@@ -240,11 +240,11 @@ st_as_binary.sfc = function(x, ..., EWKB = FALSE, endian = .Platform$endian, pur
 	stopifnot(endian %in% c("big", "little"))
 	if (pureR && precision != 0.0)
 		stop("for non-zero precision values, use pureR = FALSE")
-	ret = if (pureR) 
+	ret = if (pureR)
 		structure(lapply(x, st_as_binary.sfg, EWKB = EWKB, pureR = pureR, endian = endian), class = "WKB")
 	else {
 		stopifnot(endian == .Platform$endian)
-		structure(CPL_write_wkb(x, EWKB, endian == "little", Dimension(x[[1]]), precision), 
+		structure(CPL_write_wkb(x, EWKB, endian == "little", Dimension(x[[1]]), precision),
 				class = "WKB")
 	}
 	if (hex)
@@ -275,7 +275,7 @@ createType = function(x, endian, EWKB = FALSE) {
 
 #' @name st_as_binary
 #' @export
-st_as_binary.sfg = function(x, ..., endian = .Platform$endian, EWKB = FALSE, pureR = FALSE, 
+st_as_binary.sfg = function(x, ..., endian = .Platform$endian, EWKB = FALSE, pureR = FALSE,
 		hex = FALSE) {
 # if pureR, it's done here, if not, it's done in st_as_binary.sfc
 	stopifnot(endian %in% c("big", "little"))
@@ -295,7 +295,7 @@ st_as_binary.sfg = function(x, ..., endian = .Platform$endian, EWKB = FALSE, pur
 #' Convert raw vector(s) into hexadecimal character string(s)
 #'
 #' Convert raw vector(s) into hexadecimal character string(s)
-#' @param x raw vector, or list with raw vectors 
+#' @param x raw vector, or list with raw vectors
 #' @export
 rawToHex = function(x) {
 	if (is.raw(x))
@@ -320,12 +320,12 @@ writeData = function(x, rc, endian, EWKB = FALSE) {
 	switch(class(x)[2],
 		POINT = writeBin(as.vector(as.double(x)), rc, size = 8L, endian = endian),
 		LINESTRING = writeMatrix(x, rc, endian),
-		POLYGON = , 
+		POLYGON = ,
 		TRIANGLE = writeMatrixList(x, rc, endian),
 		MULTIPOINT = writeMPoints(x, rc, endian, EWKB),
-		POLYHEDRALSURFACE = , 
-		TIN = , 
-		MULTILINESTRING = , 
+		POLYHEDRALSURFACE = ,
+		TIN = ,
+		MULTILINESTRING = ,
 		MULTIPOLYGON = writeMulti(x, rc, endian, EWKB),
 		GEOMETRYCOLLECTION = writeGC(x, rc, endian, EWKB),
 		stop(paste("unimplemented class to write:", class(x)[2]))
@@ -342,7 +342,7 @@ writeMulti = function(x, rc, endian, EWKB) {
 }
 writeGC = function(x, rc, endian, EWKB) {
 	writeBin(as.integer(length(x)), rc, size = 4L, endian = endian)
-	lapply(x, writeData, rc = rc, endian = endian, EWKB = EWKB) 
+	lapply(x, writeData, rc = rc, endian = endian, EWKB = EWKB)
 }
 writeMatrix = function(x, rc, endian) {
 	writeBin(as.integer(nrow(x)), rc, size = 4L, endian = endian)

--- a/R/wkt.R
+++ b/R/wkt.R
@@ -24,7 +24,7 @@ prnt.LINESTRING = function(x, ...) paste0(WKT_name(x, ...), prnt.Matrix(x))
 prnt.POLYGON = function(x, ...) paste0(WKT_name(x, ...), prnt.MatrixList(x))
 prnt.MULTILINESTRING = function(x, ...) paste0(WKT_name(x, ...), prnt.MatrixList(x))
 prnt.MULTIPOLYGON = function(x, ...) paste0(WKT_name(x, ...), prnt.MatrixListList(x))
-prnt.GEOMETRYCOLLECTION = function(x, ...) 
+prnt.GEOMETRYCOLLECTION = function(x, ...)
 	paste0(WKT_name(x, ...), "(", paste0(vapply(x, st_as_text, ""), collapse=", "), ")")
 
 #' Return Well-known Text representation of simple feature geometry or coordinate reference system

--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@
 [![Build Status](https://travis-ci.org/r-spatial/sf.png?branch=master)](https://travis-ci.org/r-spatial/sf)
 [![AppVeyor Build Status](https://ci.appveyor.com/api/projects/status/github/r-spatial/sf?branch=master&svg=true)](https://ci.appveyor.com/project/edzerpebesma/sf)
 [![Coverage Status](https://img.shields.io/codecov/c/github/r-spatial/sf/master.svg)](https://codecov.io/github/r-spatial/sf?branch=master)
-[![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html) 
-[![CRAN](http://www.r-pkg.org/badges/version/sf)](https://cran.r-project.org/package=sf) 
+[![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)
+[![CRAN](http://www.r-pkg.org/badges/version/sf)](https://cran.r-project.org/package=sf)
 [![Downloads](http://cranlogs.r-pkg.org/badges/sf?color=brightgreen)](http://www.r-pkg.org/pkg/sf)
 
 A package that provides [simple features access](https://en.wikipedia.org/wiki/Simple_Features) for R. Package sf:
 
 * represents natively in R all 17 simple feature types for all dimensions (XY, XYZ, XYM, XYZM)
-* uses S3 classes: simple features are `data.frame` objects (or `tibbles`) that have a geometry list-column 
+* uses S3 classes: simple features are `data.frame` objects (or `tibbles`) that have a geometry list-column
 * interfaces to [GEOS](https://trac.osgeo.org/geos) to support the [DE9-IM](https://en.wikipedia.org/wiki/DE-9IM)
 * interfaces to [GDAL](http://www.gdal.org/) with driver dependent dataset or layer creation options, Date and DateTime (`POSIXct`) columns, and coordinate reference system transformations through [PROJ.4](http://proj4.org/)
 * provides fast I/O with GDAL and GEOS using [well-known-binary](https://en.wikipedia.org/wiki/Well-known_text#Well-known_binary) written in C++/Rcpp
@@ -26,7 +26,7 @@ See also:
 * UseR! 2016 [presentation](http://pebesma.staff.ifgi.de/pebesma_sfr.pdf)
 
 
-## Installling 
+## Installling
 
 Install either from CRAN with:
 ```r
@@ -52,8 +52,8 @@ see e.g. [here](http://www.karambelkar.info/2016/10/gdal-2-on-mac-with-homebrew/
 ```
 brew unlink gdal
 brew tap osgeo/osgeo4mac && brew tap --repair
-brew install proj 
-brew install geos 
+brew install proj
+brew install geos
 brew install udunits
 brew install gdal2 --with-armadillo --with-complete --with-libkml --with-unsupported
 brew link --force gdal2
@@ -85,7 +85,7 @@ To install on Debian, the [rocker geospatial](https://github.com/rocker-org/geos
 
 ### Contributing
 
-* Contributions of all sorts are most welcome, issues and pull requests are the preferred ways of sharing them. 
+* Contributions of all sorts are most welcome, issues and pull requests are the preferred ways of sharing them.
 * When contributing pull requests, please adhere to the package style (in package code use `=` rather than `<-`; don't change indentation; tab stops of 4 spaces are preferred)
 * This project is released with a [Contributor Code of Conduct](CONDUCT.md). By participating in this project you agree to abide by its terms.
 

--- a/cleanup
+++ b/cleanup
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# rm -fr man R/Rcpp*R src/Rcpp*cpp 
+# rm -fr man R/Rcpp*R src/Rcpp*cpp
 rm -fr src/Makevars config.log config.status autom4te.cache src/*.o src/*.so
 rm -fr vignette/nc*
 rm -fr proj_conf_test*

--- a/demo/affine.R
+++ b/demo/affine.R
@@ -11,12 +11,12 @@ outer = rbind(c(-1,-1), c(1, -1), c(1, 1), c(-1, 1), c(-1, -1))
 hole = a * outer[5:1,]
 
 # only shift:
-p = st_sfc(lapply(0:n, 
+p = st_sfc(lapply(0:n,
 	function(i) { st_polygon(list(outer, hole)) * rot(0) * b^i + drift * i * b ^ i } ))
 plot(p, col = grey(0:n/n), border = 0)
 
 # shift + rotate:
-p = st_sfc(lapply(0:n, 
+p = st_sfc(lapply(0:n,
 	function(i) { st_polygon(list(outer, hole)) * rot(i * ang) * b ^ i + drift * i * b ^ i } ))
 p
 plot(p, col = grey(0:n/n), border = 0)

--- a/demo/bm_wkb.R
+++ b/demo/bm_wkb.R
@@ -25,7 +25,7 @@ WKB_MULTILINESTRING = function(m = 1, n = 2, p = 2) {
 
 mls = WKB_MULTILINESTRING(1, 5e5)
 ls1 = WKB_LINESTRING(1, 1e6)
-ls2 = WKB_LINESTRING(5e5, 2) 
+ls2 = WKB_LINESTRING(5e5, 2)
 
 system.time(sf::st_as_sfc(mls, pureR = TRUE))
 system.time(sf::st_as_sfc(mls))

--- a/inst/docker/README.md
+++ b/inst/docker/README.md
@@ -6,9 +6,9 @@ To allows building `sf` in alternative environments with all
 external system requirements (udunits, proj, gdal, geos, lwgeom),
 this directory has subdirectories with Docker files:
 
-* base: for installing R-release with all system dependencies required by `sf`, 
-* devel: for building R-devel from source (downloaded from svn, without X11) on top of that. 
-* gdal22: for testing with gdal 2.2beta0 
+* base: for installing R-release with all system dependencies required by `sf`,
+* devel: for building R-devel from source (downloaded from svn, without X11) on top of that.
+* gdal22: for testing with gdal 2.2beta0
 * custom: for testing with libraries (gdal, geos, proj.4) installed in custom, non-standard directories
 
 The images are built on ubuntu:16.04 (xenial). They use [ubuntugis-unstable](https://launchpad.net/~ubuntugis/+archive/ubuntu/ubuntugis-unstable) for GIS package system dependencies.
@@ -21,7 +21,7 @@ In directory `base`, type
 
 this will build a docker image of approx. 3.8 Gb size, called `sf`. It will also install package `sf` with its dependencies from CRAN, and run a check on the github sources.
 
-Run a container from this image interactively with 
+Run a container from this image interactively with
 
 	docker run -ti sf
 
@@ -31,7 +31,7 @@ If you want to run it while mounting the current working directory (`pwd`) to `/
 
 ## build R-devel, check with R-devel
 
-_After_ you built docker image `sf` above, on top of that you can install r-devel; it counts up to 4 Gb. Build it by executing the following command in the `devel` directory: 
+_After_ you built docker image `sf` above, on top of that you can install r-devel; it counts up to 4 Gb. Build it by executing the following command in the `devel` directory:
 
     docker build . -t sf_devel
 

--- a/inst/docker/gdal22/Dockerfile
+++ b/inst/docker/gdal22/Dockerfile
@@ -55,8 +55,7 @@ RUN svn checkout svn://scm.r-forge.r-project.org/svnroot/rgdal/
 # svn checkout svn+ssh://edzer@scm.r-forge.r-project.org/svnroot/rgdal/
 
 RUN R CMD build rgdal/pkg --no-build-vignettes
-RUN R CMD INSTALL rgdal_1.2-7.tar.gz 
+RUN R CMD INSTALL rgdal_1.2-7.tar.gz
 RUN R CMD check --no-build-vignettes --no-manual --as-cran sf_*tar.gz
 
 CMD ["/bin/bash"]
-

--- a/src/bbox.cpp
+++ b/src/bbox.cpp
@@ -33,7 +33,7 @@ Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 					// Rcpp::stop("CPL_get_bbox: invalid geometry");
 				bb(0) = bb(2) = m(0,0);
 				bb(1) = bb(3) = m(0,1);
-			} 
+			}
 			for (int j = 0; j < m.nrow(); j++) {
 				bb(0) = std::min(m(j,0),bb(0));
 				bb(1) = std::min(m(j,1),bb(1));

--- a/src/gdal.cpp
+++ b/src/gdal.cpp
@@ -36,7 +36,7 @@ static void __err_handler(CPLErr eErrClass, int err_no, const char *msg)
         case 4:
             Rf_warning("GDAL Error %d: %s\n", err_no, msg); // #nocov
             Rcpp::stop("Unrecoverable GDAL error\n"); // #nocov
-            break;        
+            break;
         default:
             Rf_warning("Received invalid error class %d (errno %d: %s)\n", eErrClass, err_no, msg); // #nocov
             break; // #nocov
@@ -310,7 +310,7 @@ Rcpp::List CPL_transform(Rcpp::List sfc, Rcpp::CharacterVector proj4) {
 		dest->Release(); // #nocov
 		Rcpp::stop("CPL_transform: zero length geometry list"); // #nocov
 	}
-	OGRCoordinateTransformation *ct = 
+	OGRCoordinateTransformation *ct =
 		OGRCreateCoordinateTransformation(g[0]->getSpatialReference(), dest);
 	if (ct == NULL) {
 		dest->Release(); // #nocov
@@ -334,7 +334,7 @@ Rcpp::List CPL_transform(Rcpp::List sfc, Rcpp::CharacterVector proj4) {
 	Rcpp::List ret = sfc_from_ogr(g, true); // destroys g;
 	ct->DestroyCT(ct);
 	dest->Release();
-	return ret; 
+	return ret;
 }
 
 // [[Rcpp::export]]

--- a/src/gdal_geom.cpp
+++ b/src/gdal_geom.cpp
@@ -6,7 +6,7 @@
 #include "gdal.h"
 
 // [[Rcpp::export]]
-Rcpp::NumericVector CPL_area(Rcpp::List sfc) { 
+Rcpp::NumericVector CPL_area(Rcpp::List sfc) {
 	std::vector<OGRGeometry *> g = ogr_from_sfc(sfc, NULL);
 	Rcpp::NumericVector out(sfc.length());
 	for (size_t i = 0; i < g.size(); i++) {
@@ -37,7 +37,7 @@ Rcpp::IntegerVector CPL_gdal_dimension(Rcpp::List sfc, bool NA_if_empty = true) 
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector CPL_length(Rcpp::List sfc) { 
+Rcpp::NumericVector CPL_length(Rcpp::List sfc) {
 	std::vector<OGRGeometry *> g = ogr_from_sfc(sfc, NULL);
 	Rcpp::NumericVector out(sfc.length());
 	for (size_t i = 0; i < g.size(); i++) {

--- a/src/gdal_read.cpp
+++ b/src/gdal_read.cpp
@@ -76,7 +76,7 @@ Rcpp::List allocate_out_list(OGRFeatureDefn *poFDefn, int n_features, bool int64
 
 int to_multi_what(std::vector<OGRGeometry *> gv) {
 	bool points = false, multipoints = false,
-		lines = false, multilines = false, 
+		lines = false, multilines = false,
 		polygons = false, multipolygons = false;
 
 	for (unsigned int i = 0; i < gv.size(); i++) {
@@ -127,7 +127,7 @@ Rcpp::List CPL_get_layers(Rcpp::CharacterVector datasource, Rcpp::CharacterVecto
 		Rcpp::stop("argument datasource should have length 1.\n"); // #nocov
 	std::vector <char *> open_options = create_options(options, false);
 	GDALDataset *poDS;
-	poDS = (GDALDataset *) GDALOpenEx(datasource[0], GDAL_OF_VECTOR | GDAL_OF_READONLY, NULL, 
+	poDS = (GDALDataset *) GDALOpenEx(datasource[0], GDAL_OF_VECTOR | GDAL_OF_READONLY, NULL,
 		open_options.data(), NULL);
 	if (poDS == NULL) {
 		Rcpp::Rcout << "Cannot open data source " << datasource[0] << std::endl;
@@ -189,13 +189,13 @@ std::vector<OGRGeometry *> replace_null_with_empty(std::vector<OGRGeometry *> po
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_read_ogr(Rcpp::CharacterVector datasource, Rcpp::CharacterVector layer, 
+Rcpp::List CPL_read_ogr(Rcpp::CharacterVector datasource, Rcpp::CharacterVector layer,
 		Rcpp::CharacterVector options, bool quiet, Rcpp::NumericVector toTypeUser,
 		bool promote_to_multi = true, bool int64_as_string = false) {
 	// adapted from the OGR tutorial @ www.gdal.org
 	std::vector <char *> open_options = create_options(options, quiet);
 	GDALDataset *poDS;
-	poDS = (GDALDataset *) GDALOpenEx( datasource[0], GDAL_OF_VECTOR | GDAL_OF_READONLY, NULL, 
+	poDS = (GDALDataset *) GDALOpenEx( datasource[0], GDAL_OF_VECTOR | GDAL_OF_READONLY, NULL,
 		open_options.data(), NULL );
 	if( poDS == NULL ) {
 		Rcpp::Rcout << "Cannot open data source " << datasource[0] << std::endl;
@@ -307,9 +307,9 @@ Rcpp::List CPL_read_ogr(Rcpp::CharacterVector datasource, Rcpp::CharacterVector 
 					poFeature->GetFieldAsDateTime(iField, &Year, &Month, &Day, &Hour, &Minute,
 						&Second, &TZFlag);
 					//  POSIXlt: sec   min  hour  mday   mon  year  wday  yday isdst ...
-					Rcpp::List dtlst = 
-						Rcpp::List::create((double) Second, (double) Minute, 
-						(double) Hour, (double) Day, (double) Month - 1, (double) Year - 1900, 
+					Rcpp::List dtlst =
+						Rcpp::List::create((double) Second, (double) Minute,
+						(double) Hour, (double) Day, (double) Month - 1, (double) Year - 1900,
 						0.0, 0.0, 0.0);
 					dtlst.attr("class") = "POSIXlt";
 					if (TZFlag == 100)
@@ -369,7 +369,7 @@ Rcpp::List CPL_read_ogr(Rcpp::CharacterVector datasource, Rcpp::CharacterVector 
 					for (int j = 0; j < iv.size(); j++)
 						iv(j) = psField->IntegerList.paList[j];
 					lv[i] = iv;
-					} 
+					}
 					break; // #nocov end
 				default: // break through: anything else to be converted to string?
 				case OFTString: {
@@ -416,8 +416,8 @@ Rcpp::List CPL_read_ogr(Rcpp::CharacterVector datasource, Rcpp::CharacterVector 
 				OGRGeometry *geom = poFeatureV[i]->StealGeometry(iGeom); // transfer ownership
 				if (geom == NULL)
 					geom = OGRGeometryFactory::createGeometry((OGRwkbGeometryType) toType); // #nocov
-				else if ((geom = 
-						OGRGeometryFactory::forceTo(geom, (OGRwkbGeometryType) toType, NULL)) 
+				else if ((geom =
+						OGRGeometryFactory::forceTo(geom, (OGRwkbGeometryType) toType, NULL))
 						== NULL)
 					Rcpp::stop("OGRGeometryFactory::forceTo returned NULL"); // #nocov
 				handle_error(poFeatureV[i]->SetGeomFieldDirectly(iGeom, geom));
@@ -438,7 +438,7 @@ Rcpp::List CPL_read_ogr(Rcpp::CharacterVector datasource, Rcpp::CharacterVector 
 	}
 
 	if (warn_int64)
-		Rcpp::Rcout << "Integer64 values larger than " << dbl_max_int64 << 
+		Rcpp::Rcout << "Integer64 values larger than " << dbl_max_int64 <<
 			" lost significance after conversion to double;" << std::endl <<
 			"use argument int64_as_string = TRUE to import them lossless, as character" << std::endl;
 

--- a/src/gdal_write.cpp
+++ b/src/gdal_write.cpp
@@ -36,7 +36,7 @@ std::vector<OGRFieldType> SetupFields(OGRLayer *poLayer, Rcpp::List obj) {
 
 // this is like an unlist -> dbl, but only does the first 6; if we'd do unlist on the POSIXlt
 // object, we'd get a character vector...
-Rcpp::NumericVector get_dbl6(Rcpp::List in) { 
+Rcpp::NumericVector get_dbl6(Rcpp::List in) {
 	Rcpp::NumericVector ret(6);
 	for (int i = 0; i < 6; i++) {
 		Rcpp::NumericVector x = in(i);
@@ -116,7 +116,7 @@ void SetFields(OGRFeature *poFeature, std::vector<OGRFieldType> tp, Rcpp::List o
 				} break;
 			default:
 				// we should never get here! // #nocov start
-				Rcpp::Rcout << "field with unsupported type ignored" << std::endl; 
+				Rcpp::Rcout << "field with unsupported type ignored" << std::endl;
 				Rcpp::stop("Layer creation failed.\n");
 				break; // #nocov end
 		}
@@ -152,10 +152,10 @@ void CPL_write_ogr(Rcpp::List obj, Rcpp::CharacterVector dsn, Rcpp::CharacterVec
 
 	// data set:
 	std::vector <char *> options = create_options(dco, quiet);
-	GDALDataset *poDS; 
+	GDALDataset *poDS;
 
 	// delete layer:
-	if (delete_layer && (poDS = (GDALDataset *) GDALOpenEx(dsn[0], GDAL_OF_VECTOR | GDAL_OF_UPDATE, NULL, 
+	if (delete_layer && (poDS = (GDALDataset *) GDALOpenEx(dsn[0], GDAL_OF_VECTOR | GDAL_OF_UPDATE, NULL,
 				options.data(), NULL)) != NULL) { // don't complain if the layer is not present
 		// find & delete layer:
 		bool deleted = false;
@@ -168,7 +168,7 @@ void CPL_write_ogr(Rcpp::List obj, Rcpp::CharacterVector dsn, Rcpp::CharacterVec
 						Rcpp::Rcout << "Deleting layer not supported by driver `" << driver[0] << "'"  // #nocov
 							<< std::endl; // #nocov
 					else  {
-						Rcpp::Rcout << "Deleting layer `" << layer[0] << "' using driver `" << 
+						Rcpp::Rcout << "Deleting layer `" << layer[0] << "' using driver `" <<
 							driver[0] << "'" << std::endl;
 					}
 				}
@@ -180,21 +180,21 @@ void CPL_write_ogr(Rcpp::List obj, Rcpp::CharacterVector dsn, Rcpp::CharacterVec
 			Rcpp::Rcout << "Deleting layer `" << layer[0] << "' failed" << std::endl;
 		GDALClose(poDS);
 	}
-	
+
 	// update ds:
-	if (update && (poDS = (GDALDataset *) GDALOpenEx(dsn[0], GDAL_OF_VECTOR | GDAL_OF_UPDATE, NULL, 
+	if (update && (poDS = (GDALDataset *) GDALOpenEx(dsn[0], GDAL_OF_VECTOR | GDAL_OF_UPDATE, NULL,
 				options.data(), NULL)) != NULL) {
 		if (! quiet)
 			Rcpp::Rcout << "Updating layer `" << layer[0] << "' to data source `" << dsn[0] <<
 			"' using driver `" << driver[0] << "'" << std::endl;
-	} else { // create new ds: 
+	} else { // create new ds:
 		// error when it already exists:
-		if ((poDS = (GDALDataset *) GDALOpenEx(dsn[0], GDAL_OF_VECTOR | GDAL_OF_READONLY, NULL, 
+		if ((poDS = (GDALDataset *) GDALOpenEx(dsn[0], GDAL_OF_VECTOR | GDAL_OF_READONLY, NULL,
 					options.data(), NULL)) != NULL) {
 			GDALClose(poDS);
-			Rcpp::Rcout << "Dataset " <<  dsn[0] << 
-				" already exists: remove first, use update=TRUE to append," << std::endl <<  
-				"delete_layer=TRUE to delete layer, or delete_dsn=TRUE to remove the entire data source before writing." 
+			Rcpp::Rcout << "Dataset " <<  dsn[0] <<
+				" already exists: remove first, use update=TRUE to append," << std::endl <<
+				"delete_layer=TRUE to delete layer, or delete_dsn=TRUE to remove the entire data source before writing."
 				<< std::endl;
 			Rcpp::stop("Dataset already exists.\n");
 		}

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -14,7 +14,7 @@
 #include "wkb.h"
 
 typedef char (* log_fn)(GEOSContextHandle_t, const GEOSGeometry *, const GEOSGeometry *);
-typedef char (* log_prfn)(GEOSContextHandle_t, const GEOSPreparedGeometry *, 
+typedef char (* log_prfn)(GEOSContextHandle_t, const GEOSPreparedGeometry *,
 	const GEOSGeometry *);
 typedef GEOSGeom (* geom_fn)(GEOSContextHandle_t, const GEOSGeom, const GEOSGeom);
 
@@ -51,7 +51,7 @@ static void __warningHandler(const char *fmt, ...) {
 
 	Rcpp::Function warning("warning");
 	warning(buf);
-	
+
 	return;
 }
 
@@ -201,7 +201,7 @@ Rcpp::LogicalVector get_dense(std::vector<size_t> items, int length) {
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, double par = 0.0, 
+Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, double par = 0.0,
 		std::string pattern = "", bool sparse = true, bool prepared = false) {
 
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
@@ -272,8 +272,8 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 
 		if (op == "equals_exact") { // has it's own signature, needing `par':
 			for (int i = 0; i < sfc0.length(); i++) { // row
-				Rcpp::LogicalVector rowi(sfc1.length()); 
-				for (int j = 0; j < sfc1.length(); j++) 
+				Rcpp::LogicalVector rowi(sfc1.length());
+				for (int j = 0; j < sfc1.length(); j++)
 					rowi(j) = chk_(GEOSEqualsExact_r(hGEOSCtxt, gmv0[i], gmv1[j], par));
 				if (! sparse)
 					densemat(i,_) = rowi;
@@ -356,7 +356,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector CPL_geos_is_valid_reason(Rcpp::List sfc) { 
+Rcpp::CharacterVector CPL_geos_is_valid_reason(Rcpp::List sfc) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	std::vector<GEOSGeom> gmv = geometries_from_sfc(hGEOSCtxt, sfc, NULL);
@@ -376,7 +376,7 @@ Rcpp::CharacterVector CPL_geos_is_valid_reason(Rcpp::List sfc) {
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = true) { 
+Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = true) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	int notice = 0;
@@ -384,10 +384,10 @@ Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = tru
 		if (sfc.size() > 1)
 			Rcpp::stop("NA_on_exception will only work reliably with length 1 sfc objects"); // #nocov
 #ifdef HAVE350
-		GEOSContext_setNoticeMessageHandler_r(hGEOSCtxt, 
+		GEOSContext_setNoticeMessageHandler_r(hGEOSCtxt,
 			(GEOSMessageHandler_r) __emptyNoticeHandler, (void *) &notice);
-		GEOSContext_setErrorMessageHandler_r(hGEOSCtxt, 
-			(GEOSMessageHandler_r) __countErrorHandler, (void *) &notice); 
+		GEOSContext_setErrorMessageHandler_r(hGEOSCtxt,
+			(GEOSMessageHandler_r) __countErrorHandler, (void *) &notice);
 #endif
 	}
 
@@ -410,7 +410,7 @@ Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = tru
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalVector CPL_geos_is_simple(Rcpp::List sfc) { 
+Rcpp::LogicalVector CPL_geos_is_simple(Rcpp::List sfc) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	Rcpp::LogicalVector out(sfc.length());
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, NULL);
@@ -423,7 +423,7 @@ Rcpp::LogicalVector CPL_geos_is_simple(Rcpp::List sfc) {
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) { 
+Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) {
 	int dim = 2;
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	std::vector<GEOSGeom> gmv = geometries_from_sfc(hGEOSCtxt, sfc, &dim);
@@ -454,13 +454,13 @@ GEOSGeometry *chkNULL(GEOSGeometry *value) {
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc, 
+Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc,
 		Rcpp::NumericVector bufferDist, int nQuadSegs = 30,
-		double dTolerance = 0.0, bool preserveTopology = false, 
+		double dTolerance = 0.0, bool preserveTopology = false,
 		int bOnlyEdges = 1, double dfMaxLength = 0.0) {
 
 	int dim = 2;
-	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init(); 
+	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, &dim);
 	std::vector<GEOSGeom> out(sfc.length());
@@ -520,7 +520,7 @@ Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc,
 Rcpp::List CPL_geos_voronoi(Rcpp::List sfc, Rcpp::List env, double dTolerance = 0.0, int bOnlyEdges = 1) {
 
 	int dim = 2;
-	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init(); 
+	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, &dim);
 	std::vector<GEOSGeom> out(sfc.length());
@@ -531,7 +531,7 @@ Rcpp::List CPL_geos_voronoi(Rcpp::List sfc, Rcpp::List env, double dTolerance = 
 		case 1: {
 			std::vector<GEOSGeom> g_env = geometries_from_sfc(hGEOSCtxt, env);
 			for (size_t i = 0; i < g.size(); i++) {
-				out[i] = chkNULL(GEOSVoronoiDiagram_r(hGEOSCtxt, g[i], 
+				out[i] = chkNULL(GEOSVoronoiDiagram_r(hGEOSCtxt, g[i],
 					g_env.size() ? g_env[0] : NULL, dTolerance, bOnlyEdges));
 				GEOSGeom_destroy_r(hGEOSCtxt, g[i]);
 			}
@@ -659,7 +659,7 @@ Rcpp::NumericMatrix CPL_geos_dist(Rcpp::List sfc0, Rcpp::List sfc1) {
 // [[Rcpp::export]]
 Rcpp::CharacterVector CPL_geos_relate(Rcpp::List sfc0, Rcpp::List sfc1) {
 	Rcpp::CharacterVector out = CPL_geos_binop(sfc0, sfc1, "relate", 0.0, "", false)[0];
-	return out;	
+	return out;
 }
 
 // [[Rcpp::export]]

--- a/src/init.c
+++ b/src/init.c
@@ -3,7 +3,7 @@
 #include <stdlib.h> // for NULL
 #include <R_ext/Rdynload.h>
 
-/* FIXME: 
+/* FIXME:
    Check these declarations against the C/Fortran source code.
 */
 

--- a/src/lwgeom.cpp
+++ b/src/lwgeom.cpp
@@ -21,7 +21,7 @@ std::vector<LWGEOM *> lwgeom_from_sfc(Rcpp::List sfc) {
 	Rcpp::List wkblst = CPL_write_wkb(sfc, true, native_endian(), get_dim_sfc(sfc, NULL), precision);
 	for (int i = 0; i < wkblst.size(); i++) {
 		Rcpp::RawVector rv = wkblst[i];
-		const uint8_t *wkb = &(rv[0]); 
+		const uint8_t *wkb = &(rv[0]);
 		lwgeom_v[i] = lwgeom_from_wkb(wkb, rv.size(),
 			LW_PARSER_CHECK_MINPOINTS & LW_PARSER_CHECK_ODD & LW_PARSER_CHECK_CLOSURE);
 	}
@@ -30,7 +30,7 @@ std::vector<LWGEOM *> lwgeom_from_sfc(Rcpp::List sfc) {
 
 // out
 Rcpp::List sfc_from_lwgeom(std::vector<LWGEOM *> lwgeom_v) {
-	Rcpp::List wkblst(lwgeom_v.size()); 
+	Rcpp::List wkblst(lwgeom_v.size());
 	for (int i = 0; i < wkblst.size(); i++) {
 		size_t size;
 		const uint8_t *wkb = lwgeom_to_wkb(lwgeom_v[i], WKB_EXTENDED, &size);

--- a/src/proj.cpp
+++ b/src/proj.cpp
@@ -5,7 +5,7 @@
 
 // [[Rcpp::export]]
 std::string CPL_proj_version(bool b = false) {
-	int v = PJ_VERSION;	
+	int v = PJ_VERSION;
 	std::stringstream buffer;
 	buffer << v / 100 << "." << (v / 10) % 10 << "." << v % 10;
 	return buffer.str();
@@ -53,7 +53,7 @@ struct PJ_DATUMS {
 	char	*ellipse_id; /* ie from ellipse table */
 	char	*comments; /* EPSG code, etc */
 };
-struct PJ_DATUMS *pj_get_datums_ref( void ); 
+struct PJ_DATUMS *pj_get_datums_ref( void );
 struct PJ_UNITS {
 	char	*id;		/* units keyword */
 	char	*to_meter;	/* multiply by value to get meters */
@@ -89,11 +89,11 @@ Rcpp::List CPL_proj_info(int type) {
 		} break;
 		case 1: {
 			Rcpp::List ans(4);
-			ans.attr("names") = Rcpp::CharacterVector::create("name", 
+			ans.attr("names") = Rcpp::CharacterVector::create("name",
 				"major", "ell", "description");
 			int n = 0;
 			struct PJ_ELLPS *le;
-			for (le = pj_get_ellps_ref(); le->id ; ++le) 
+			for (le = pj_get_ellps_ref(); le->id ; ++le)
 				n++;
 			Rcpp::CharacterVector ans0(n);
 			Rcpp::CharacterVector ans1(n);
@@ -119,7 +119,7 @@ Rcpp::List CPL_proj_info(int type) {
 				"definition", "description");
 			int n = 0;
 			struct PJ_DATUMS *ld;
-			for (ld = pj_get_datums_ref(); ld->id ; ++ld) 
+			for (ld = pj_get_datums_ref(); ld->id ; ++ld)
 				n++;
 			Rcpp::CharacterVector ans0(n);
 			Rcpp::CharacterVector ans1(n);
@@ -145,7 +145,7 @@ Rcpp::List CPL_proj_info(int type) {
 				"name");
 			int n = 0;
 			struct PJ_UNITS *ld;
-			for (ld = pj_get_units_ref(); ld->id ; ++ld) 
+			for (ld = pj_get_units_ref(); ld->id ; ++ld)
 				n++;
 			Rcpp::CharacterVector ans0(n);
 			Rcpp::CharacterVector ans1(n);

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -27,9 +27,9 @@ typedef struct {
 
 void wkb_read(wkb_buf *wkb, void *dst, size_t n);
 
-Rcpp::List read_data(wkb_buf *wkb, bool EWKB, bool spatialite, int endian, 
+Rcpp::List read_data(wkb_buf *wkb, bool EWKB, bool spatialite, int endian,
 	bool addclass, int *type, uint32_t *srid);
-void write_data(std::ostringstream& os, Rcpp::List sfc, int i, bool EWKB, 
+void write_data(std::ostringstream& os, Rcpp::List sfc, int i, bool EWKB,
 		int endian, const char *cls, const char *dim, double prec, int srid);
 
 void wkb_read(wkb_buf *wkb, void *dst, size_t n) {
@@ -116,7 +116,7 @@ void read_spatialite_header(wkb_buf *wkb, uint32_t *srid, bool swap) {
 	// verify special marker; if not there, raise error:
 	unsigned char marker;
 	wkb_read(wkb, &marker, 1); // skip header
-	if (marker != 0x7c) { 
+	if (marker != 0x7c) {
 		Rcpp::Rcout << "byte 39 should be 0x7c, but is " << marker << std::endl; // #nocov
 		Rcpp::stop("invalid spatialite header"); // #nocov
 	}
@@ -182,8 +182,8 @@ Rcpp::NumericMatrix read_multipoint(wkb_buf *wkb, int n_dims, bool swap,
 	return ret;
 }
 
-Rcpp::List read_geometrycollection(wkb_buf *wkb, int n_dims, bool swap, bool EWKB = 0, 
-		bool spatialite = false, int endian = 0, Rcpp::CharacterVector cls = "", bool isGC = true, 
+Rcpp::List read_geometrycollection(wkb_buf *wkb, int n_dims, bool swap, bool EWKB = 0,
+		bool spatialite = false, int endian = 0, Rcpp::CharacterVector cls = "", bool isGC = true,
 		bool *empty = NULL) {
 
 	uint32_t nlst;
@@ -255,7 +255,7 @@ Rcpp::NumericMatrix read_numeric_matrix(wkb_buf *wkb, int n_dims, bool swap,
 	return ret;
 }
 
-Rcpp::List read_matrix_list(wkb_buf *wkb, int n_dims, bool swap, 
+Rcpp::List read_matrix_list(wkb_buf *wkb, int n_dims, bool swap,
 		Rcpp::CharacterVector cls = "", bool *empty = NULL) {
 
 	uint32_t nlst;
@@ -304,12 +304,12 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 		swap = ((int) swap_char != (int) endian); // endian check
 	}
 	if (spatialite) {
-		if (swap) 
+		if (swap)
 			Rcpp::stop("reading non-native endian spatialite geometries not supported"); // #nocov
 		if (srid != NULL) // not nested:
 			read_spatialite_header(wkb, srid, swap);
 	}
-	
+
 	// read type:
 	uint32_t wkbType;
 	wkb_read(wkb, &wkbType, 4);
@@ -318,7 +318,7 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 		wkbType = swap_endian<uint32_t>(wkbType); // #nocov
 
 	int sf_type = 0, n_dims = 0;
-	std::string dim_str = ""; 
+	std::string dim_str = "";
 	if (EWKB) { // EWKB: PostGIS default
 		sf_type =     wkbType & 0x000000ff; // mask the other bits
 		int wkbZ =    wkbType & EWKB_Z_BIT;
@@ -334,7 +334,7 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 		else
 			dim_str = "XYZM";
 		if (wkbSRID != 0) {
-			if (srid != NULL) { 
+			if (srid != NULL) {
 				wkb_read(wkb, srid, 4);
 				if (swap)
 					*srid = swap_endian<uint32_t>(*srid); // #nocov
@@ -343,10 +343,10 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 	} else { // ISO
 		sf_type = wkbType % 1000;
 		switch (wkbType / 1000) { // 0: XY, 1: XYZ, 2: XYM, 3: XYZM
-			case 0: n_dims = 2; dim_str = "XY"; break; 
-			case 1: n_dims = 3; dim_str = "XYZ"; break; 
-			case 2: n_dims = 3; dim_str = "XYM"; break; 
-			case 3: n_dims = 4; dim_str = "XYZM"; break; 
+			case 0: n_dims = 2; dim_str = "XY"; break;
+			case 1: n_dims = 3; dim_str = "XYZ"; break;
+			case 2: n_dims = 3; dim_str = "XYM"; break;
+			case 3: n_dims = 4; dim_str = "XYZM"; break;
 			default:
 				Rcpp::Rcout << "wkbType: " << wkbType << std::endl; // #nocov
 				Rcpp::stop("unsupported wkbType dim in switch"); // #nocov
@@ -354,7 +354,7 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 	}
 	bool empty = false;
 	switch(sf_type) {
-		case SF_Point: 
+		case SF_Point:
 			output[0] = read_numeric_vector(wkb, n_dims, swap, addclass ?
 				Rcpp::CharacterVector::create(dim_str, "POINT", "sfg") : "");
 			break;
@@ -362,13 +362,13 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 			output[0] = read_numeric_matrix(wkb, n_dims, swap, addclass ?
 				Rcpp::CharacterVector::create(dim_str, "LINESTRING", "sfg") : "", &empty);
 			break;
-		case SF_Polygon: 
+		case SF_Polygon:
 			output[0] = read_matrix_list(wkb, n_dims, swap, addclass ?
 				Rcpp::CharacterVector::create(dim_str, "POLYGON", "sfg") : "", &empty);
 			break;
-		case SF_MultiPoint: 
-			output[0] = read_multipoint(wkb, n_dims, swap, EWKB, spatialite, endian, addclass ?  
-				Rcpp::CharacterVector::create(dim_str, "MULTIPOINT", "sfg") : "", &empty); 
+		case SF_MultiPoint:
+			output[0] = read_multipoint(wkb, n_dims, swap, EWKB, spatialite, endian, addclass ?
+				Rcpp::CharacterVector::create(dim_str, "MULTIPOINT", "sfg") : "", &empty);
 			break;
 		case SF_MultiLineString:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
@@ -378,7 +378,7 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
 				Rcpp::CharacterVector::create(dim_str, "MULTIPOLYGON", "sfg"), false, &empty);
 			break;
-		case SF_GeometryCollection: 
+		case SF_GeometryCollection:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
 				Rcpp::CharacterVector::create(dim_str, "GEOMETRYCOLLECTION", "sfg"), true,
 				&empty);
@@ -389,11 +389,11 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 			break;
 		case SF_CompoundCurve:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
-				Rcpp::CharacterVector::create(dim_str, "COMPOUNDCURVE", "sfg"), true, &empty); 
+				Rcpp::CharacterVector::create(dim_str, "COMPOUNDCURVE", "sfg"), true, &empty);
 			break;
 		case SF_CurvePolygon:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
-				Rcpp::CharacterVector::create(dim_str, "CURVEPOLYGON", "sfg"), true, &empty); 
+				Rcpp::CharacterVector::create(dim_str, "CURVEPOLYGON", "sfg"), true, &empty);
 			break;
 		case SF_MultiCurve:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
@@ -405,17 +405,17 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 			break;
 		case SF_Curve: // #nocov start
 			output[0] = read_numeric_matrix(wkb, n_dims, swap, addclass ?
-				Rcpp::CharacterVector::create(dim_str, "CURVE", "sfg") : "", &empty); 
+				Rcpp::CharacterVector::create(dim_str, "CURVE", "sfg") : "", &empty);
 			break;
-		case SF_Surface: 
+		case SF_Surface:
 			output[0] = read_matrix_list(wkb, n_dims, swap, addclass ?
 				Rcpp::CharacterVector::create(dim_str, "SURFACE", "sfg") : "", &empty);
 			break; // #nocov end
-		case SF_PolyhedralSurface: 
+		case SF_PolyhedralSurface:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
 				Rcpp::CharacterVector::create(dim_str, "POLYHEDRALSURFACE", "sfg"), false, &empty);
 			break;
-		case SF_TIN: 
+		case SF_TIN:
 			output[0] = read_geometrycollection(wkb, n_dims, swap, EWKB, spatialite, endian,
 				Rcpp::CharacterVector::create(dim_str, "TIN", "sfg"), false, &empty);
 			break;
@@ -497,9 +497,9 @@ unsigned int make_type(const char *cls, const char *dim, bool EWKB = false, int 
 	else if (strcmp(cls, "COMPOUNDCURVE") == 0)
 		type = SF_CompoundCurve;
 	else if (strcmp(cls, "CURVEPOLYGON") == 0)
-		type = SF_CurvePolygon; 
+		type = SF_CurvePolygon;
 	else if (strcmp(cls, "MULTICURVE") == 0)
-		type = SF_MultiCurve; 
+		type = SF_MultiCurve;
 	else if (strcmp(cls, "MULTISURFACE") == 0)
 		type = SF_MultiSurface;
 	else if (strcmp(cls, "CURVE") == 0)
@@ -512,7 +512,7 @@ unsigned int make_type(const char *cls, const char *dim, bool EWKB = false, int 
 		type = SF_TIN;
 	else if (strcmp(cls, "TRIANGLE") == 0)
 		type = SF_Triangle;
-	else 
+	else
 		type = SF_Unknown; // a mix: GEOMETRY
 	if (tp != NULL)
 		*tp = type;
@@ -580,7 +580,7 @@ void write_matrix_list(std::ostringstream& os, Rcpp::List lst, double prec) {
 		write_matrix(os, lst[i], prec);
 }
 
-void write_multilinestring(std::ostringstream& os, Rcpp::List lst, bool EWKB = false, 
+void write_multilinestring(std::ostringstream& os, Rcpp::List lst, bool EWKB = false,
 		int endian = 0, double prec = 0.0) {
 	Rcpp::CharacterVector cl_attr = lst.attr("class");
 	const char *dim = cl_attr[0];
@@ -589,7 +589,7 @@ void write_multilinestring(std::ostringstream& os, Rcpp::List lst, bool EWKB = f
 		write_data(os, lst, i, EWKB, endian, "LINESTRING", dim, prec, 0);
 }
 
-void write_multipolygon(std::ostringstream& os, Rcpp::List lst, bool EWKB = false, 
+void write_multipolygon(std::ostringstream& os, Rcpp::List lst, bool EWKB = false,
 		int endian = 0, double prec = 0.0) {
 	Rcpp::CharacterVector cl_attr = lst.attr("class");
 	const char *dim = cl_attr[0];
@@ -598,7 +598,7 @@ void write_multipolygon(std::ostringstream& os, Rcpp::List lst, bool EWKB = fals
 		write_data(os, lst, i, EWKB, endian, "POLYGON", dim, prec, 0);
 }
 
-void write_triangles(std::ostringstream& os, Rcpp::List lst, bool EWKB = false, 
+void write_triangles(std::ostringstream& os, Rcpp::List lst, bool EWKB = false,
 		int endian = 0, double prec = 0.0) {
 	Rcpp::CharacterVector cl_attr = lst.attr("class");
 	const char *dim = cl_attr[0];
@@ -607,18 +607,18 @@ void write_triangles(std::ostringstream& os, Rcpp::List lst, bool EWKB = false,
 		write_data(os, lst, i, EWKB, endian, "TRIANGLE", dim, prec, 0);
 }
 
-void write_geometrycollection(std::ostringstream& os, Rcpp::List lst, bool EWKB = false, 
+void write_geometrycollection(std::ostringstream& os, Rcpp::List lst, bool EWKB = false,
 		int endian = 0, double prec = 0.0) {
 	add_int(os, lst.length());
 	Rcpp::Function Rclass("class");
 	for (int i = 0; i < lst.length(); i++) {
-		Rcpp::CharacterVector cl_attr = Rclass(lst[i]); 
+		Rcpp::CharacterVector cl_attr = Rclass(lst[i]);
 		const char *cls = cl_attr[1], *dim = cl_attr[0];
 		write_data(os, lst, i, EWKB, endian, cls, dim, prec, 0);
 	}
 }
 
-void write_multipoint(std::ostringstream& os, Rcpp::NumericMatrix mat, 
+void write_multipoint(std::ostringstream& os, Rcpp::NumericMatrix mat,
 		bool EWKB = false, int endian = 0, double prec = 0.0) {
 	add_int(os, mat.nrow());
 	Rcpp::CharacterVector cl_attr = mat.attr("class");
@@ -632,10 +632,10 @@ void write_multipoint(std::ostringstream& os, Rcpp::NumericMatrix mat,
 }
 
 // write single simple feature object as (E)WKB to stream os
-void write_data(std::ostringstream& os, Rcpp::List sfc, int i = 0, bool EWKB = false, 
+void write_data(std::ostringstream& os, Rcpp::List sfc, int i = 0, bool EWKB = false,
 		int endian = 0, const char *cls = NULL, const char *dim = NULL, double prec = 0.0,
 		int srid = 0) {
-	
+
 	add_byte(os, (char) endian);
 	int tp;
 	unsigned int sf_type = make_type(cls, dim, EWKB, &tp, srid);
@@ -664,7 +664,7 @@ void write_data(std::ostringstream& os, Rcpp::List sfc, int i = 0, bool EWKB = f
 		case SF_CurvePolygon: write_geometrycollection(os, sfc[i], EWKB, endian, prec);
 			break;
 		case SF_MultiCurve: write_geometrycollection(os, sfc[i], EWKB, endian, prec);
-			break; 
+			break;
 		case SF_MultiSurface: write_geometrycollection(os, sfc[i], EWKB, endian, prec);
 			break;
 		case SF_Curve: write_matrix(os, sfc[i], prec); // #nocov start
@@ -691,7 +691,7 @@ int native_endian(void) {
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_write_wkb(Rcpp::List sfc, bool EWKB = false, int endian = 0, 
+Rcpp::List CPL_write_wkb(Rcpp::List sfc, bool EWKB = false, int endian = 0,
 		Rcpp::CharacterVector dim = "XY", double precision = 0.0) {
 
 	Rcpp::List output(sfc.size()); // with raw vectors
@@ -712,7 +712,7 @@ Rcpp::List CPL_write_wkb(Rcpp::List sfc, bool EWKB = false, int endian = 0,
 			Rcpp::stop("sfc_GEOMETRY should have attr classes; please file an issue"); // #nocov
 	}
 
-	Rcpp::List crs = sfc.attr("crs"); 
+	Rcpp::List crs = sfc.attr("crs");
 	int srid = crs(0);
 	if (srid == NA_INTEGER)
 		srid = 0; // non-zero now means: we have an srid

--- a/tests/cast.R
+++ b/tests/cast.R
@@ -7,8 +7,8 @@ mp = st_sfc(st_multipoint(matrix(0:3,,2)), st_multipoint(matrix(10:15,,2)))
 st_cast(ls, "MULTIPOINT")
 
 # column 2:
-mls = st_sfc(st_multilinestring(list(rbind(c(0,0), c(10,0), c(10,10), c(0,10)), 
-	rbind(c(5,5),c(5,6), c(6,6), c(6,5)))), 
+mls = st_sfc(st_multilinestring(list(rbind(c(0,0), c(10,0), c(10,10), c(0,10)),
+	rbind(c(5,5),c(5,6), c(6,6), c(6,5)))),
 	st_multilinestring(list(rbind(c(0,0), c(1,0), c(1,1), c(0,1)))))
 (pol = st_cast(mls, "POLYGON"))
 st_cast(pol, "MULTILINESTRING")
@@ -32,8 +32,8 @@ st_cast(st_cast(g, "MULTILINESTRING"), "LINESTRING") # will not loose
 
 gc = st_sfc(st_geometrycollection(
   list(
-    st_multilinestring(list(rbind(c(0,0), c(10,0), c(10,10), c(0,10)), 
-	rbind(c(5,5),c(5,6), c(6,6), c(6,5)))), 
+    st_multilinestring(list(rbind(c(0,0), c(10,0), c(10,10), c(0,10)),
+	rbind(c(5,5),c(5,6), c(6,6), c(6,5)))),
 	st_multilinestring(list(rbind(c(0,0), c(1,0), c(1,1), c(0,1)))),
 	st_point(0:1)
   )))

--- a/tests/dplyr.R
+++ b/tests/dplyr.R
@@ -4,14 +4,14 @@ nc = st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
 nc %>% filter(AREA > .1) %>% plot()
 
 # plot 10 smallest counties in grey:
-nc %>% 
-  select(BIR74, geometry) %>% 
+nc %>%
+  select(BIR74, geometry) %>%
   plot()
 
-nc %>% 
-  select(AREA, geometry) %>% 
-  arrange(AREA) %>% 
-  slice(1:10) %>% 
+nc %>%
+  select(AREA, geometry) %>%
+  arrange(AREA) %>%
+  slice(1:10) %>%
   plot(add = TRUE, col = 'grey', main ="")
 
 # select: check both when geometry is part of the selection, and when not:
@@ -73,8 +73,8 @@ nc.merc <- nc.merc %>% mutate(area = st_area(nc.merc), dens = BIR74 * person /ar
 nc.merc$area_cl <- cut(nc$AREA, c(0, .1, .12, .15, .25))
 nc.grp <- nc.merc %>% group_by(area_cl)
 
-out <- nc.grp %>% summarise(A = sum(area), pop = sum(dens * area), 
-	new_dens = sum(dens * area)/sum(area)) 
+out <- nc.grp %>% summarise(A = sum(area), pop = sum(dens * area),
+	new_dens = sum(dens * area)/sum(area))
 
 # mean densities depend on grouping:
 nc.merc %>% summarize(mean(dens))

--- a/tests/gdal_geom.R
+++ b/tests/gdal_geom.R
@@ -38,7 +38,7 @@ b = nc[4:10,]
 
 x <- st_intersection(a[1,] ,b)
 
-u = st_union(b) 
+u = st_union(b)
 
 x <- st_intersection(st_geometry(a), st_geometry(u))
 

--- a/tests/geos.R
+++ b/tests/geos.R
@@ -9,14 +9,14 @@ st_distance(x)
 
 st_is_valid(nc)
 
-ops = c("intersects", #"disjoint", 
+ops = c("intersects", #"disjoint",
 "touches", "crosses", "within", "contains", "overlaps", "equals", "covers", "covered_by", "equals_exact")
 for (op in ops) {
 	x = sf:::st_geos_binop(op, ncm[1:50,], ncm[51:100,], 0, NA_character_, FALSE)
 	x = sf:::st_geos_binop(op, ncm[1:50,], ncm[51:100,], 0, NA_character_, TRUE)
 }
 
-ops = c("intersects", #"disjoint", 
+ops = c("intersects", #"disjoint",
 "touches", "crosses", "within", "contains", "overlaps", "covers", "covered_by")
 df = data.frame(ops = ops)
 df$equal = NA
@@ -31,7 +31,7 @@ st_contains_properly(ncm[1:3,], ncm[1:3])
 
 st_combine(nc)
 
-st_dimension(st_sfc(st_point(0:1), st_linestring(rbind(c(0,0),c(1,1))), 
+st_dimension(st_sfc(st_point(0:1), st_linestring(rbind(c(0,0),c(1,1))),
 	st_polygon(list(rbind(c(0,0), c(1,0), c(1,1), c(0,1), c(0,0))))))
 
 g = st_make_grid(nc)

--- a/tests/graticule.R
+++ b/tests/graticule.R
@@ -19,16 +19,16 @@ points(g$x_end, g$y_end, col = 'blue')
 
 invisible(lapply(seq_len(nrow(g)), function(i) {
 	if (g$type[i] == "N" && g$x_start[i] - min(g$x_start) < 1000)
-		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]), 
+		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]),
 			srt = g$angle_start[i], pos = 2, cex = .7)
 	if (g$type[i] == "E" && g$y_start[i] - min(g$y_start) < 1000)
-		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]), 
+		text(g[i,"x_start"], g[i,"y_start"], labels = parse(text = g[i,"degree_label"]),
 			srt = g$angle_start[i] - 90, pos = 1, cex = .7)
 	if (g$type[i] == "N" && g$x_end[i] - max(g$x_end) > -1000)
-		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]), 
+		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]),
 			srt = g$angle_end[i], pos = 4, cex = .7)
 	if (g$type[i] == "E" && g$y_end[i] - max(g$y_end) > -1000)
-		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]), 
+		text(g[i,"x_end"], g[i,"y_end"], labels = parse(text = g[i,"degree_label"]),
 			srt = g$angle_end[i] - 90, pos = 3, cex = .7)
 }))
 

--- a/tests/grid.R
+++ b/tests/grid.R
@@ -19,7 +19,7 @@ data(meuse, package = "sp")
 meuse_sf = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant")
 grid.newpage()
 pushViewport(st_viewport(meuse_sf))
-invisible(lapply(st_geometry(meuse_sf), 
+invisible(lapply(st_geometry(meuse_sf),
 	function(x) grid.draw(st_as_grob(x, gp = gpar(fill = 'red')))))
 
 
@@ -45,14 +45,14 @@ grid.draw(st_as_grob(ls, gp = gpar(fill = 'red')))
 meuse_ll = st_transform(meuse_sf, 4326)
 grid.newpage()
 pushViewport(st_viewport(meuse_ll))
-invisible(lapply(st_geometry(meuse_ll), 
+invisible(lapply(st_geometry(meuse_ll),
 	function(x) grid.draw(st_as_grob(x, gp = gpar(fill = 'red')))))
 
 # WRONG aspect:
 st_crs(meuse_ll) = NA
 grid.newpage()
 pushViewport(st_viewport(meuse_ll))
-invisible(lapply(st_geometry(meuse_ll), 
+invisible(lapply(st_geometry(meuse_ll),
 	function(x) grid.draw(st_as_grob(x, gp = gpar(fill = 'red')))))
 
 gc = st_geometrycollection(list(st_point(0:1), st_linestring(matrix(1:4,2))))

--- a/tests/plot.R
+++ b/tests/plot.R
@@ -65,9 +65,9 @@ plot(st_sfc(mp1, mpo1))
 nc = st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
 plot(nc)
 plot(nc, axes = TRUE)
-plot(nc, col="lightgrey") 
-nc %>% 
-  select(geometry) %>% 
+plot(nc, col="lightgrey")
+nc %>%
+  select(geometry) %>%
   plot()
 
 # test background map plotting:
@@ -77,7 +77,7 @@ WGS84 = st_crs(4326)
 nc = st_transform(nc, WGS84)
 ## ggmap:
 #library(ggmap)
-#bgMap = get_map(unname(st_bbox(nc)), source = "google", zoom = 8) 
+#bgMap = get_map(unname(st_bbox(nc)), source = "google", zoom = 8)
 plot(st_transform(nc[1], merc), bgMap = bgMap)
 
 # RgoogleMaps:

--- a/tests/sfc.R
+++ b/tests/sfc.R
@@ -20,7 +20,7 @@ st_as_sfc(c("POINT(0 0)", "POINT(1 1)"))
 st_as_sfc(c("POINT(0 0)", "POINT(1 1)", "POLYGON((0 0,1 1,0 1,0 0))"))
 st_as_sfc(character(0))
 st_as_sfc(character(0), 4326)
-st_as_sfc(c("POINT(0 0)", "POINT(1 1)", "POLYGON((0 0,1 1,0 1,0 0))"), 
+st_as_sfc(c("POINT(0 0)", "POINT(1 1)", "POLYGON((0 0,1 1,0 1,0 0))"),
 	"+proj=longlat +datum=WGS84")
 dg = st_as_sf(d, wkt = "geom")
 print(dg, n = 1)
@@ -79,9 +79,9 @@ st_sfc(st_polygon(list(pts)), st_multipolygon(list(list(pts)))) %>% st_cast("POL
 st_sfc(st_polygon(list(pts)), st_multipolygon(list(list(pts)))) %>% st_cast("MULTIPOLYGON")
 
 
-st_sfc(st_geometrycollection(list(p)), st_geometrycollection(list(mp))) %>% st_cast() 
-st_sfc(st_geometrycollection(list(p)), st_geometrycollection(list(mp))) %>% 
-	st_cast() %>% 
+st_sfc(st_geometrycollection(list(p)), st_geometrycollection(list(mp))) %>% st_cast()
+st_sfc(st_geometrycollection(list(p)), st_geometrycollection(list(mp))) %>%
+	st_cast() %>%
 	st_cast("POINT")
 
 p = rbind(c(0,0),c(1,0),c(1,1),c(0,1),c(0,0))
@@ -93,7 +93,7 @@ st_length(st_sfc(st_point(c(0,0))))
 try(as(st_sfc(st_linestring(matrix(1:9,3))), "Spatial"))
 
 # check conus is present:
-x = st_sfc(st_point(c(-90,35)), st_point(c(-80,36)), 
+x = st_sfc(st_point(c(-90,35)), st_point(c(-80,36)),
 	crs = "+proj=longlat +datum=NAD27")
 st_transform(x, 3857)
 

--- a/tests/sfg.R
+++ b/tests/sfg.R
@@ -12,5 +12,5 @@ c(st_linestring(matrix(1:6,3)), st_point(1:2))
 c(st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:6,3)))),
   st_geometrycollection(list(st_multilinestring(list(matrix(11:16,3))))))
 c(st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:6,3)))),
-  st_multilinestring(list(matrix(11:16,3))), st_point(5:6), 
+  st_multilinestring(list(matrix(11:16,3))), st_point(5:6),
   st_geometrycollection(list(st_point(10:11))))

--- a/tests/testthat/test_crs.R
+++ b/tests/testthat/test_crs.R
@@ -5,10 +5,10 @@ test_that("st_crs works", {
   nc2 = st_read(system.file("shape/nc.shp", package="sf"), "nc", quiet = TRUE)
   nc3 = st_read(system.file("shape/nc.shp", package="sf"), "nc", crs = NA, quiet = TRUE)
   crs_4267 <- structure(
-    list(epsg = 4267L, proj4string = "+proj=longlat +datum=NAD27 +no_defs"), 
+    list(epsg = 4267L, proj4string = "+proj=longlat +datum=NAD27 +no_defs"),
     class = "crs")
   crs_na <- structure(
-    list(epsg = NA_integer_, 
+    list(epsg = NA_integer_,
          proj4string = NA_character_), class = "crs")
   expect_equal(st_crs(nc2), crs_4267)
   expect_equal(st_crs(nc3), crs_na)
@@ -45,6 +45,6 @@ test_that("st_proj_info works", {
 test_that("$.crs works", {
   expect_true(is.numeric(st_crs("+init=epsg:3857")$epsg))
   expect_true(is.character(st_crs("+init=epsg:3857")$proj4string))
-  expect_true(is.numeric(st_crs("+init=epsg:3857 +units=km")$b)) 
+  expect_true(is.numeric(st_crs("+init=epsg:3857 +units=km")$b))
   expect_true(is.character(st_crs("+init=epsg:3857 +units=km")$units))
 })

--- a/tests/testthat/test_gdal.R
+++ b/tests/testthat/test_gdal.R
@@ -2,10 +2,10 @@ context("sf: gdal tests")
 
 test_that("st_transform works", {
   library(sp)
-  
+
   s = st_sfc(st_point(c(1,1)), st_point(c(10,10)), st_point(c(5,5)), crs = 4326)
   s1.tr = st_transform(s, 3857)
-  
+
   sp = as(s, "Spatial")
   sp.tr = spTransform(sp, CRS("+init=epsg:3857"))
   s2.tr = st_as_sfc(sp.tr)

--- a/tests/testthat/test_geos.R
+++ b/tests/testthat/test_geos.R
@@ -69,10 +69,10 @@ test_that("geos ops give warnings and errors on longlat", {
 test_that("st_area() works on GEOMETRY in longlat (#131)", {
   single <- list(rbind(c(0,0), c(1,0), c(1, 1), c(0,1), c(0,0))) %>% st_polygon()
   multi <- list(single + 2, single + 4) %>% st_multipolygon()
-  
+
   w <- st_sfc(single, multi)
   expect_equal(st_area(w), 1:2)
-  expect_equal(st_area(st_set_crs(w, 4326)) %>% as.numeric(), 
+  expect_equal(st_area(st_set_crs(w, 4326)) %>% as.numeric(),
                c(12308778361, 24570125261))
 })
 
@@ -90,33 +90,33 @@ test_that("geom operations work on sfg or sfc or sf", {
   expect_silent(st_buffer(pnc, 1000))
   expect_silent(st_buffer(gpnc, 1000))
   expect_silent(st_buffer(gpnc[[1L]], 1000))
-  
+
   expect_silent(st_boundary(pnc))
   expect_that(st_boundary(gpnc), is_a("sfc_MULTILINESTRING"))
   expect_that(st_boundary(gpnc[[1L]]), is_a("MULTILINESTRING"))
-  
+
   expect_true(inherits(st_convex_hull(pnc)$geometry, "sfc_POLYGON"))
   expect_true(inherits(st_convex_hull(gpnc), "sfc_POLYGON"))
   expect_true(inherits(st_convex_hull(gpnc[[1L]]), "POLYGON"))
-  
+
   expect_silent(st_simplify(pnc, FALSE, 1e4))
   expect_silent(st_simplify(gpnc, FALSE, 1e4))
   expect_silent(st_simplify(gpnc[[1L]], FALSE, 1e4))
 
-  if (sf:::CPL_geos_version() >= "3.4.0") {  
+  if (sf:::CPL_geos_version() >= "3.4.0") {
    expect_silent(st_triangulate(pnc))
    expect_that(st_triangulate(gpnc), is_a("sfc_GEOMETRYCOLLECTION"))
    expect_that(st_triangulate(gpnc[[1]]), is_a("GEOMETRYCOLLECTION"))
   }
-  
+
   expect_silent(st_polygonize(lnc))
-  expect_silent(st_polygonize(glnc)) 
-  expect_silent(st_polygonize(glnc[[1]])) 
-  
+  expect_silent(st_polygonize(glnc))
+  expect_silent(st_polygonize(glnc[[1]]))
+
   expect_that(st_line_merge(lnc), is_a("sf"))
   expect_that(st_line_merge(glnc), is_a("sfc"))
   expect_that(st_line_merge(glnc[[4]]), is_a("sfg"))
-  
+
   expect_silent(st_centroid(lnc))
   expect_that(st_centroid(glnc),  is_a("sfc_POINT"))
   expect_that(st_centroid(glnc[[1]]),  is_a("POINT"))
@@ -124,7 +124,7 @@ test_that("geom operations work on sfg or sfc or sf", {
   expect_silent(st_point_on_surface(lnc))
   expect_that(st_point_on_surface(glnc),  is_a("sfc_POINT"))
   expect_that(st_point_on_surface(glnc[[1]]),  is_a("POINT"))
-  
+
   expect_silent(st_segmentize(lnc, 10000))
   expect_silent(st_segmentize(glnc, 10000))
   expect_silent(st_segmentize(glnc[[1]], 10000))

--- a/tests/testthat/test_postgis.R
+++ b/tests/testthat/test_postgis.R
@@ -17,9 +17,9 @@ require("sp")
 data(meuse)
 pts <- st_as_sf(meuse, coords = c("x", "y"), crs = 28992)
 
-epsg_31370 = paste0("+proj=lcc +lat_1=51.16666723333333 +lat_2=49.8333339 ", 
-                    "+lat_0=90 +lon_0=4.367486666666666 +x_0=150000.013 ", 
-                    "+y_0=5400088.438 +ellps=intl +towgs84=-106.869,52.2978,", 
+epsg_31370 = paste0("+proj=lcc +lat_1=51.16666723333333 +lat_2=49.8333339 ",
+                    "+lat_0=90 +lon_0=4.367486666666666 +x_0=150000.013 ",
+                    "+y_0=5400088.438 +ellps=intl +towgs84=-106.869,52.2978,",
                     "-103.724,0.3366,-0.457,1.8422,-1.2747 +units=m +no_defs")
 
 pg <- NULL
@@ -56,7 +56,7 @@ test_that("can write to other schema", {
     try(DBI::dbSendQuery(pg, "CREATE SCHEMA sf_test__;"), silent = TRUE)
     q <- "SELECT schema_name FROM information_schema.schemata WHERE schema_name = 'sf_test__';"
     could_schema <- DBI::dbGetQuery(pg, q) %>% nrow() > 0
-    
+
     skip_if_not(could_schema, "Could not create schema (might need to run 'GRANT CREATE ON DATABASE postgis TO <user>')")
     expect_error(st_write_db(pg, pts, c("public", "sf_meuse__")), "exists")
     expect_silent(st_write_db(pg, pts, c("sf_test__", "sf_meuse__")))
@@ -66,7 +66,7 @@ test_that("can write to other schema", {
     expect_warning(z <- st_set_crs(pts, epsg_31370))
     expect_silent(st_write_db(pg, z, c("sf_test__", "sf_meuse33__"),  binary = TRUE))
     expect_silent(st_write_db(pg, z, c("sf_test__", "sf_meuse4__"),  binary = FALSE))
-    
+
     # weird name work, but create lots of noise from RPostgreSQL
     #expect_silent(st_write_db(pg, pts, c(NULL, "sf_test__.meuse__")))
 })
@@ -76,31 +76,31 @@ test_that("can read from db", {
     q <- "select * from sf_meuse__"
     #expect_warning(x <- st_read_db(pg, query = q), "crs")
     expect_silent(x <- st_read_db(pg, query = q))
-    
+
     expect_error(st_read_db(), "no connection provided")
     expect_error(st_read_db(pg), "table name or a query")
-    
+
     y <- st_read_db(pg, "sf_meuse__")
     expect_equal(dim(pts), dim(y))
     expect_identical(st_crs(pts), st_crs(y))
     expect_identical(st_precision(pts), st_precision(y))
-    
+
     z <- st_read_db(pg, "sf_meuse2__")
     expect_equal(dim(pts), dim(z))
     expect_identical(st_crs(pts), st_crs(z))
     expect_identical(st_precision(pts), st_precision(z))
-    
+
     z <- st_read_db(pg, "sf_meuse3__")
     expect_equal(dim(pts), dim(z))
     #expect_identical(st_crs(NA), st_crs(z))
     expect_identical(st_crs(epsg_31370), st_crs(z))
     expect_identical(st_precision(pts), st_precision(z))
-    
+
     w <- st_read_db(pg, c("sf_test__", "sf_meuse__"))
     expect_equal(dim(y), dim(w))
     expect_identical(st_crs(y), st_crs(w))
     expect_identical(st_precision(y), st_precision(w))
-    
+
     expect_error(st_read_db(pg, "missing"), "not exist")
     expect_error(st_read_db(pg, c("missing", "missing")), "not exist")
     # make sure it reads in the correct schema
@@ -109,13 +109,13 @@ test_that("can read from db", {
 
 test_that("can read views (#212)", {
     skip_if_not(can_con(pg), "could not connect to postgis database")
-    expect_equal(DBI::dbExecute(pg, 
+    expect_equal(DBI::dbExecute(pg,
                 "CREATE VIEW sf_view__ AS SELECT * FROM sf_meuse__;"), 0)
-    expect_equal(DBI::dbExecute(pg, 
+    expect_equal(DBI::dbExecute(pg,
                 "CREATE VIEW sf_test__.sf_view__ AS SELECT * FROM sf_meuse__;"), 0)
-    expect_equal(DBI::dbExecute(pg, 
+    expect_equal(DBI::dbExecute(pg,
                                 "CREATE MATERIALIZED VIEW sf_viewm__ AS SELECT * FROM sf_meuse__;"), 155)
-    expect_equal(DBI::dbExecute(pg, 
+    expect_equal(DBI::dbExecute(pg,
                                 "CREATE MATERIALIZED VIEW sf_test__.sf_viewm__ AS SELECT * FROM sf_meuse__;"), 155)
     x <- st_read_db(pg, "sf_meuse__")
     expect_identical(st_read_db(pg, "sf_view__"), x)
@@ -123,7 +123,7 @@ test_that("can read views (#212)", {
     expect_identical(st_read_db(pg, c("sf_test__", "sf_view__")), x)
     expect_identical(st_read_db(pg, c("sf_viewm__")), x)
     expect_identical(st_read_db(pg, c("sf_test__", "sf_viewm__")), x)
-    
+
     try(DBI::dbExecute(pg, "DROP VIEW sf_view__"), silent = TRUE)
     try(DBI::dbExecute(pg, "DROP VIEW sf_test__.sf_view__"), silent = TRUE)
     try(DBI::dbExecute(pg, "DROP MATERIALIZED VIEW sf_viewm__"), silent = TRUE)
@@ -157,33 +157,33 @@ test_that("round trips", {
     round_trip(pg, "POLYGON((0 0, 1 0, 1 1, 0 0))")
     round_trip(pg, "MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))")
     round_trip(pg, paste("MULTIPOLYGON(((0 0, 1 0, 1 1, 0 0),",
-                         "(0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.2)),", 
+                         "(0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.2)),",
                          "((2 2, 3 2, 3 3, 2 2)))"))
-    round_trip(pg, paste("MULTILINESTRING((0 0, 1 0, 1 1, 0 0),", 
-                         "(0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.2),", 
+    round_trip(pg, paste("MULTILINESTRING((0 0, 1 0, 1 1, 0 0),",
+                         "(0.2 0.2, 0.8 0.2, 0.8 0.8, 0.2 0.2),",
                          "(2 2, 3 2, 3 3, 2 2))"))
-    
+
     # other types; examples taken from the PostGIS manuals (ch 4):
     round_trip(pg, "CIRCULARSTRING(0 0, 1 1, 1 0)")
     round_trip(pg, "CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0)")
-    round_trip(pg, paste("CURVEPOLYGON(CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0),", 
+    round_trip(pg, paste("CURVEPOLYGON(CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0),",
                          "LINESTRING(1 1, 3 3, 3 1, 1 1))"))
-    round_trip(pg, paste("COMPOUNDCURVE(CIRCULARSTRING(0 0, 1 1, 1 0),", 
+    round_trip(pg, paste("COMPOUNDCURVE(CIRCULARSTRING(0 0, 1 1, 1 0),",
                          "LINESTRING(1 0, 0 1))"))
-    round_trip(pg, paste0("CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0, 2 0, 2 1, 2 3, 4 3), ", 
-                          "LINESTRING(4 3, 4 5, 1 4, 0 0)), ", 
+    round_trip(pg, paste0("CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0, 2 0, 2 1, 2 3, 4 3), ",
+                          "LINESTRING(4 3, 4 5, 1 4, 0 0)), ",
                           "CIRCULARSTRING(1.7 1, 1.4 0.4, 1.6 0.4, 1.6 0.5, 1.7 1))"))
     round_trip(pg, "MULTICURVE(LINESTRING(0 0, 5 5), CIRCULARSTRING(4 0, 4 4, 8 4))")
     round_trip(pg, paste("MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 0, 4 0, 4 4, 0 4, 0 0),",
-                         "LINESTRING(1 1, 3 3, 3 1, 1 1)),", 
-                         "POLYGON((10 10, 14 12, 11 10, 10 10),", 
+                         "LINESTRING(1 1, 3 3, 3 1, 1 1)),",
+                         "POLYGON((10 10, 14 12, 11 10, 10 10),",
                          "(11 11, 11.5 11, 11 11.5, 11 11)))"))
-    
+
     round_trip(pg, paste("MULTICURVE(LINESTRING(0 0, 5 5),",
                          "CIRCULARSTRING(4 0, 4 4, 8 4))"))
-    round_trip(pg, paste("POLYHEDRALSURFACEZ(((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),", 
+    round_trip(pg, paste("POLYHEDRALSURFACEZ(((0 0 0, 0 0 1, 0 1 1, 0 1 0, 0 0 0)),",
                          "((0 0 0, 0 1 0, 1 1 0, 1 0 0, 0 0 0)),",
-                         "((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)),", 
+                         "((0 0 0, 1 0 0, 1 0 1, 0 0 1, 0 0 0)),",
                          "((1 1 0, 1 1 1, 1 0 1, 1 0 0, 1 1 0)),",
                          "((0 1 0, 0 1 1, 1 1 1, 1 1 0, 0 1 0)),",
                          "((0 0 1, 1 0 1, 1 1 1, 0 1 1, 0 0 1)))"))
@@ -194,14 +194,14 @@ test_that("round trips", {
 test_that("can read using driver", {
     skip_if_not(can_con(pg), "could not connect to postgis database")
     layers <- st_layers("PG:dbname=postgis")
-    lyr_expect <- sort(c("sf_meuse__", "sf_meuse2__", "sf_meuse3__", 
-                    "sf_test__.sf_meuse__", "sf_test__.sf_meuse2__", 
+    lyr_expect <- sort(c("sf_meuse__", "sf_meuse2__", "sf_meuse3__",
+                    "sf_test__.sf_meuse__", "sf_test__.sf_meuse2__",
                     "sf_test__.sf_meuse33__", "sf_test__.sf_meuse4__"))
     expect_equal(sort(layers$name), lyr_expect)
     expect_equal(layers$features, rep(155, length(lyr_expect)))
     expect_equal(layers$fields, rep(13, length(lyr_expect)))
-    
-    skip_if_not(can_con(RPostgreSQL::dbConnect(RPostgreSQL::PostgreSQL(), dbname = "empty")), 
+
+    skip_if_not(can_con(RPostgreSQL::dbConnect(RPostgreSQL::PostgreSQL(), dbname = "empty")),
                 "could not connect to 'empty' database")
     expect_error(st_read("PG:dbname=empty", quiet = TRUE), "No layers")
 })
@@ -240,7 +240,7 @@ test_that("new SRIDs are handled correctly", {
 		"+towgs84=565.4171,50.3319,465.5524,-0.398957,0.343988,-1.87740,4.0725 +units=m +no_defs"))
 	st_crs(meuse_sf) = crs
 	expect_silent(st_write_db(pg, meuse_sf, drop = TRUE))
-	expect_warning(x <- st_read_db(pg, query = "select * from meuse_sf limit 3;"), 
+	expect_warning(x <- st_read_db(pg, query = "select * from meuse_sf limit 3;"),
 		"not found in EPSG support files")
 	expect_true(st_crs(x) == crs)
 })

--- a/tests/testthat/test_read.R
+++ b/tests/testthat/test_read.R
@@ -32,7 +32,7 @@ test_that("guess_driver works on extensions", {
   # for repeatability, this is how I turned the list to tests
   # `^"(\w+)" = ("[\w\s]+"),?`
   # to `expect_equal(guess_driver("nc.\1"), c("\1" = \2))`
-  
+
   expect_equal(guess_driver("nc.bna"), c("bna" = "BNA"))
   expect_equal(guess_driver("nc.csv"), c("csv" = "CSV"))
   expect_equal(guess_driver("nc.e00"), c("e00" = "AVCE00"))
@@ -42,7 +42,7 @@ test_that("guess_driver works on extensions", {
   expect_equal(guess_driver("nc.gmt"), c("gmt" = "GMT"))
   expect_equal(guess_driver("nc.gpkg"), c("gpkg" = "GPKG"))
   expect_equal(guess_driver("nc.gps"), c("gps" = "GPSBabel"))
-  expect_equal(guess_driver("nc.gtm"), c("gtm" = "GPSTrackMaker"))   
+  expect_equal(guess_driver("nc.gtm"), c("gtm" = "GPSTrackMaker"))
   expect_equal(guess_driver("nc.gxt"), c("gxt" = "Geoconcept"))
   expect_equal(guess_driver("nc.kml"), c("kml" = "KML"))
   expect_equal(guess_driver("nc.jml"), c("jml" = "JML"))
@@ -57,7 +57,7 @@ test_that("guess_driver works on extensions", {
   expect_equal(guess_driver("nc.vdv"), c("vdv" = "VDV"))
   expect_equal(guess_driver("nc.xls"), c("xls" = "xls"))
   expect_equal(guess_driver("nc.xlsx"), c("xlsx" = "XLSX"))
-  
+
   # unsuported
   expect_equal(guess_driver("nc.notsupported"), NA)
 })
@@ -66,7 +66,7 @@ test_that("guess_driver works on suffixes", {
   # for repeatability, this is how I turned the list to tests
   # `^"(\w+)" = ("[\w\s]+"),?`
   # to `expect_equal(guess_driver("nc.\1"), c("\1" = \2))`
-  
+
   expect_equal(guess_driver("couchdb:nc"), c("couchdb" = "CouchDB"))
   expect_equal(guess_driver("db2odbc:nc"), c("db2odbc" = "DB2ODBC"))
   expect_equal(guess_driver("dods:nc"), c("dods" = "DODS"))
@@ -77,7 +77,7 @@ test_that("guess_driver works on suffixes", {
   expect_equal(guess_driver("odbc:nc"), c("odbc" = "ODBC"))
   expect_equal(guess_driver("pg:nc"), c("pg" = "PostgreSQL"))
   expect_equal(guess_driver("sde:nc"), c("sde" = "SDE"))
-  
+
   # upper case
   expect_equal(guess_driver("CouchDB:nc"), c("couchdb" = "CouchDB"))
   expect_equal(guess_driver("db2ODBC:nc"), c("db2odbc" = "DB2ODBC"))
@@ -89,7 +89,7 @@ test_that("guess_driver works on suffixes", {
   expect_equal(guess_driver("ODBC:nc"), c("odbc" = "ODBC"))
   expect_equal(guess_driver("PG:nc"), c("pg" = "PostgreSQL"))
   expect_equal(guess_driver("SDE:nc"), c("sde" = "SDE"))
-  
+
   # unsuported
   expect_equal(guess_driver("notsupported:nc"), NA)
 })
@@ -99,7 +99,7 @@ test_that("weird names are supported", {
   expect_equal(guess_driver("pg:nc.shp.e00"), c("pg" = "PostgreSQL"))
   expect_equal(guess_driver("nc.shp.e00"), c("e00" = "AVCE00"))
   expect_equal(guess_driver("couchdb:shp"), c("couchdb" = "CouchDB"))
-  
+
   expect_equal(guess_driver("notsupported:nc.shp"), NA)
   expect_equal(guess_driver("notsupported"), NA)
 })
@@ -109,7 +109,7 @@ test_that("driver utils work", {
   expect_true(is_driver_available("shp", data.frame(name = c("shp"))))
   expect_false(is_driver_available("shp", data.frame(name = c("x", "y", "z"))))
   expect_false(is_driver_available("shp", data.frame(name = c("x", "y", "z"))))
-  
+
   expect_error(is_driver_can("shp", data.frame(name = c("x", "y", "shp")), operation = "nothing"))
   expect_error(is_driver_can("shp", data.frame(name = c("x", "y")), operation = "nothing"))
   expect_true(is_driver_can("shp", data.frame(name = c("x", "y", "shp"), write = rep(TRUE, 3)), operation = "write"))
@@ -121,23 +121,23 @@ test_that("guess_driver_can_write", {
   expect_error(guess_driver_can_write("x.not", c("nothing" = "nothing")), "not available")
   expect_equal(guess_driver_can_write("x.csv"), c("csv" = "CSV"))
   expect_equal(guess_driver_can_write("c:/x.csv"), c("csv" = "CSV"))
-  
+
   expect_error(guess_driver_can_write("x.unsuported"), "Could not guess driver")
   expect_error(guess_driver_can_write("unsuported:x"), "Could not guess driver")
 })
 
-test_that("driver operations", {  
+test_that("driver operations", {
   # These tests are driver specifics to GDAL version and OS.
   expect_error(guess_driver_can_write("x.e00"), "cannot write")
   expect_error(guess_driver_can_write("x.gdb"), "cannot write")
-  
+
   expect_equal(guess_driver_can_write("x.geojson"), c("geojson" = "GeoJSON"))
   expect_equal(guess_driver_can_write("x.csv"), c("csv" = "CSV"))
   expect_equal(guess_driver_can_write("x.gml"), c("gml" = "GML"))
 })
 
 test_that("guess driver on windows with backslashes (#127)", {
-    expect_identical(guess_driver("c:\\Temp\\this.shp"), 
+    expect_identical(guess_driver("c:\\Temp\\this.shp"),
                      guess_driver("c:/Temp/this.shp"))
 })
 

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -12,7 +12,7 @@ test_that("we can subset sf objects", {
 
   a = c("x", "y")
   g = st_sfc(pt1, pt2)
-  expect_silent(xxx <- st_sf(a, g, g)) 
+  expect_silent(xxx <- st_sf(a, g, g))
   expect_silent(st_sf(a, geom1 = g, geom2 = g, sf_column_name = "geom2"))
   x = st_sf(a, geom1 = g, geom2 = g, sf_column_name = "geom2")
   expect_silent(st_geometry(x) <- "geom2")
@@ -73,5 +73,5 @@ test_that("st_as_sf bulk points work", {
   expect_identical(class(xyz_sf), c("sf", "data.frame"))
   expect_identical(class(xym_sf), c("sf", "data.frame"))
   expect_identical(class(xyzm_sf), c("sf", "data.frame"))
-  
+
 })

--- a/tests/testthat/test_sfc.R
+++ b/tests/testthat/test_sfc.R
@@ -66,7 +66,7 @@ test_that("st_precision()", {
 })
 
 test_that("st_precision() works for sf", {
-    x <- st_as_sf(data.frame("a" = 1), 
+    x <- st_as_sf(data.frame("a" = 1),
                   st_sfc(st_point(c(pi, pi)), precision = 1e-4))
     expect_equal(st_precision(x), 1e-4)
     expect_error(st_set_precision(x, NULL))

--- a/tests/testthat/test_sfg.R
+++ b/tests/testthat/test_sfg.R
@@ -40,9 +40,9 @@ test_that("xx2multixx works", {
 
 test_that("format works", {
 	expect_identical(format(st_multipoint(matrix(1:6/6,3))), "MULTIPOINT(0.16666666666666...")
-	expect_identical(format(st_sfc(st_multipoint(matrix(1:6/6,3)))), 
+	expect_identical(format(st_sfc(st_multipoint(matrix(1:6/6,3)))),
 		"MULTIPOINT(0.16666666666666...")
-	expect_identical(obj_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))), 
+	expect_identical(obj_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))),
 		"MULTIPOINT(0...")
 	expect_identical(type_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))), "simple_feature")
 })

--- a/tests/testthat/test_sp.R
+++ b/tests/testthat/test_sp.R
@@ -26,7 +26,7 @@ test_that("we can convert points & lines to and from sp objects", {
 test_that("as() can convert GEOMETRY to Spatial (#131)", {
   single <- list(rbind(c(0,0), c(1,0), c(1, 1), c(0,1), c(0,0))) %>% st_polygon()
   multi <- list(single + 2, single + 4) %>% st_multipolygon()
-  
+
   # polygons
   w <- st_sfc(single, multi)
   # class is GEOMETRY
@@ -36,17 +36,17 @@ test_that("as() can convert GEOMETRY to Spatial (#131)", {
   # lines
   lns <- st_cast(w, "MULTILINESTRING")
   expect_is(as(lns, "Spatial"), "SpatialLines")
-  
+
   expect_warning(ln <- st_cast(w, "LINESTRING"), "first ring")
   expect_is(as(ln, "Spatial"), "SpatialLines")
-  
+
   # points
   expect_warning(pt <- st_cast(w, "POINT"), "first coordinate")
   expect_is(as(pt, "Spatial"), "SpatialPoints")
-  
+
   pts <- st_cast(w, "MULTIPOINT")
   expect_is(as(pts, "Spatial"), "SpatialMultiPoints")
-  
+
   expect_warning(pt <- st_cast(w, "POINT"), "first coordinate")
   expect_is(as(pt, "Spatial"), "SpatialPoints")
 })

--- a/tests/testthat/test_st_cast.R
+++ b/tests/testthat/test_st_cast.R
@@ -8,11 +8,11 @@ cc <- list(
     multi = m %>% st_multipoint()
   ),
   lines = list(
-    single = m %>% st_linestring(), 
+    single = m %>% st_linestring(),
     multi = list(m, m + s) %>% st_multilinestring()
   ),
   polygons = list(
-    single = list(m + s)  %>% st_polygon(), 
+    single = list(m + s)  %>% st_polygon(),
     multi = list(list(m), list(m + s)) %>% st_multipolygon()
   )
 )
@@ -32,28 +32,28 @@ test_that("st_cast() can coerce to MULTI* or GEOMETRY", {
   expect_error(st_cast(pts, "MULTILINESTRING"), "cannot create MULTILINESTRING from POINT")
   expect_error(st_cast(pts, "POLYGON"), "cannot create POLYGON from POINT")
   expect_error(st_cast(pts, "MULTIPOLYGON"), "cannot create MULTIPOLYGON from POINT")
-  
+
   # lines
   ln <- st_sfc(cc$lines$single, cc$lines$single)
   expect_is(st_cast(ln), "sfc_LINESTRING")
   lns <- st_sfc(cc$lines$single, cc$lines$multi)
   expect_is(st_cast(lns), "sfc_MULTILINESTRING")
   expect_warning(ln <- st_cast(lns, "POINT"), "first coordinate")
-  expect_is(ln, "sfc_POINT") 
+  expect_is(ln, "sfc_POINT")
   expect_is(st_cast(lns, "MULTIPOINT"), "sfc_MULTIPOINT")
   expect_warning(ln2 <- st_cast(lns, "LINESTRING"), "first linestring")
   expect_is(ln2, "sfc_LINESTRING")
   expect_is(st_cast(lns, "MULTILINESTRING"), "sfc_MULTILINESTRING")
   expect_is(st_cast(lns, "POLYGON"), "sfc_POLYGON")
   expect_is(st_cast(lns, "MULTIPOLYGON"), "sfc_MULTIPOLYGON")
-  
+
   # polygons
   pl <- st_sfc(cc$polygons$single, cc$polygons$single)
   expect_is(st_cast(pl), "sfc_POLYGON")
   pls <- st_sfc(cc$polygons$single, cc$polygons$multi)
   expect_is(st_cast(pls), "sfc_MULTIPOLYGON")
   expect_warning(pl <- st_cast(pls, "POINT"), "first coordinate")
-  expect_is(pl, "sfc_POINT") 
+  expect_is(pl, "sfc_POINT")
   expect_is(st_cast(pls, "MULTIPOINT"), "sfc_MULTIPOINT")
   expect_warning(pl2 <- st_cast(pls, "LINESTRING"), "first ring")
   expect_is(pl2, "sfc_LINESTRING")
@@ -61,21 +61,21 @@ test_that("st_cast() can coerce to MULTI* or GEOMETRY", {
   expect_warning(pl3 <- st_cast(pls, "POLYGON"), "first part")
   expect_is(pl3, "sfc_POLYGON")
   expect_is(st_cast(pls, "MULTIPOLYGON"), "sfc_MULTIPOLYGON")
-  
+
   # mixed
   expect_is(st_cast(st_sfc(cc$points$single, cc$lines$multi)), "sfc_GEOMETRY")
   expect_is(st_cast(st_sfc(cc$lines$multi, cc$polygons$multi)), "sfc_GEOMETRY")
-  
+
   expect_is(st_cast(st_sfc(cc$lines$multi, cc$polygons$multi)), "sfc_GEOMETRY")
   expect_is(st_cast(st_sfc(cc$points$multi, cc$polygons$multi)), "sfc_GEOMETRY")
-  expect_is(st_cast(st_sfc(cc$points$multi, cc$lines$multi, cc$polygons$multi)), 
+  expect_is(st_cast(st_sfc(cc$points$multi, cc$lines$multi, cc$polygons$multi)),
             "sfc_GEOMETRY")
-  expect_is(st_cast(st_sfc(list(cc$points$multi, cc$lines$multi, cc$polygons$multi))), 
+  expect_is(st_cast(st_sfc(list(cc$points$multi, cc$lines$multi, cc$polygons$multi))),
             "sfc_GEOMETRY")
 })
 
 test_that("st_cast preserves crs (#154)", {
-  expect_identical(st_cast(st_sfc(cc$points$single, cc$lines$multi, crs = 4326)) %>% st_crs(), 
+  expect_identical(st_cast(st_sfc(cc$points$single, cc$lines$multi, crs = 4326)) %>% st_crs(),
               st_sfc(cc$points$single, cc$lines$multi, crs = 4326) %>% st_crs())
 })
 
@@ -86,7 +86,7 @@ test_that("st_cast can crack GEOMETRYCOLLECTION", {
   gc3 <- st_geometrycollection(list(st_multilinestring(list(
     rbind(c(4,4),c(4,3)), rbind(c(2,2),c(2,1),c(3,1))))))
   gc4 <- st_geometrycollection(list(st_multipoint(rbind(c(1,5), c(4,3)))))
-  
+
   sfc <- st_sfc(gc1, gc2, gc3)
   expect_is(st_cast(sfc), "sfc_GEOMETRY")  # first, it cracks the collection
   expect_is(st_cast(st_cast(sfc)), "sfc_MULTILINESTRING")  # then cast to multi*
@@ -95,8 +95,8 @@ test_that("st_cast can crack GEOMETRYCOLLECTION", {
 # @etienne: I think this is more useful; attr(x, "ids") contains the original lengths
   expect_is(st_cast(sfc, "MULTIPOINT"), "sfc_MULTIPOINT")
   expect_is(st_cast(sfc, "LINESTRING"), "sfc_LINESTRING")
-  
-  sfc2 <- st_sfc(gc1, gc2, gc4) 
+
+  sfc2 <- st_sfc(gc1, gc2, gc4)
   expect_is(sfc2 %>% st_cast, "sfc_GEOMETRY")
   expect_equal(sapply(sfc2 %>% st_cast, class)[2, ], c("LINESTRING", "MULTILINESTRING", "MULTIPOINT"))
 })

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -13,7 +13,7 @@ test_that("separate and unite work", {
   expect_true(st_read(system.file("shape/nc.shp", package="sf")) %>%
     separate(CNTY_ID, c("a", "b"), sep = 2) %>% inherits("sf"))
   expect_true(st_read(system.file("shape/nc.shp", package="sf")) %>%
-    separate(CNTY_ID, c("a", "b"), sep = 2) %>% 
+    separate(CNTY_ID, c("a", "b"), sep = 2) %>%
 	unite(CNTY_ID_NEW, c("a", "b"), sep = "") %>% inherits("sf"))
 })
 

--- a/tests/testthat/test_tm.R
+++ b/tests/testthat/test_tm.R
@@ -2,15 +2,15 @@ context("sf: date and time")
 
 test_that("st_read and write handle date and time", {
 	Sys.setenv(TZ="") # local time
-    x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3, 
+    x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3,
               geometry = st_sfc(st_point(c(1,1)), st_point(c(2,2))))
     shp <- paste0(tempfile(), ".shp")
     gpkg <- paste0(tempfile(), ".gpkg")
-    
+
     st_write(x[-4], shp[1], quiet = TRUE)
     x2 = st_read(shp[1], quiet = TRUE)
     expect_equal(x[-4], x2)
-    
+
     st_write(x, gpkg, quiet = TRUE)
     x2 = st_read(gpkg, quiet = TRUE)
     expect_equal(x[["a"]], x2[["a"]])
@@ -19,15 +19,15 @@ test_that("st_read and write handle date and time", {
     expect_equal(x[["tm"]], x2[["tm"]])
 
 	Sys.setenv(TZ="UTC") # GMT
-    x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3, 
+    x = st_sf(a = 1:2, b=c(5.6,3), dt = Sys.Date()+1:2, tm = Sys.time()+2:3,
               geometry = st_sfc(st_point(c(1,1)), st_point(c(2,2))))
     shp <- paste0(tempfile(), ".shp")
     gpkg <- paste0(tempfile(), ".gpkg")
-    
+
     st_write(x[-4], shp[1], quiet = TRUE)
     x2 = st_read(shp[1], quiet = TRUE)
     expect_equal(x[-4], x2)
-    
+
     st_write(x, gpkg, quiet = TRUE)
     x2 = st_read(gpkg, quiet = TRUE)
     expect_equal(x[["a"]], x2[["a"]])

--- a/tests/testthat/test_wkt.R
+++ b/tests/testthat/test_wkt.R
@@ -2,10 +2,10 @@ context("sf: wkt")
 
 test_that("well-known text", {
   gcol <- st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:4,2))))
-  expect_message(x <- print(gcol), 
+  expect_message(x <- print(gcol),
                  "GEOMETRYCOLLECTION\\(POINT\\(1 2\\), LINESTRING\\(1 3, 2 4\\)\\)", all = TRUE)
   expect_equal(x, "GEOMETRYCOLLECTION(POINT(1 2), LINESTRING(1 3, 2 4))")
-  
+
   p1 = st_point(1:3)
   p2 = st_point(5:7)
   sfc = st_sfc(p1,p2)

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -6,7 +6,7 @@ meuse <- st_as_sf(meuse, coords = c("x", "y"), crs = 28992)
 test_that("sf can write to all writable formats", {
     # write to all formats available
     tf <- tempfile()
-    drvs <- st_drivers()$name[sapply(st_drivers()$name, 
+    drvs <- st_drivers()$name[sapply(st_drivers()$name,
 		function(x) is_driver_can(x, operation = "write"))] %>% as.character()
     excluded_drivers = c("gps", # requires options
                          "gtm", # doesn't handle attributes
@@ -33,7 +33,7 @@ test_that("sf can write units (#264)", {
     expect_equal(as.numeric(meuse[["length"]]), disc[["length"]])
 })
 
-test_that("delete and update work (#304) ", { 
+test_that("delete and update work (#304) ", {
   skip_if_not("GPKG" %in% st_drivers()$name)  # shapefiles can't write point+multipoint mix:
   skip_on_os("mac")
 
@@ -41,7 +41,7 @@ test_that("delete and update work (#304) ", {
   expect_error(st_write(x, "x.gpkg", layer = c("a", "b"), driver = "GPKG")) # error
   expect_error(st_write(x, "x.gpkg",  driver = "foo")) # error
   expect_output(st_write(x, "x.gpkg", delete_dsn = TRUE), "Deleting source")
-  expect_error(st_write(x, "x.gpkg", update = FALSE, quiet = TRUE), "Dataset already exists") 
+  expect_error(st_write(x, "x.gpkg", update = FALSE, quiet = TRUE), "Dataset already exists")
   expect_output(st_write(x, "x.gpkg", delete_dsn = TRUE), "Writing layer `x'")
   expect_output(st_write(x, "x.gpkg", layer = "foo", delete_layer = TRUE), "Deleting layer `foo' failed")
   expect_output(st_write(x, "x.gpkg", layer = "foo", delete_layer = TRUE), "Deleting layer `foo' using")
@@ -53,7 +53,7 @@ test_that("delete and update work (#304) ", {
   expect_error(write_sf(x, "x.shp", "x"), "Feature creation failed") # on osx el capitan: "c++ exception (unknown reason)"
   expect_error(write_sf(x, "x.shp", "x"))
   expect_silent(x <- st_read("x.gpkg", quiet = TRUE))
-  x <- st_sf(a = 1:2, geom = st_sfc(st_linestring(matrix(1:4,2,2)), 
+  x <- st_sf(a = 1:2, geom = st_sfc(st_linestring(matrix(1:4,2,2)),
 	st_multilinestring(list(matrix(1:4,2,2), matrix(10:13,2,2)))))
   # expect_output(st_write(x, "x.shp"))
   expect_silent(write_sf(x, "x.shp", "x"))

--- a/tests/wkb.R
+++ b/tests/wkb.R
@@ -47,7 +47,7 @@ rawToHex(st_as_binary(st_multipoint(matrix(1:6,3))))
 rawToHex(st_as_binary(st_sfc(st_point(c(0,1)), st_multipoint(matrix(1:6,3)))))
 try(rawToHex("error"))
 
-# debug roundtrips sf -> GDAL -> sf; 
+# debug roundtrips sf -> GDAL -> sf;
 # the first WKT is what GDAL reports, and will lack M
 st_as_text(st_sfc(sf:::CPL_roundtrip(st_sfc(st_linestring(matrix(1:18,6,3),dim="XYZ")))))
 st_as_text(st_sfc(sf:::CPL_roundtrip(st_sfc(st_multipoint(matrix(1:18,6,3),dim="XYZ")))))

--- a/vignettes/sf1.Rmd
+++ b/vignettes/sf1.Rmd
@@ -601,11 +601,11 @@ Unit: milliseconds
  kml_read_sf()    8.132629    8.268952   10.44328    8.52626    9.420043
         max neval   cld
  5186.16240    10     e
-  376.64045    10   c  
+  376.64045    10   c
  5282.25874    10     e
  1178.42358    10    d
-  189.29191    10  b   
-   26.20221    10 a    
+  189.29191    10  b
+   26.20221    10 a
 ```
 
 This shows that `sf::st_read()` is substantially faster than

--- a/vignettes/sf2.Rmd
+++ b/vignettes/sf2.Rmd
@@ -85,7 +85,7 @@ and layers in a datasource, e.g.
 
 ```{r eval=FALSE}
 > st_layers("PG:dbname=postgis")
-Driver: PostgreSQL 
+Driver: PostgreSQL
 Available layers:
   layer_name geometry_type features fields
 1      meuse         Point      155     12
@@ -93,7 +93,7 @@ Available layers:
 3       sids Multi Polygon      100     14
 4  meuse_tbl         Point      155     13
 5 meuse_tbl2         Point      155     13
-> 
+>
 ```
 
 A particular layer can now be read by e.g.
@@ -154,7 +154,7 @@ How the guessing of drivers works is explained in the next section.
 
 The output driver is guessed from the datasource name, either from
 its extension (`.shp`: `ESRI Shapefile`), or its prefix (`PG:`:
-`PostgreSQL`). The list of extensions with corresponding driver 
+`PostgreSQL`). The list of extensions with corresponding driver
 (short driver name) is:
 
 | extension| driver short name |
@@ -207,7 +207,7 @@ table already exists in a database: append records to the table
 or overwrite it:
 
 ```{r eval=FALSE}
-st_write(st_as_sf(meuse), "PG:dbname=postgis", "meuse", 
+st_write(st_as_sf(meuse), "PG:dbname=postgis", "meuse",
     layer_options = "OVERWRITE=true")
 ```
 
@@ -229,11 +229,11 @@ So far, testing has mainly be done with `PostGIS`, other databases
 might work but may also need more work. An example of reading is:
 
 ```{r eval=FALSE}
-library(RPostgreSQL) 
-conn = dbConnect(PostgreSQL(), dbname = "postgis") 
+library(RPostgreSQL)
+conn = dbConnect(PostgreSQL(), dbname = "postgis")
 meuse = st_read_db(conn, "meuse")
-meuse_1_3 = st_read_db(conn, query = "select * from meuse limit 3;") 
-dbDisconnect(conn) 
+meuse_1_3 = st_read_db(conn, query = "select * from meuse limit 3;")
+dbDisconnect(conn)
 ```
 
 We see here that in the second example a query is given. This
@@ -327,7 +327,7 @@ opar = par(mar=rep(0,4))
 plot(m.sf)
 ```
 
-Conversion of simple feature objects of class `sf` or `sfc` into corresponding 
+Conversion of simple feature objects of class `sf` or `sfc` into corresponding
 `Spatial*` objects is done using the `as` method, coercing to `Spatial`:
 
 ```{r}

--- a/vignettes/sf3.Rmd
+++ b/vignettes/sf3.Rmd
@@ -19,7 +19,7 @@ manipulated, where manipulations include
 
 * type transformations (e.g., `POLYGON` to `MULTIPOLYGON`)
 * affine transformation (shift, scale, rotate)
-* transformation into a different coordinate reference system 
+* transformation into a different coordinate reference system
 * geometrical operations, e.g. finding the centroid of a polygon, detecting whether pairs of feature geometries intersect, or find the union (overlap) of two polygons.
 
 ## Type transformations
@@ -33,7 +33,7 @@ For single geometries, `st_cast` will
 1. convert from XX to MULTIXX, e.g. `LINESTRING` to `MULTILINESTRING`
 2. convert from MULTIXX to XX if MULTIXX has length one (else, it will still convert but warn about loss of information)
 3. convert from MULTIXX to XX if MULTIXX does not have length one, but it will warn about the loss of information
-4. convert GEOMETRYCOLLECTION of length one to its component if 
+4. convert GEOMETRYCOLLECTION of length one to its component if
 
 Examples of the first three types are
 ```{r}
@@ -58,9 +58,9 @@ class(st_geometry(st_read(shp, quiet = TRUE, type = 3)))
 class(st_geometry(st_read(shp, quiet = TRUE, type = 1)))
 ```
 
-This option is handled by the GDAL library; in case of failure to convert to the target type, the original types are returned, which in this case is a mix of `POLYGON` and `MULTIPOLYGON` geometries, leading to a `GEOMETRY` as superclass. When we try to read multipolygons as polygons, all secondary rings of multipolygons get lost. 
+This option is handled by the GDAL library; in case of failure to convert to the target type, the original types are returned, which in this case is a mix of `POLYGON` and `MULTIPOLYGON` geometries, leading to a `GEOMETRY` as superclass. When we try to read multipolygons as polygons, all secondary rings of multipolygons get lost.
 
-When functions return objects with mixed geometry type (`GEOMETRY`), downstream functions such as `st_write` may have difficulty handling them. For some of these cases, `st_cast` may help modifying their type.  For sets of geometry objects (`sfc`) and simple feature sets (`sf), `st_cast` can be used by specifying the target type, or without specifying it. 
+When functions return objects with mixed geometry type (`GEOMETRY`), downstream functions such as `st_write` may have difficulty handling them. For some of these cases, `st_cast` may help modifying their type.  For sets of geometry objects (`sfc`) and simple feature sets (`sf), `st_cast` can be used by specifying the target type, or without specifying it.
 
 ```{r}
 ls <- st_linestring(rbind(c(0,0),c(1,1),c(2,1)))
@@ -138,7 +138,7 @@ s2 = s
 st_crs(s2) <- "+proj=longlat +datum=WGS84"
 all.equal(s1, s2)
 ```
-an alternative, more pipe-friendly version of `st_crs<-` is 
+an alternative, more pipe-friendly version of `st_crs<-` is
 ```{r}
 s1 %>% st_set_crs(4326)
 ```
@@ -153,7 +153,7 @@ did not reproject values:
 s3 <- s1 %>% st_set_crs(4326) %>% st_set_crs(3857)
 ```
 A cleaner way to do this that better expresses intention and does
-not generate this warning is to first wipe the CRS by assigning it 
+not generate this warning is to first wipe the CRS by assigning it
 a missing value, and then setting it to the intended value.
 ```{r}
 s3 <- s1  %>% st_set_crs(NA) %>% st_set_crs(3857)
@@ -201,7 +201,7 @@ st_is_valid(st_sfc(b0,b1))
 ```
 and `st_is_simple` whether line geometries are simple:
 ```{r}
-s = st_sfc(st_linestring(rbind(c(0,0), c(1,1))), 
+s = st_sfc(st_linestring(rbind(c(0,0), c(1,1))),
 	st_linestring(rbind(c(0,0), c(1,1),c(0,1),c(1,0))))
 st_is_simple(s)
 ```
@@ -228,7 +228,7 @@ st_relate(x,y)
 ```
 element [i,j] of this matrix has nine characters, refering to relationship between x[i] and y[j], encoded as $I_xI_y,I_xB_y,I_xE_y,B_xI_y,B_xB_y,B_xE_y,E_xI_y,E_xB_y,E_xE_y$ where $I$ refers to interior, $B$ to boundary, and $B$ to exterior, and e.g. $B_xI_y$ the dimensionality of the intersection of the the boundary $B_x$ of x[i] and the interior $I_y$ of y[j], which is one of {0,1,2,F}, indicating zero-, one-, two-dimension intersection, and (F) no intersection, respectively.
 
-### Binary logical operations: 
+### Binary logical operations:
 Binary logical operations return either a sparse matrix
 ```{r}
 st_intersects(x,y)
@@ -308,7 +308,7 @@ plot(st_intersection(st_union(x),st_union(y)), add = TRUE, col = 'red')
 To get _everything but_ the intersection, use `st_difference` or st_sym_difference`:
 ```{r,fig=TRUE}
 par(mfrow=c(2,2), mar = c(0,0,1,0))
-plot(x, col = '#ff333388'); 
+plot(x, col = '#ff333388');
 plot(y, add=TRUE, col='#33ff3388')
 title("x: red, y: green")
 plot(x, border = 'grey')

--- a/vignettes/sf4.Rmd
+++ b/vignettes/sf4.Rmd
@@ -26,7 +26,7 @@ library(sf)
 nc <- st_read(system.file("shape/nc.shp", package="sf"))
 nc <- st_transform(nc, 2264)
 nc[1,]
-``` 
+```
 prints the first record.
 
 Many of the tidyverse/dplyr verbs have methods for `sf` objects. This means that given that both `sf` and `dplyr` are loaded, manipulations such as selecting a single attribute will return an `sf` object:


### PR DESCRIPTION
It'd be nice to remove all trailing spaces from the code (partly for style, partly because Atom keeps doing it automatically), but feel free to reject this PR if it's overly aggressive.

The python programmer in me also wants to replace the mix of tabs and spaces with all spaces, but that's an even more dramatic change.