### PR TITLE
Update rwinlib gdal2 stack

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,28 +1,31 @@
+VERSION = 2.2.3
 COMPILED_BY ?= gcc-4.6.3
-RWINLIB = lib${subst gcc,,${COMPILED_BY}}${R_ARCH}
+RWINLIB = ../windows/gdal2-$(VERSION)
+TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 
 PKG_CPPFLAGS =\
-	-I../windows/gdal2-2.2.0/include/gdal \
-	-I../windows/gdal2-2.2.0/include/geos \
-	-I../windows/gdal2-2.2.0/include/proj
+	-I$(RWINLIB)/include/gdal \
+	-I$(RWINLIB)/include/geos \
+	-I$(RWINLIB)/include/proj
 
 PKG_LIBS = \
-	-L../windows/gdal2-2.2.0/${RWINLIB} \
+	-L$(RWINLIB)/$(TARGET) \
 	-lgdal -lsqlite3 -lspatialite -lproj -lgeos_c -lgeos  \
-	-ljson-c -lnetcdf -lpq -lintl -lwebp -lcurl -lssh2 -lssl -lcrypto \
-	-lhdf5_hl -lhdf5 -lexpat -lfreexl -lcfitsio \
-	-lpng16 -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lszip -lz \
+	-ljson-c -lnetcdf -lmariadbclient -lpq -lintl -lwebp -lcurl -lssh2 -lssl -lcrypto \
+	-lkea -lhdf5_cpp -lhdf5_hl -lhdf5 -lexpat -lfreexl -lcfitsio \
+	-lmfhdf -ldf -lxdr \
+	-lopenjp2 -ljasper -lpng16 -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lszip -lz \
 	-lodbc32 -lodbccp32 -liconv -lpsapi -lws2_32 -lcrypt32 -lwldap32 -lsecur32 -lgdi32
 
 all: clean winlibs
 
-CXX_STD=CXX11
+CXX_STD = CXX11
 
 winlibs:
 	mkdir -p ../inst
-	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla "../tools/winlibs.R"
-	cp -r ../windows/gdal2-2.2.0/share/gdal ../inst/
-	cp -r ../windows/gdal2-2.2.0/share/proj ../inst/
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla "../tools/winlibs.R" $(VERSION)
+	cp -r $(RWINLIB)/share/gdal ../inst/
+	cp -r $(RWINLIB)/share/proj ../inst/
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -2,9 +2,11 @@ if(getRversion() < "3.3.0") {
   stop("Your version of R is too old. This package requires R-3.3.0 or newer on Windows.")
 }
 
-# Download gdal-2.2.0 from rwinlib
-if(!file.exists("../windows/gdal2-2.2.0/include/gdal/gdal.h")){
-  download.file("https://github.com/rwinlib/gdal2/archive/v2.2.0.zip", "lib.zip", quiet = TRUE)
+# For details see: https://github.com/rwinlib/gdal2
+VERSION <- commandArgs(TRUE)
+if(!file.exists(sprintf("../windows/gdal2-%s/include/gdal/gdal.h", VERSION))){
+  if(getRversion() < "3.3.0") setInternet2()
+  download.file(sprintf("https://github.com/rwinlib/gdal2/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
Updates Windows stack to gdal 2.2.3 and adds drivers for mysql, openjpeg, jasper, hdf4, and kealib.

