### PR TITLE
Correction on crs retrieval on bbox for Raster and sp objects

### DIFF
--- a/R/bbox.R
+++ b/R/bbox.R
@@ -2,8 +2,8 @@
 #' @details
 #' \code{NA_bbox_} is the \code{bbox} object with a missing value.
 #' @export
-NA_bbox_ = structure(rep(NA_real_, 4), 
-	names = c("xmin", "ymin", "xmax", "ymax"), 
+NA_bbox_ = structure(rep(NA_real_, 4),
+	names = c("xmin", "ymin", "xmax", "ymax"),
 	crs = NA_crs_,
 	class = "bbox")
 
@@ -23,25 +23,25 @@ bbox.Set = function(obj) {
 		bb_wrap(CPL_get_bbox(unclass(obj)[sel], 0))
 }
 bbox.Mtrx = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(list(obj), 1)) # note the list()
 }
 bbox.MtrxSet = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(obj, 1))
 }
 bbox.MtrxSetSet = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(obj, 2))
 }
 bbox.MtrxSetSetSet = function(obj) {
-	if (length(obj) == 0) 
+	if (length(obj) == 0)
 		NA_bbox_
 	else
 		bb_wrap(CPL_get_bbox(obj, 3))
@@ -55,7 +55,7 @@ bbox.MtrxSetSetSet = function(obj) {
 #' @return a numeric vector of length four, with \code{xmin}, \code{ymin}, \code{xmax}
 #' and \code{ymax} values; if \code{obj} is of class \code{sf}, \code{sfc}, \code{Spatial} or \code{Raster}, the object
 #' returned has a class \code{bbox}, an attribute \code{crs} and a method to print the
-#' bbox and an \code{st_crs} method to retrieve the coordinate reference system 
+#' bbox and an \code{st_crs} method to retrieve the coordinate reference system
 #' corresponding to \code{obj} (and hence the bounding box). \link{st_as_sfc} has a
 #' methods for \code{bbox} objects to generate a polygon around the four bounding box points.
 #' @name st_bbox
@@ -89,7 +89,7 @@ bbox_list = function(obj) {
 	if (length(s) == 0 || all(is.na(s[1L,])))
 		NA_bbox_
 	else
-		bb_wrap(c(min(s[1L,], na.rm = TRUE), min(s[2L,], na.rm = TRUE), 
+		bb_wrap(c(min(s[1L,], na.rm = TRUE), min(s[2L,], na.rm = TRUE),
 		  max(s[3L,], na.rm = TRUE), max(s[4L,], na.rm = TRUE)))
 }
 #' @export
@@ -131,7 +131,7 @@ print.bbox = function(x, ...) {
 	print(unclass(x))
 }
 
-compute_bbox = function(obj) { 
+compute_bbox = function(obj) {
 	switch(class(obj)[1],
 		sfc_POINT = bb_wrap(bbox.Set(obj)),
 		sfc_MULTIPOINT = bb_wrap(bbox.MtrxSet(obj)),
@@ -158,7 +158,7 @@ st_bbox.Spatial = function(obj) {
 		stop("package sp required, please install it first")
 	bb = bbox(obj)
 	structure(bb_wrap(c(bb[1,1],bb[2,1],bb[1,2],bb[2,2])),
-		crs = st_crs(proj4string(meuse)))
+		crs = st_crs(proj4string(obj)))
 }
 
 #' @export
@@ -168,5 +168,5 @@ st_bbox.Raster = function(obj) {
 		stop("package raster required, please install it first")
 	bb = bbox(obj)
 	structure(bb_wrap(c(bb[1,1],bb[2,1],bb[1,2],bb[2,2])),
-		crs = st_crs(proj4string(meuse)))
+		crs = st_crs(proj4string(obj)))
 }


### PR DESCRIPTION
Hi. This should correct a "typo" on crs retrieval for bboxes on `sp` and `Raster` objects, which is using: 

`crs = st_crs(proj4string(meuse)))`

instead than:

`crs = st_crs(proj4string(obj)))`

(the other changes are just automatic removal of end-of-line spaces). 

HTH.