### PR TITLE
Update vignette: dropTable is now drop

### DIFF
--- a/vignettes/sf2.Rmd
+++ b/vignettes/sf2.Rmd
@@ -245,12 +245,12 @@ Similarly, tables can be written:
 
 ```{r eval=FALSE}
 conn = dbConnect(PostgreSQL(), dbname = "postgis")
-st_write_db(conn, meuse, dropTable = TRUE)
+st_write_db(conn, meuse, drop = TRUE)
 dbDisconnect(conn)
 ```
 
 Here, the default table (layer) name is taken from the object name
-(`meuse`). Argument `dropTable` informs to drop (remove) the table
+(`meuse`). Argument `drop` informs to drop (remove) the table
 before writing; logical argument `binary` determines whether to
 use well-known binary or well-known text when writing the geometry
 (where well-known binary is faster and lossless).


### PR DESCRIPTION
The `dropTable` argument in `st_write_db` is now `drop` (see commit 4d187f1, #274). 

You'd still have to update the html file. Too many unrelated changes when I `devtools::build_vignettes()`.