### PR TITLE
GeoJSON exported as ANSI not UTF-8 on Windows

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -40,7 +40,7 @@
 
 * add `st_collection_extract`, which, given an object with geometries of type `GEOMETRY` or `GEOMETRYCOLLECTION`, returns an object consisting only of elements of the specified type; by Andy Teucher, #482
 
-* `st_write` exports GeoJSON with ANSI encoding on Windows; #444
+* `st_write` exports GeoJSON with UTF-8 encoding on Windows; #444
 
 * move package methods from Imports: to Depends: ; #478
 


### PR DESCRIPTION
Unless I missed something?