### PR TITLE
Add color key

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -8,6 +8,7 @@
 #' @param nbreaks number of colors breaks (ignored for \code{factor} or \code{character} variables)
 #' @param breaks either a numeric vector with the actual breaks, or a name of a method accepted by the \code{style} argument of \link[classInt]{classIntervals}
 #' @param max.plot integer; lower boundary to maximum number of attributes to plot; the default value (9) can be overriden by setting the global option \code{sf_max.plot}, e.g. \code{options(sf_max.plot=2)}
+#' @param key.pos integer; which side to plot a color key: 1 bottom, 2 left, 3 top, 4 right. Set to \code{NULL} for no key.
 #' @param pch plotting symbol
 #' @param cex symbol size
 #' @param bg symbol background color
@@ -84,7 +85,7 @@
 #' gc = st_sf(a=2:3, b = st_sfc(gc1,gc2))
 #' plot(gc, cex = gc$a, col = gc$a, border = rev(gc$a) + 2, lwd = 2)
 #' @export
-plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, breaks = "pretty", max.plot = ifelse(is.null(n <- options("sf_max.plot")[[1]]), 9, n), axis.pos = 4) {
+plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, breaks = "pretty", max.plot = ifelse(is.null(n <- options("sf_max.plot")[[1]]), 9, n), key.pos = 4) {
 	stopifnot(missing(y))
 	dots = list(...)
 
@@ -158,23 +159,23 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 			if (exists("values")) {
 				mar = c(1,1,1,1)
 				if (! is.factor(values))
-					mar[axis.pos] = 3
-				if (axis.pos %in% c(2,4))
+					mar[key.pos] = 3
+				if (key.pos %in% c(2,4))
 					mar[1] = 3
-				if (axis.pos %in% c(1,3))
+				if (key.pos %in% c(1,3))
 					mar[2] = 3
 				par(mar = mar)
 				si = lcm(2.8) # scale size
-				switch(axis.pos,
+				switch(key.pos,
 					layout(matrix(c(2,1), nrow = 2, ncol = 1), widths = 1, heights = c(1, si)),  # 1
 					layout(matrix(c(1,2), nrow = 1, ncol = 2), widths = c(si, 1), heights = 1),  # 2
 					layout(matrix(c(1,2), nrow = 2, ncol = 1), widths = 1, heights = c(si, 1)),  # 3
 					layout(matrix(c(2,1), nrow = 1, ncol = 2), widths = c(1, si), heights = 1)   # 4
 				)
 				if (is.factor(values))
-					image.scale.factor(levels(values), pal(nlevels(values)), axis.pos = axis.pos)
+					image.scale.factor(levels(values), pal(nlevels(values)), key.pos = key.pos)
 				else
-					image.scale(values, pal(nbreaks), breaks = breaks, axis.pos = axis.pos)
+					image.scale(values, pal(nbreaks), breaks = breaks, key.pos = key.pos)
 			}
 			plot(st_geometry(x), col = col, ...)
 		}
@@ -594,18 +595,18 @@ degAxis = function (side, at, labels, ..., lon, lat, ndiscr) {
 	axis(side, at = at, labels = labels, ...)
 }
 
-image.scale = function(z, col, breaks = NULL, axis.pos = 1, add.axis = TRUE,
+image.scale = function(z, col, breaks = NULL, key.pos = 1, add.axis = TRUE,
 	at = NULL, ...) {
 	if (!is.null(breaks) && length(breaks) != (length(col) + 1))
 		stop("must have one more break than colour")
 	zlim = range(z, na.rm=TRUE)
 	if (is.null(breaks))
 		breaks = seq(zlim[1], zlim[2], length.out = length(col) + 1)
-	if (axis.pos %in% c(1,3)) {
+	if (key.pos %in% c(1,3)) {
 		ylim = c(0, 1)
 		xlim = range(breaks)
 	}
-	if (axis.pos %in% c(2,4)) {
+	if (key.pos %in% c(2,4)) {
 		ylim = range(breaks)
 		xlim = c(0, 1)
 	}
@@ -615,18 +616,18 @@ image.scale = function(z, col, breaks = NULL, axis.pos = 1, add.axis = TRUE,
 	plot(1, 1, t="n", ylim = ylim, xlim = xlim, axes = FALSE,
 		xlab = "", ylab = "", xaxs = "i", yaxs = "i", ...)
 	for(i in seq(poly)) {
-		if (axis.pos %in% c(1,3))
+		if (key.pos %in% c(1,3))
 			polygon(poly[[i]], c(0,0,1,1), col=col[i], border=NA)
-		if (axis.pos %in% c(2,4))
+		if (key.pos %in% c(2,4))
 			polygon(c(0,0,1,1), poly[[i]], col=col[i], border=NA)
 	}
 
 	box()
 	if (add.axis)
-		axis(axis.pos, at)
+		axis(key.pos, at)
 }
 
-image.scale.factor <- function(labels, colors, axis.pos = 1, scale.frac = 0.3,
+image.scale.factor <- function(labels, colors, key.pos = 1, scale.frac = 0.3,
 	scale.n = 15, ...) {
 	frc = scale.frac
 	stre = scale.n
@@ -645,22 +646,22 @@ image.scale.factor <- function(labels, colors, axis.pos = 1, scale.frac = 0.3,
 	for (i in seq(poly))
 		poly[[i]] <- c(breaks[i], breaks[i+1], breaks[i+1], breaks[i])
 	for(i in seq(poly)) {
-		if (axis.pos %in% c(1,3))
+		if (key.pos %in% c(1,3))
 			polygon(poly[[i]], c(1,1,1-frc,1-frc), col=colors[i], border=NA)
-		if (axis.pos %in% c(2,4))
+		if (key.pos %in% c(2,4))
 			polygon(c(0,0,frc,frc), poly[[i]], col=colors[i], border=NA)
 	}
 	b = c(breaks[1], breaks[length(breaks)])
-	if (axis.pos %in% c(1,3)) {
+	if (key.pos %in% c(1,3)) {
 		text_y_loc = (1-frc)/1.05
-		if (axis.pos == 3) text_y_loc = text_y_loc - frc
+		if (key.pos == 3) text_y_loc = text_y_loc - frc
 		lines(y = c(1,1-frc,1-frc,1,1), x = c(b[1],b[1],b[2],b[2],b[1]))
-		text(y = text_y_loc, x = lb, labels, pos = axis.pos)
+		text(y = text_y_loc, x = lb, labels, pos = key.pos)
 	}
-	if (axis.pos %in% c(2,4)) {
+	if (key.pos %in% c(2,4)) {
 		text_x_loc = 1.05 * frc
-		if (axis.pos == 2) text_x_loc = text_x_loc + frc
+		if (key.pos == 2) text_x_loc = text_x_loc + frc
 		lines(x = c(0,frc,frc,0,0), y = c(b[1],b[1],b[2],b[2],b[1]))
-		text(x = text_x_loc, y = lb, labels, pos = axis.pos)
+		text(x = text_x_loc, y = lb, labels, pos = key.pos)
 	}
 }

--- a/R/plot.R
+++ b/R/plot.R
@@ -85,7 +85,7 @@
 #' gc = st_sf(a=2:3, b = st_sfc(gc1,gc2))
 #' plot(gc, cex = gc$a, col = gc$a, border = rev(gc$a) + 2, lwd = 2)
 #' @export
-plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, breaks = "pretty", max.plot = ifelse(is.null(n <- options("sf_max.plot")[[1]]), 9, n), key.pos = 4) {
+plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, breaks = "pretty", max.plot = if(is.null(n <- options("sf_max.plot")[[1]])) 9 else n, key.pos = if (ncol(x) > 2) NULL else 4) {
 	stopifnot(missing(y))
 	dots = list(...)
 
@@ -112,7 +112,7 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 		cols = setdiff(names(x), attr(x, "sf_column"))
 		# loop over each map to plot:
 		invisible(lapply(cols, function(cname) plot(x[, cname], main = cname, col = col,
-			pal = pal, nbreaks = nbreaks, breaks = breaks, ...)))
+			pal = pal, nbreaks = nbreaks, breaks = breaks, key.pos = key.pos, ...)))
 	} else { # single map:
 		if (is.null(col) && ncol(x) == 2) { # compute colors from single attribute:
 			values = x[[setdiff(names(x), attr(x, "sf_column"))]]
@@ -156,7 +156,7 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 			# or we've computed them from a factor; or from a numeric
 			# in all cases, they are in col. But we only want to plot
 			# an image scale if they map to "values"
-			if (exists("values")) {
+			if (exists("values") && ! is.null(key.pos)) {
 				mar = c(1,1,1,1)
 				if (! is.factor(values))
 					mar[key.pos] = 3

--- a/R/plot.R
+++ b/R/plot.R
@@ -8,7 +8,7 @@
 #' @param nbreaks number of colors breaks (ignored for \code{factor} or \code{character} variables)
 #' @param breaks either a numeric vector with the actual breaks, or a name of a method accepted by the \code{style} argument of \link[classInt]{classIntervals}
 #' @param max.plot integer; lower boundary to maximum number of attributes to plot; the default value (9) can be overriden by setting the global option \code{sf_max.plot}, e.g. \code{options(sf_max.plot=2)}
-#' @param key.pos integer; which side to plot a color key: 1 bottom, 2 left, 3 top, 4 right. Set to \code{NULL} for no key.
+#' @param key.pos integer; which side to plot a color key: 1 bottom, 2 left, 3 top, 4 right. Set to \code{NULL} for no key. Currently ignored if multiple columns are plotted.
 #' @param pch plotting symbol
 #' @param cex symbol size
 #' @param bg symbol background color
@@ -112,7 +112,7 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 		cols = setdiff(names(x), attr(x, "sf_column"))
 		# loop over each map to plot:
 		invisible(lapply(cols, function(cname) plot(x[, cname], main = cname, col = col,
-			pal = pal, nbreaks = nbreaks, breaks = breaks, key.pos = key.pos, ...)))
+			pal = pal, nbreaks = nbreaks, breaks = breaks, key.pos = NULL, ...)))
 	} else { # single map:
 		if (is.null(col) && ncol(x) == 2) { # compute colors from single attribute:
 			values = x[[setdiff(names(x), attr(x, "sf_column"))]]
@@ -152,10 +152,6 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 		if (is.null(col)) # no attribute available
 			plot(st_geometry(x), ...)
 		else {
-			# we either have a list of colours given;
-			# or we've computed them from a factor; or from a numeric
-			# in all cases, they are in col. But we only want to plot
-			# an image scale if they map to "values"
 			if (exists("values") && ! is.null(key.pos)) {
 				mar = c(1,1,1,1)
 				if (! is.factor(values))

--- a/R/plot.R
+++ b/R/plot.R
@@ -132,7 +132,7 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 				if (is.character(breaks)) { # compute breaks from values:
 					if (! requireNamespace("classInt", quietly = TRUE))
 						stop("package classInt required, please install it first")
-					breaks = if (length(values) > 1)
+					breaks = if (! all(is.na(values)) && length(unique(values)) > 1)
 						classInt::classIntervals(values, nbreaks, breaks)$brks
 					else
 						c(values, values) # lowest and highest!

--- a/R/plot.R
+++ b/R/plot.R
@@ -165,16 +165,16 @@ plot.sf <- function(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10, break
 					mar[2] = 3
 				par(mar = mar)
 				si = lcm(2.8) # scale size
-				switch (axis.pos,
-					layout(matrix(c(2,1), nrow=2, ncol=1), widths=1, heights=c(1,si)),  # 1
-					layout(matrix(c(1,2), nrow=1, ncol=2), widths=c(si,1), heights=1),  # 2
-					layout(matrix(c(1,2), nrow=2, ncol=1), widths=1, heights=c(si,1)),  # 3
-					layout(matrix(c(2,1), nrow=1, ncol=2), widths=c(1,si), heights=1)   # 4
+				switch(axis.pos,
+					layout(matrix(c(2,1), nrow = 2, ncol = 1), widths = 1, heights = c(1, si)),  # 1
+					layout(matrix(c(1,2), nrow = 1, ncol = 2), widths = c(si, 1), heights = 1),  # 2
+					layout(matrix(c(1,2), nrow = 2, ncol = 1), widths = 1, heights = c(si, 1)),  # 3
+					layout(matrix(c(2,1), nrow = 1, ncol = 2), widths = c(1, si), heights = 1)   # 4
 				)
 				if (is.factor(values))
-					image.scale.factor(values, col, axis.pos = axis.pos)
+					image.scale.factor(levels(values), pal(nlevels(values)), axis.pos = axis.pos)
 				else
-					image.scale(values, col, breaks = breaks, axis.pos = axis.pos)
+					image.scale(values, pal(nbreaks), breaks = breaks, axis.pos = axis.pos)
 			}
 			plot(st_geometry(x), col = col, ...)
 		}
@@ -596,7 +596,6 @@ degAxis = function (side, at, labels, ..., lon, lat, ndiscr) {
 
 image.scale = function(z, col, breaks = NULL, axis.pos = 1, add.axis = TRUE,
 	at = NULL, ...) {
-	# what we need; the palette, the breaks.
 	if (!is.null(breaks) && length(breaks) != (length(col) + 1))
 		stop("must have one more break than colour")
 	zlim = range(z, na.rm=TRUE)
@@ -627,19 +626,17 @@ image.scale = function(z, col, breaks = NULL, axis.pos = 1, add.axis = TRUE,
 		axis(axis.pos, at)
 }
 
-image.scale.factor <- function(z, col = heat.colors(nlevels(z)), axis.pos = 1, scale.frac = 0.3,
+image.scale.factor <- function(labels, colors, axis.pos = 1, scale.frac = 0.3,
 	scale.n = 15, ...) {
-	stopifnot(is.factor(z))
-	stopifnot(axis.pos %in% c(1,4))
 	frc = scale.frac
 	stre = scale.n
 	plot(1, 1, t="n", ylim = c(0,1), xlim = c(0,1), axes = FALSE,
 		xlab = "", ylab = "", xaxs = "i", yaxs = "i", ...)
-	n = nlevels(z)
-	if (n != length(col))
+	n = length(labels)
+	if (n != length(colors))
 		stop("# of colors must be equal to # of factor levels")
 	lb = (1:n - 0.5)/max(n, stre) # place of the labels
-	poly <- vector(mode="list", length(col))
+	poly <- vector(mode="list", length(colors))
 	breaks = (0:n) / max(n, stre)
 	if (n < stre) { # center
 		breaks = breaks + (stre - n)/(2 * stre)
@@ -649,18 +646,21 @@ image.scale.factor <- function(z, col = heat.colors(nlevels(z)), axis.pos = 1, s
 		poly[[i]] <- c(breaks[i], breaks[i+1], breaks[i+1], breaks[i])
 	for(i in seq(poly)) {
 		if (axis.pos %in% c(1,3))
-			polygon(poly[[i]], c(1,1,1-frc,1-frc), col=col[i], border=NA)
+			polygon(poly[[i]], c(1,1,1-frc,1-frc), col=colors[i], border=NA)
 		if (axis.pos %in% c(2,4))
-			polygon(c(0,0,frc,frc), poly[[i]], col=col[i], border=NA)
+			polygon(c(0,0,frc,frc), poly[[i]], col=colors[i], border=NA)
 	}
 	b = c(breaks[1], breaks[length(breaks)])
 	if (axis.pos %in% c(1,3)) {
+		text_y_loc = (1-frc)/1.05
+		if (axis.pos == 3) text_y_loc = text_y_loc - frc
 		lines(y = c(1,1-frc,1-frc,1,1), x = c(b[1],b[1],b[2],b[2],b[1]))
-		# text(x = 1.05 * frc, y = lb, levels(z), pos = axis.pos)
-		text(y = (1-frc)/1.05, x = lb, levels(z), pos = axis.pos)
+		text(y = text_y_loc, x = lb, labels, pos = axis.pos)
 	}
 	if (axis.pos %in% c(2,4)) {
+		text_x_loc = 1.05 * frc
+		if (axis.pos == 2) text_x_loc = text_x_loc + frc
 		lines(x = c(0,frc,frc,0,0), y = c(b[1],b[1],b[2],b[2],b[1]))
-		text(x = 1.05 * frc, y = lb, levels(z), pos = axis.pos)
+		text(x = text_x_loc, y = lb, labels, pos = axis.pos)
 	}
 }

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -30,8 +30,9 @@
 \title{Plot sf object}
 \usage{
 \method{plot}{sf}(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10,
-  breaks = "pretty", max.plot = ifelse(is.null(n <-
-  options("sf_max.plot")[[1]]), 9, n), key.pos = 4)
+  breaks = "pretty", max.plot = if (is.null(n <-
+  options("sf_max.plot")[[1]])) 9 else n, key.pos = if (ncol(x) > 2) NULL else
+  4)
 
 \method{plot}{sfc_POINT}(x, y, ..., pch = 1, cex = 1, col = 1, bg = 0,
   lwd = 1, lty = 1, type = "p", add = FALSE)
@@ -88,7 +89,7 @@ sf.colors(n = 10, cutoff.tails = c(0.35, 0.2), alpha = 1,
 
 \item{max.plot}{integer; lower boundary to maximum number of attributes to plot; the default value (9) can be overriden by setting the global option \code{sf_max.plot}, e.g. \code{options(sf_max.plot=2)}}
 
-\item{key.pos}{integer; which side to plot a color key: 1 bottom, 2 left, 3 top, 4 right. Set to \code{NULL} for no key.}
+\item{key.pos}{integer; which side to plot a color key: 1 bottom, 2 left, 3 top, 4 right. Set to \code{NULL} for no key. Currently ignored if multiple columns are plotted.}
 
 \item{pch}{plotting symbol}
 

--- a/man/plot.Rd
+++ b/man/plot.Rd
@@ -31,7 +31,7 @@
 \usage{
 \method{plot}{sf}(x, y, ..., col = NULL, main, pal = NULL, nbreaks = 10,
   breaks = "pretty", max.plot = ifelse(is.null(n <-
-  options("sf_max.plot")[[1]]), 9, n))
+  options("sf_max.plot")[[1]]), 9, n), key.pos = 4)
 
 \method{plot}{sfc_POINT}(x, y, ..., pch = 1, cex = 1, col = 1, bg = 0,
   lwd = 1, lty = 1, type = "p", add = FALSE)
@@ -87,6 +87,8 @@ sf.colors(n = 10, cutoff.tails = c(0.35, 0.2), alpha = 1,
 \item{breaks}{either a numeric vector with the actual breaks, or a name of a method accepted by the \code{style} argument of \link[classInt]{classIntervals}}
 
 \item{max.plot}{integer; lower boundary to maximum number of attributes to plot; the default value (9) can be overriden by setting the global option \code{sf_max.plot}, e.g. \code{options(sf_max.plot=2)}}
+
+\item{key.pos}{integer; which side to plot a color key: 1 bottom, 2 left, 3 top, 4 right. Set to \code{NULL} for no key.}
 
 \item{pch}{plotting symbol}
 


### PR DESCRIPTION
Here is the beginning of a color key. It is very basic and doubtless has bugs, but I just want to check you think the approach is OK. The drawing code is copied over from `sp` and simplified a bit.

I don't try to plot a key if there are multiple columns. It could be done, but it would require changing from `par(mfrow)` and/or `layout` to `split.screen` (which claims to nest nicely).