### PR TITLE
Fix issues with multibyte string data sources on Windows

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -71,7 +71,7 @@ st_read = function(dsn, layer, ..., options = NULL, quiet = FALSE, geometry_colu
 		layer = character(0)
 
 	if (file.exists(dsn))
-		dsn = normalizePath(dsn)
+		dsn = enc2utf8(normalizePath(dsn))
 
 	if (length(promote_to_multi) > 1)
 		stop("`promote_to_multi' should have length one, and applies to all geometry columns")
@@ -237,7 +237,7 @@ st_write = function(obj, dsn, layer = file_path_sans_ext(basename(dsn)),
 		stop("dsn should specify a data source or filename")
 
 	if (file.exists(dsn))
-		dsn = normalizePath(dsn)
+		dsn = enc2utf8(normalizePath(dsn))
 
 	geom = st_geometry(obj)
 	obj[[attr(obj, "sf_column")]] = NULL
@@ -325,7 +325,7 @@ st_layers = function(dsn, options = character(0), do_count = FALSE) {
 	if (missing(dsn))
 		stop("dsn should specify a data source or filename")
 	if (file.exists(dsn))
-		dsn = normalizePath(dsn)
+		dsn = enc2utf8(normalizePath(dsn))
 	CPL_get_layers(dsn, options, do_count)
 }
 


### PR DESCRIPTION
On Windows in CJK locale, data sources with multibyte characters cannot be read or write by sf. For example:

```r
library(sf)

# copy nc.shp to a path which has multibyte characters
dsn_dir <- file.path(tempdir(), "データ")
dir.create(dsn_dir)
nc <- read_sf(system.file("shape/nc.shp", package="sf"))
write_sf(nc, dsn_dir, layer = "nc", driver="ESRI Shapefile")

# verify
list.files(dsn_dir)
#> [1] "nc.dbf" "nc.prj" "nc.shp" "nc.shx"

st_layers(dsn_dir)
#> Cannot open data source C:\Users\user1\AppData\Local\Temp\Rtmp21SLMr\データ
#> Error in CPL_get_layers(dsn, options, do_count) : Open failed.
```

`st_read()` and `st_write()` also fails in many cases (I'm not sure why `write_sf()` works in the example above...).

I'm not familiar with GDAL, but it seems that GDAL accepts UTF-8 characters only; it succeeds if we call `CPL_get_layers()` directly with a UTF-8 argument like this:

```r
sf:::CPL_get_layers(enc2utf8(dsn_dir), character(0), FALSE)
#> Reading layer `nc' from data source `C:\Users\user1\AppData\Local\Temp\Rtmp21SLMr\繝・・繧ｿ' using driver `ESRI Shapefile'
#> Simple feature collection with 100 features and 14 fields
#> geometry type:  MULTIPOLYGON
#> dimension:      XY
#> bbox:           xmin: -84.32385 ymin: 33.88199 xmax: -75.45698 ymax: 36.58965
#> epsg (SRID):    4267
#> proj4string:    +proj=longlat +datum=NAD27 +no_defs
```

But, if we call `st_layers()`, it fails.

```r
st_layers(enc2utf8(dsn_dir))
#> Cannot open data source C:\Users\user1\AppData\Local\Temp\Rtmp21SLMr\データ
#> Error in CPL_get_layers(dsn, options, do_count) : Open failed.
```

This is because `normalizePath()` doesn't keep the encoding.

```r
dsn <- enc2utf8("データ/nc.shp")
Encoding(dsn)
#> [1] "UTF-8"

dsn_normalized <- normalizePath(dsn)
Encoding(dsn_normalized)
#> [1] "unknown"
```

So, we need to convert the strings into UTF-8 ones *after* `normalizePath()`. Fortunately, `sub()`, `basename()` and `file_path_sans_ext()`, which are used to extract layer names from `dsn`, all keep the encoding.