### PR TITLE
Cleanup db tests

### DIFF
--- a/src/gdal_write.cpp
+++ b/src/gdal_write.cpp
@@ -238,7 +238,18 @@ void CPL_write_ogr(Rcpp::List obj, Rcpp::CharacterVector dsn, Rcpp::CharacterVec
 		poFeature->SetGeometryDirectly(geomv[i]);
 		if (poLayer->CreateFeature(poFeature) != OGRERR_NONE) {
 			Rcpp::Rcout << "Failed to create feature " << i << " in " << layer[0] << std::endl;
+		    // delete layer when  failing to  create feature
+		    OGRErr err = poDS->DeleteLayer(0);
 			GDALClose(poDS);
+			Rcpp::Rcout << "Failed to create feature " << i << " in " << layer[0] << std::endl;
+			if (err != OGRERR_NONE) {
+			    if (err == OGRERR_UNSUPPORTED_OPERATION) {
+			        Rcpp::Rcout << "Deleting layer not supported by driver `" << driver[0] << "'"  // #nocov
+                       << std::endl; // #nocov
+			    } else {
+			        Rcpp::Rcout << "Deleting layer `" << layer[0] << "' failed" << std::endl;
+			    }
+			}
 			Rcpp::stop("Feature creation failed.\n");
 		}
 		OGRFeature::DestroyFeature(poFeature); // deletes geom[i] as well

--- a/tests/testthat/test_postgis.R
+++ b/tests/testthat/test_postgis.R
@@ -248,6 +248,7 @@ test_that("new SRIDs are handled correctly", {
 
 if (can_con(pg)) {
     # cleanup
+    try(db_drop_table_schema(pg, "meuse_sf"), silent = TRUE)
     try(db_drop_table_schema(pg, "meuse_multi"), silent = TRUE)
     try(db_drop_table_schema(pg, "sf_meuse__"), silent = TRUE)
     try(db_drop_table_schema(pg, "sf_meuse2__"), silent = TRUE)

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -59,7 +59,6 @@ test_that("delete and update work (#304) ", {
   expect_warning(
   	expect_error(write_sf(x, shp, "x"), "Feature creation failed") ,
   	"non-point")# on osx el capitan: "c++ exception (unknown reason)"
-  expect_error(write_sf(x, shp, "x"), "already exists")
   expect_silent(x <- st_read(gpkg, quiet = TRUE))
   x <- st_sf(a = 1:2, geom = st_sfc(st_linestring(matrix(1:4,2,2)),
 	st_multilinestring(list(matrix(1:4,2,2), matrix(10:13,2,2)))))
@@ -68,6 +67,16 @@ test_that("delete and update work (#304) ", {
   expect_silent(x <- st_read(shp, quiet = TRUE))
   expect_silent(x <- read_sf(shp))
   expect_error(st_write(x, shp, driver = character(0))) # err
+})
+
+test_that("layer is deleted when fails to create features (#549)", {
+	skip_on_os("mac")
+	shp <- tempfile(fileext = ".shp")
+	x <- st_sf(a = 1:2, geom = st_sfc(st_point(0:1), st_multipoint(matrix(1:4,2,2))))
+	expect_warning(expect_error(st_write(x, shp, "x"), "Feature creation failed"),
+				   "non-point")
+	expect_warning(expect_error(st_write(x, shp, "x"), "Feature creation failed"),
+				   "non-point")
 })
 
 test_that("esri shapefiles shorten long field names", {

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -49,16 +49,20 @@ test_that("delete and update work (#304) ", {
   expect_output(st_write(x, gpkg, layer = "foo", delete_layer = TRUE), "Deleting layer `foo' failed")
   expect_output(st_write(x, gpkg, layer = "foo", delete_layer = TRUE), "Deleting layer `foo' using")
   expect_output(st_write(x, gpkg, layer = "foo", delete_layer = TRUE), "Updating layer `foo' to data source")
-  expect_error(st_write(x, gpkg, layer = ".", quiet = TRUE), "Layer creation failed")
+  expect_warning(
+  	expect_error(st_write(x, gpkg, layer = ".", quiet = TRUE),
+  				 "Layer creation failed"),
+  	"special characters")
   expect_silent(st_layers(gpkg))
   expect_output(st_write(x, gpkg, layer = "foo", delete_dsn = TRUE), "Deleting source")
   expect_silent(st_layers(gpkg))
-  expect_error(write_sf(x, shp, "x"), "Feature creation failed") # on osx el capitan: "c++ exception (unknown reason)"
+  expect_warning(
+  	expect_error(write_sf(x, shp, "x"), "Feature creation failed") ,
+  	"non-point")# on osx el capitan: "c++ exception (unknown reason)"
   expect_error(write_sf(x, shp, "x"), "already exists")
   expect_silent(x <- st_read(gpkg, quiet = TRUE))
   x <- st_sf(a = 1:2, geom = st_sfc(st_linestring(matrix(1:4,2,2)),
 	st_multilinestring(list(matrix(1:4,2,2), matrix(10:13,2,2)))))
-  # expect_output(st_write(x, shp))
   expect_silent(write_sf(x, shp, "x"))
   expect_silent(write_sf(x, shp))
   expect_silent(x <- st_read(shp, quiet = TRUE))

--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -33,41 +33,46 @@ test_that("sf can write units (#264)", {
     expect_equal(as.numeric(meuse[["length"]]), disc[["length"]])
 })
 
-test_that("delete and update work (#304) ", { 
+test_that("delete and update work (#304) ", {
   skip_if_not("GPKG" %in% st_drivers()$name)  # shapefiles can't write point+multipoint mix:
   skip_on_os("mac")
 
+  gpkg <- tempfile(fileext = ".gpkg")
+  shp <- tempfile(fileext = ".shp")
+
   x <- st_sf(a = 1:2, geom = st_sfc(st_point(0:1), st_multipoint(matrix(1:4,2,2))))
-  expect_error(st_write(x, "x.gpkg", layer = c("a", "b"), driver = "GPKG")) # error
-  expect_error(st_write(x, "x.gpkg",  driver = "foo")) # error
-  expect_output(st_write(x, "x.gpkg", delete_dsn = TRUE), "Deleting source")
-  expect_error(st_write(x, "x.gpkg", update = FALSE, quiet = TRUE), "Dataset already exists") 
-  expect_output(st_write(x, "x.gpkg", delete_dsn = TRUE), "Writing layer `x'")
-  expect_output(st_write(x, "x.gpkg", layer = "foo", delete_layer = TRUE), "Deleting layer `foo' failed")
-  expect_output(st_write(x, "x.gpkg", layer = "foo", delete_layer = TRUE), "Deleting layer `foo' using")
-  expect_output(st_write(x, "x.gpkg", layer = "foo", delete_layer = TRUE), "Updating layer `foo' to data source")
-  expect_error(st_write(x, "x.gpkg", layer = ".", quiet = TRUE), "Layer creation failed")
-  expect_silent(st_layers("x.gpkg"))
-  expect_output(st_write(x, "x.gpkg", layer = "foo", delete_dsn = TRUE), "Deleting source")
-  expect_silent(st_layers("x.gpkg"))
-  expect_error(write_sf(x, "x.shp", "x"), "Feature creation failed") # on osx el capitan: "c++ exception (unknown reason)"
-  expect_error(write_sf(x, "x.shp", "x"))
-  expect_silent(x <- st_read("x.gpkg", quiet = TRUE))
-  x <- st_sf(a = 1:2, geom = st_sfc(st_linestring(matrix(1:4,2,2)), 
+  expect_error(st_write(x, gpkg, layer = c("a", "b"), driver = "GPKG")) # error
+  expect_error(st_write(x, gpkg,  driver = "foo")) # error
+  expect_output(st_write(x, gpkg, delete_dsn = TRUE), "Deleting source")
+  expect_error(st_write(x, gpkg, update = FALSE, quiet = TRUE), "Dataset already exists")
+  expect_output(st_write(x, gpkg, delete_dsn = TRUE), "Writing layer ")
+  expect_output(st_write(x, gpkg, layer = "foo", delete_layer = TRUE), "Deleting layer `foo' failed")
+  expect_output(st_write(x, gpkg, layer = "foo", delete_layer = TRUE), "Deleting layer `foo' using")
+  expect_output(st_write(x, gpkg, layer = "foo", delete_layer = TRUE), "Updating layer `foo' to data source")
+  expect_error(st_write(x, gpkg, layer = ".", quiet = TRUE), "Layer creation failed")
+  expect_silent(st_layers(gpkg))
+  expect_output(st_write(x, gpkg, layer = "foo", delete_dsn = TRUE), "Deleting source")
+  expect_silent(st_layers(gpkg))
+  expect_error(write_sf(x, shp, "x"), "Feature creation failed") # on osx el capitan: "c++ exception (unknown reason)"
+  expect_error(write_sf(x, shp, "x"), "already exists")
+  expect_silent(x <- st_read(gpkg, quiet = TRUE))
+  x <- st_sf(a = 1:2, geom = st_sfc(st_linestring(matrix(1:4,2,2)),
 	st_multilinestring(list(matrix(1:4,2,2), matrix(10:13,2,2)))))
-  # expect_output(st_write(x, "x.shp"))
-  expect_silent(write_sf(x, "x.shp", "x"))
-  expect_silent(write_sf(x, "x.shp"))
-  expect_silent(x <- st_read("x.shp", quiet = TRUE))
-  expect_silent(x <- read_sf("x.shp"))
-  expect_error(st_write(x, "x.shp", driver = character(0))) # err
+  # expect_output(st_write(x, shp))
+  expect_silent(write_sf(x, shp, "x"))
+  expect_silent(write_sf(x, shp))
+  expect_silent(x <- st_read(shp, quiet = TRUE))
+  expect_silent(x <- read_sf(shp))
+  expect_error(st_write(x, shp, driver = character(0))) # err
 })
 
 test_that("esri shapefiles shorten long field names", {
+  shpx <- tempfile(fileext = ".shp")
+  shpy <- tempfile(fileext = ".shp")
   nc <- st_read(system.file("shape/nc.shp", package="sf"), "nc", crs = 4267, quiet = TRUE)
   nc$this.is.a.very.long.field.name = 1
-  expect_warning(st_write(nc, "ncx.shp", quiet = TRUE), "Field names abbreviated for ESRI Shapefile driver")
+  expect_warning(st_write(nc, shpx, quiet = TRUE), "Field names abbreviated for ESRI Shapefile driver")
   nc$this.is.a.very.long.field.name2 = 2
-  expect_warning(st_write(nc, "ncy.shp", quiet = TRUE), "Field names abbreviated for ESRI Shapefile driver")
-  # expect_error(st_write(nc, "ncy.shp", quiet = TRUE), "Non-unique field names")
+  expect_warning(st_write(nc, shpy, quiet = TRUE), "Field names abbreviated for ESRI Shapefile driver")
+  # expect_error(st_write(nc, shpz, quiet = TRUE), "Non-unique field names")
 })


### PR DESCRIPTION
It could be split in two P/R if needed... 
Summary:
* use temp files for writing
* cleanup database
* catch warnings
* delete layer on feature failure (#549)