### PR TITLE
Add unnest method for sf class

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: sf
 Version: 0.5-6
 Title: Simple Features for R
-Description: Support for simple features, a standardized way to encode spatial vector data. Binds 
+Description: Support for simple features, a standardized way to encode spatial vector data. Binds
     to GDAL for reading and writing data, to GEOS for geometrical operations, and to Proj.4 for projection
 	conversions and datum transformations.
 Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"), email = "edzer.pebesma@uni-muenster.de", comment = c(ORCID = "0000-0001-8049-7069")),
@@ -15,34 +15,34 @@ Authors@R: c(person("Edzer", "Pebesma", role = c("aut", "cre"), email = "edzer.p
 	person("Etienne", "Racine", role = "ctb"))
 Depends:
     R (>= 3.3.0), methods
-Imports: 
-    utils, 
-    stats, 
-    tools, 
-    graphics, 
-    grDevices, 
-    grid, 
-    Rcpp, 
+Imports:
+    utils,
+    stats,
+    tools,
+    graphics,
+    grDevices,
+    grid,
+    Rcpp,
     DBI (>= 0.5),
     units (>= 0.4-6),
 	classInt,
 	magrittr
-Suggests: 
-    geosphere (>= 1.5-5), 
+Suggests:
+    geosphere (>= 1.5-5),
     maps,
     rgdal,
     rgeos,
-    sp (>= 1.2-4), 
+    sp (>= 1.2-4),
 	raster,
 	spatstat,
 	tmap,
-    maptools, 
+    maptools,
 	RSQLite,
     RPostgreSQL,
     tibble,
 	rlang,
 	dplyr (>= 0.7-0),
-    tidyr (>= 0.7-1),
+    tidyr (> 0.7-2),
     ggplot2,
 	mapview,
     testthat,
@@ -80,7 +80,7 @@ Collate:
 	cast_sfc.R
 	graticule.R
 	datasets.R
-	aggregate.R 
+	aggregate.R
 	agr.R
 	maps.R
 	join.R

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -1,7 +1,7 @@
 ## dplyr methods:
 
 #' Dplyr verb methods for sf objects
-#' 
+#'
 #' Dplyr verb methods for sf objects. Geometries are sticky, use \link{as.data.frame} to let \code{dplyr}'s own methods drop them.
 #' @param .data data object of class \link{sf}
 #' @param .dots see corresponding function in package \code{dplyr}
@@ -105,7 +105,7 @@ select.sf <- function(.data, ...) {
 
 	ret <- dplyr::select(.data, ..., !! rlang::sym(sf_column))
 	st_as_sf(ret)
-} 
+}
 
 
 #' @name dplyr
