### PR TITLE
print.sf: add 1000 as "default" print, add option max.sfprint

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -356,7 +356,7 @@ st_sf = function(..., agr = NA_agr_, row.names,
 
 #' @export
 print.sf = function(x, ..., n =
-		ifelse(options("max.print")[[1]] == 99999, 20, options("max.print")[[1]])) {
+		ifelse(options("max.print")[[1]] %in% c(99999,1000), getOption("max.sfprint", default = 20), options("max.print")[[1]])) {
 
 	geoms = which(vapply(x, function(col) inherits(col, "sfc"), TRUE))
 	nf = length(x) - length(geoms)


### PR DESCRIPTION
`print.sf` sets n looking at whether options("max.print")[[1]] == 99999. This is the default in R. However, Rstudio changes this default to 1000, so it would be great if 1000 was also considered a defautl value against which to set to a lower value. 

Further, the value of 20 might be still to high in some cases with large data (and also inconsistent with the value of 5 for print.sfc?). Ideally, users could set an option specifically for this, not necesarily changing max.options (whcih can screw a few things). Which is why I suggest replacing 20 with `getOption("max.sfprint", default = 20)`

Thanks

