### PR TITLE
Pass a bare matrix to st_polygon() and a list of matrix to st_multipolygon()

### DIFF
--- a/R/sfg.R
+++ b/R/sfg.R
@@ -135,9 +135,9 @@ st_linestring = function(x = matrix(numeric(0), 0, 2), dim = "XYZ") Mtrx(x, dim,
 #' @name st
 #' @export
 st_polygon = function(x = list(), dim = if(length(x)) "XYZ" else "XY") {
-	if (identical(x, 1))
-		st_polygon(list(rbind(c(0,0),c(1,0),c(1,1),c(0,1),c(0,0))))
-	else MtrxSet(x, dim, type = "POLYGON", needClosed = TRUE)
+	if (is.matrix(x)) x = list(x)
+	if (identical(x, 1)) x = list(rbind(c(0,0),c(1,0),c(1,1),c(0,1),c(0,0)))
+	MtrxSet(x, dim, type = "POLYGON", needClosed = TRUE)
 }
 #' @name st
 #' @export
@@ -145,8 +145,11 @@ st_multilinestring = function(x = list(), dim = if (length(x)) "XYZ" else "XY")
 	MtrxSet(x, dim, type = "MULTILINESTRING", needClosed = FALSE)
 #' @name st
 #' @export
-st_multipolygon = function(x = list(), dim = if (length(x)) "XYZ" else "XY")
+st_multipolygon = function(x = list(), dim = if (length(x)) "XYZ" else "XY") {
+	idx = vapply(x, is.matrix, logical(1L))
+	x[idx] = lapply(x[idx], list)
 	MtrxSetSet(x, dim, type = "MULTIPOLYGON", needClosed = TRUE)
+}
 #' @name st
 #' @param dims character; specify dimensionality in case of an empty (NULL) geometrycollection, in which case \code{x} is the empty \code{list()}.
 #' @export
@@ -231,7 +234,7 @@ format.sfg = function(x, ..., digits = 30) {
 #' c(st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:6,3)))),
 #'   st_multilinestring(list(matrix(11:16,3))), st_point(5:6),
 #'   st_geometrycollection(list(st_point(10:11))))
-#' @details When \code{flatten=TRUE}, this method may merge points into a multipoint structure, and may not preserve order, and hence cannot be reverted. When given fish, it returns fish soup. 
+#' @details When \code{flatten=TRUE}, this method may merge points into a multipoint structure, and may not preserve order, and hence cannot be reverted. When given fish, it returns fish soup.
 c.sfg = function(..., recursive = FALSE, flatten = TRUE) {
 
 	stopifnot(! recursive)

--- a/tests/testthat/test_sfg.R
+++ b/tests/testthat/test_sfg.R
@@ -1,6 +1,6 @@
 context("sf")
 
-test_that("MtrxSet is being called", {
+test_that("MtrxSet and MtrxSetSet are being called", {
   outer = matrix(c(0,0,10,0,10,10,0,10,0,0),ncol=2, byrow=TRUE)
   hole1 = matrix(c(1,1,1,2,2,2,2,1,1,1),ncol=2, byrow=TRUE)
   hole2 = matrix(c(5,5,5,6,6,6,6,5,5,5),ncol=2, byrow=TRUE)
@@ -8,6 +8,15 @@ test_that("MtrxSet is being called", {
   pl1 = st_polygon(pts)
   expect_identical(st_as_text(pl1),
   "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (5 5, 5 6, 6 6, 6 5, 5 5))")
+  pl2 = st_polygon(outer)
+  expect_identical(st_as_text(pl2),
+  "POLYGON ((0 0, 10 0, 10 10, 0 10, 0 0))")
+  pl3 = st_multipolygon(list(pts))
+  expect_identical(st_as_text(pl3),
+  "MULTIPOLYGON (((0 0, 10 0, 10 10, 0 10, 0 0), (1 1, 1 2, 2 2, 2 1, 1 1), (5 5, 5 6, 6 6, 6 5, 5 5)))")
+  pl4 = st_multipolygon(list(outer))
+  expect_identical(st_as_text(pl4),
+  "MULTIPOLYGON (((0 0, 10 0, 10 10, 0 10, 0 0)))")
 })
 
 test_that("Dimension works", {


### PR DESCRIPTION
IIUC, in terms of the semantics of Simple Features, a bare matrix is not the equivalent of `POLYGON` and a list of matrix is not of `MULTIPOLYGON`. But, it doesn't seem a big deal to assume each matrix is a single polygon without holes and wrap them with list. This may be useful for the data like this:

``` r
library(GISTools, quietly = TRUE)
#> Checking rgeos availability: TRUE
#> rgeos version: 0.3-25, (SVN revision 555)
#>  GEOS runtime version: 3.6.1-CAPI-1.10.1 r0 
#>  Linking to sp version: 1.2-5 
#>  Polygon checking: TRUE
data("georgia")

str(georgia.polys, list.len = 5L)
#> List of 159
#>  $ : num [1:125, 1:2] 1292287 1292654 1292949 1294045 1294603 ...
#>  $ : num [1:99, 1:2] 1263206 1264530 1263799 1263714 1263095 ...
#>  $ : num [1:53, 1:2] 1267843 1270202 1271306 1272213 1272824 ...
#>  $ : num [1:124, 1:2] 1120149 1120164 1119692 1119295 1118798 ...
#>  $ : num [1:116, 1:2] 1175513 1177004 1192290 1192624 1192486 ...
#>   [list output truncated]
```

It would be nice if we can create a multipolygon with

```r
x <- sf::st_multipolygon(georgia.polys)
```

instead of manually wrapping them with list:

```r
x <- sf::st_multipolygon(lapply(georgia.polys, list))
```

But I'm not quite sure my assumptions are correct. What do you think...?