@@ -169,7 +169,7 @@ summarise.sf <- function(.data, ..., .dots, do_union = TRUE) {
 #' @param value see original function docs
 #' @param na.rm see original function docs
 #' @param factor_key see original function docs
-#' @examples 
+#' @examples
 #' library(tidyr)
 #' nc %>% select(SID74, SID79, geometry) %>% gather(VAR, SID, -geometry) %>% summary()
 gather.sf <- function(data, key, value, ..., na.rm = FALSE, convert = FALSE, factor_key = FALSE) {
@@ -177,14 +177,14 @@ gather.sf <- function(data, key, value, ..., na.rm = FALSE, convert = FALSE, fac
 	if (! requireNamespace("rlang", quietly = TRUE))
 		stop("rlang required: install first?")
 
-    key = rlang::enquo(key)
-    value = rlang::enquo(value)
+  key = rlang::enquo(key)
+  value = rlang::enquo(value)
 
 	if (!requireNamespace("tidyr", quietly = TRUE))
 		stop("tidyr required: install first?")
 
 	class(data) <- setdiff(class(data), "sf")
-    st_as_sf(tidyr::gather(data, !!key, !!value, ..., 
+    st_as_sf(tidyr::gather(data, !!key, !!value, ...,
 		na.rm = na.rm, convert = convert, factor_key = factor_key),
 		sf_column_name = attr(data, "sf_column"))
 }
@@ -199,19 +199,19 @@ gather.sf <- function(data, key, value, ..., na.rm = FALSE, convert = FALSE, fac
 #' @examples
 #' library(tidyr)
 #' nc$row = 1:100 # needed for spread to work
-#' nc %>% select(SID74, SID79, geometry, row) %>% 
-#'		gather(VAR, SID, -geometry, -row) %>% 
+#' nc %>% select(SID74, SID79, geometry, row) %>%
+#'		gather(VAR, SID, -geometry, -row) %>%
 #'		spread(VAR, SID) %>% head()
 spread.sf <- function(data, key, value, fill = NA, convert = FALSE, drop = TRUE,
 	        sep = NULL) {
 
 	if (!requireNamespace("rlang", quietly = TRUE))
 		stop("rlang required: install first?")
-    key = rlang::enquo(key)
-    value = rlang::enquo(value)
+  key = rlang::enquo(key)
+  value = rlang::enquo(value)
 
 	class(data) <- setdiff(class(data), "sf")
-    st_as_sf(tidyr::spread(data, !!key, !!value, fill = fill, convert = convert, 
+    st_as_sf(tidyr::spread(data, !!key, !!value, fill = fill, convert = convert,
 		drop = drop, sep = sep), sf_column_name = attr(data, "sf_column"))
 }
 
@@ -275,7 +275,7 @@ separate.sf = function(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
 		stop("tidyr required: install first?")
 
 	class(data) <- setdiff(class(data), "sf")
-	st_as_sf(tidyr::separate(data, !!col, into = into, 
+	st_as_sf(tidyr::separate(data, !!col, into = into,
 		sep = sep, remove = remove, convert = convert, extra = extra, fill = fill, ...),
 			sf_column_name = attr(data, "sf_column"))
 }
@@ -286,6 +286,41 @@ unite.sf <- function(data, col, ..., sep = "_", remove = TRUE) {
 	class(data) <- setdiff(class(data), "sf")
 	st_as_sf(NextMethod(), sf_column_name = attr(data, "sf_column"))
 }
+
+#' @name dplyr
+#' @param ... see \link[tidyr]{unnest}
+#' @param .preserve see \link[tidyr]{unnest}
+#' @export
+unnest.sf = function(data, ..., .preserve = NULL) {
+	if (!requireNamespace("tidyr", quietly = TRUE) ||
+			utils::packageVersion("tidyr") <= "0.7.2")
+		stop("unnest requires tidyr > 0.7.2; install that first")
+	if (!requireNamespace("tidyselect"))
+		stop("unnest requires tidyselect; install that first")
+	if (!requireNamespace("rlang"))
+		stop("unnest requires rlang; install that first")
+
+	# The user might want to preserve other columns. Get these as a character
+	# vector of variable names, using any valid dplyr (i.e. rlang)
+	# variable selection syntax. By default, with .preserve = NULL, this will be
+	# empty. Note: the !!! is from rlang.
+	preserve = tidyselect::vars_select(names(data), !!! rlang::enquo(.preserve))
+	# Get the name of the geometry column(s)
+	sf_column_name = attr(data, "sf_column", exact = TRUE)
+	preserve_incl_sf = c(preserve, sf_column_name)
+
+	# Drop the "sf" class and call unnest again, providing the updated .preserve.
+	# (Normally it wouldn't be necessary to drop the class, but tidyr calls
+	# dplyr::transmute (not sf::transmute.sf), so the geometry column is
+	# inadvertantly included in some of the unnest.data.frame code.
+	# The .preserve argument will go through the vars_select/enquo
+	# process again in unnest.data.frame, but that's fine.
+	class(data) = setdiff(class(data), "sf")
+	ret = st_sf(NextMethod(.preserve = preserve_incl_sf),
+		sf_column_name = sf_column_name)
+	ret
+}
+
 
 
 ## tibble methods:

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -39,6 +39,8 @@ test_that("st_intersection of tbl returns tbl", {
 })
 
 test_that("unnest works", {
+  skip_if_not_installed("tidyr")
+  skip_if_not(utils::packageVersion("tidyr") > "0.7.2")
   nc = read_sf(system.file("shape/nc.shp", package = "sf")) %>%
     slice(1:2) %>%
     transmute(y = list(c("a"), c("b", "c")))

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -11,7 +11,7 @@ test_that("select works", {
 suppressMessages(library(tidyr))
 test_that("separate and unite work", {
   expect_true(nc %>% separate(CNTY_ID, c("a", "b"), sep = 2) %>% inherits("sf"))
-  expect_true(nc %>% separate(CNTY_ID, c("a", "b"), sep = 2) %>% 
+  expect_true(nc %>% separate(CNTY_ID, c("a", "b"), sep = 2) %>%
 	unite(CNTY_ID_NEW, c("a", "b"), sep = "") %>% inherits("sf"))
 })
 
@@ -31,9 +31,22 @@ test_that("sample_n etc work", {
 })
 
 test_that("st_intersection of tbl returns tbl", {
- nc = read_sf(system.file("shape/nc.shp", package="sf")) 
+ nc = read_sf(system.file("shape/nc.shp", package="sf"))
  nc = st_transform(nc[1:3,], 3857)
  st_agr(nc) = "constant"
  expect_is(nc, "tbl_df")
  expect_is(st_intersection(nc[1:3], nc[4:6]), "tbl_df")
+})
+
+test_that("unnest works", {
+  nc = read_sf(system.file("shape/nc.shp", package = "sf")) %>%
+    slice(1:2) %>%
+    transmute(y = list(c("a"), c("b", "c")))
+  unnest_explicit = unnest(nc, y)
+  unnest_implicit = unnest(nc)
+  # The second row is duplicated because the "b" and "c" become separate rows
+  expected = nc[c(1,2,2), ] %>% mutate(y = c("a", "b", "c"))
+  # Would use expect_equal, but doesn't work with geometry cols
+  expect_identical(unnest_explicit, expected)
+  expect_identical(unnest_implicit, expected)
 })


### PR DESCRIPTION
Changes:
- Create unnest.sf method, automatically adding the geometry column(s) to the list of list columns that will *not* be unnested.
- Add tests.
- Increase suggested version of tidyr to > 0.7.2 to be able to use `.preserve`. (Note, the CRAN and Github versions are both at 0.7.2, so the tests currently fail.)
- Unindent a few lines in `gather.sf` and `spread.sf` for clearer expression (not part of `if` block).
- Auto-remove a bunch of trailing spaces.

Do you want to hold off merging this until tidyr does a release? 