### PR TITLE
Fix #644 - failing binary ops on tbl_dfs with common column names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * add `st_as_sfc.raw` method
 
+* Bugfix: binary operations (`st_intersection`, `st_difference`, etc) no longer fail when operating on data frames of class `"tbl_df"` with common column names; #644
+
 # version 0.6-0
 
 * add `pillar` to Imports: to provide method for printing WKT geometries in tibbles

--- a/R/geom.R
+++ b/R/geom.R
@@ -743,9 +743,9 @@ geos_op2_df = function(x, y, geoms) {
 		warning("attribute variables are assumed to be spatially constant throughout all geometries",
 			call. = FALSE)
 	if (inherits(x, "tbl_df")) {
-		if (!requireNamespace("dplyr", quietly = TRUE))
-			stop("package dplyr required: install first?")
-		df = dplyr::tbl_df(df)
+		if (!requireNamespace("tibble", quietly = TRUE))
+			stop("package tibble required: install first?")
+		df = tibble::as_tibble(df)
 	}
 	df[[ attr(x, "sf_column") ]] = geoms
 	st_sf(df, sf_column_name = attr(x, "sf_column"))

--- a/R/geom.R
+++ b/R/geom.R
@@ -128,7 +128,7 @@ st_geos_binop = function(op, x, y, par = 0.0, pattern = NA_character_,
 #' @param x object of class \code{sf}, \code{sfc} or \code{sfg}
 #' @param y object of class \code{sf}, \code{sfc} or \code{sfg}, defaults to \code{x}
 #' @param ... ignored
-#' @param dist_fun deprecated 
+#' @param dist_fun deprecated
 #' @param by_element logical; if \code{TRUE}, return a vector with distance between the first elements of \code{x} and \code{y}, the second, etc. if \code{FALSE}, return the dense matrix with all pairwise distances.
 #' @param which character; if equal to \code{Haussdorf} or \code{Frechet}, Hausdorff resp. Frechet distances are returned
 #' @param par for \code{which} equal to \code{Haussdorf} or \code{Frechet}, use a positive value this to densify the geometry
@@ -159,7 +159,7 @@ st_distance = function(x, y, ..., dist_fun, by_element = FALSE, which = "distanc
 		if (by_element) {
 			crs = st_crs(x)
 			dist_ll = function(x, y, tolerance)
-				lwgeom::st_geod_distance(st_sfc(x, crs = crs), st_sfc(y, crs = crs), 
+				lwgeom::st_geod_distance(st_sfc(x, crs = crs), st_sfc(y, crs = crs),
 					tolerance = tolerance)
 			d = mapply(dist_ll, x, y, tolerance = tolerance)
 			units(d) = units(crs_parameters(st_crs(x))$SemiMajor)
@@ -244,7 +244,7 @@ st_disjoint		= function(x, y = x, sparse = TRUE, prepared = TRUE) {
 	# disjoint = !intersects :
 	if (sparse)
 		sgbp(lapply(int, function(g) setdiff(1:length(st_geometry(y)), g)),
-			predicate = "disjoint", 
+			predicate = "disjoint",
 			ncol = attr(int, "ncol"),
 			region.id = attr(int, "region.id"))
 	else
@@ -737,7 +737,7 @@ geos_op2_df = function(x, y, geoms) {
 	if (inherits(y, "sf")) {
 		all_constant_y = all_constant(y)
 		st_geometry(y) = NULL
-		df = cbind(df, y[idx[,2], , drop = FALSE])
+		df = data.frame(df, y[idx[,2], , drop = FALSE])
 	}
 	if (! (all_constant_x && all_constant_y))
 		warning("attribute variables are assumed to be spatially constant throughout all geometries",
@@ -852,10 +852,10 @@ st_difference.sfg = function(x, y)
 
 #' @name geos_binary_ops
 #' @export
-#' @details When \code{st_difference} is called with a single argument, 
+#' @details When \code{st_difference} is called with a single argument,
 #' overlapping areas are erased from geometries that are indexed at greater
-#' numbers in the argument to \code{x}; geometries that are empty 
-#' or contained fully inside geometries with higher priority are removed entirely. 
+#' numbers in the argument to \code{x}; geometries that are empty
+#' or contained fully inside geometries with higher priority are removed entirely.
 #' The \code{st_difference.sfc} method with a single argument returns an object with
 #' an \code{"idx"} attribute with the orginal index for returned geometries.
 st_difference.sfc = function(x, y) {

--- a/tests/testthat/test_geos.R
+++ b/tests/testthat/test_geos.R
@@ -241,12 +241,10 @@ test_that("binary operations work on sf objects with common column names", {
 	pol2 <- pol1 + 1
 	sf1 <- st_sf(id = 1, pol1)
 	sf2 <- st_sf(id = 2, pol2)
-
+	# Test as regular data.frames
 	expect_is(st_intersection(sf1, sf2), "sf")
-
 	# Convert to tibbles
 	sf1 <- st_as_sf(tibble::as_tibble(sf1))
 	sf2 <- st_as_sf(tibble::as_tibble(sf2))
-
-	expect_is(st_intersection(sf1, sf2), c("sf", "tbl"))
+	expect_is(st_intersection(sf1, sf2), c("sf", "tbl_df"))
 })

--- a/tests/testthat/test_geos.R
+++ b/tests/testthat/test_geos.R
@@ -72,7 +72,7 @@ test_that("geos ops give warnings and errors on longlat", {
 test_that("st_area() works on GEOMETRY in longlat (#131)", {
   single <- list(rbind(c(0,0), c(1,0), c(1, 1), c(0,1), c(0,0))) %>% st_polygon()
   multi <- list(single + 2, single + 4) %>% st_multipolygon()
-  
+
   w <- st_sfc(single + 0.1, multi)
   expect_equal(st_area(w), 1:2)
   expect_silent(st_area(st_set_crs(w, 4326))) # outcome might depend on backend used: lwgeom if proj.4 < 490, else proj.4
@@ -92,33 +92,33 @@ test_that("geom operations work on sfg or sfc or sf", {
   expect_silent(st_buffer(pnc, 1000))
   expect_silent(st_buffer(gpnc, 1000))
   expect_silent(st_buffer(gpnc[[1L]], 1000))
-  
+
   expect_silent(st_boundary(pnc))
   expect_that(st_boundary(gpnc), is_a("sfc_MULTILINESTRING"))
   expect_that(st_boundary(gpnc[[1L]]), is_a("MULTILINESTRING"))
-  
+
   expect_true(inherits(st_convex_hull(pnc)$geometry, "sfc_POLYGON"))
   expect_true(inherits(st_convex_hull(gpnc), "sfc_POLYGON"))
   expect_true(inherits(st_convex_hull(gpnc[[1L]]), "POLYGON"))
-  
+
   expect_silent(st_simplify(pnc, FALSE, 1e4))
   expect_silent(st_simplify(gpnc, FALSE, 1e4))
   expect_silent(st_simplify(gpnc[[1L]], FALSE, 1e4))
 
-  if (sf:::CPL_geos_version() >= "3.4.0") {  
+  if (sf:::CPL_geos_version() >= "3.4.0") {
    expect_silent(st_triangulate(pnc))
    expect_that(st_triangulate(gpnc), is_a("sfc_GEOMETRYCOLLECTION"))
    expect_that(st_triangulate(gpnc[[1]]), is_a("GEOMETRYCOLLECTION"))
   }
-  
+
   expect_silent(st_polygonize(lnc))
-  expect_silent(st_polygonize(glnc)) 
-  expect_silent(st_polygonize(glnc[[1]])) 
-  
+  expect_silent(st_polygonize(glnc))
+  expect_silent(st_polygonize(glnc[[1]]))
+
   expect_that(st_line_merge(lnc), is_a("sf"))
   expect_that(st_line_merge(glnc), is_a("sfc"))
   expect_that(st_line_merge(glnc[[3]]), is_a("sfg"))
-  
+
   expect_silent(st_centroid(lnc))
   expect_that(st_centroid(glnc),  is_a("sfc_POINT"))
   expect_that(st_centroid(glnc[[1]]),  is_a("POINT"))
@@ -126,7 +126,7 @@ test_that("geom operations work on sfg or sfc or sf", {
   expect_silent(st_point_on_surface(lnc))
   expect_that(st_point_on_surface(glnc),  is_a("sfc_POINT"))
   expect_that(st_point_on_surface(glnc[[1]]),  is_a("POINT"))
-  
+
   expect_silent(st_segmentize(lnc, 10000))
   expect_silent(st_segmentize(glnc, 10000))
   expect_silent(st_segmentize(glnc[[1]], 10000))
@@ -183,7 +183,7 @@ test_that("st_difference works with partially overlapping geometries", {
 	# erase overlaps
 	out1 = st_difference(in1)
 	out2 = st_difference(in2)
-	# check that output class is correct 
+	# check that output class is correct
 	expect_is(out1, "sfc")
 	expect_is(out2, "sf")
 	# check that output geometries are valid
@@ -234,4 +234,19 @@ test_that("st_difference works with fully contained geometries", {
 	#expect_equal(out1[[2]][[1]], correct_geom[[2]][[1]])
 	#expect_equal(out2[[1]][[1]], correct_geom[[1]][[1]])
 	#expect_equal(out2[[2]][[1]], correct_geom[[2]][[1]])
+})
+
+test_that("binary operations work on sf objects with common column names", {
+	pol1 <- st_sfc(st_polygon(list(cbind(c(0,3,3,0,0),c(0,0,3,3,0)))))
+	pol2 <- pol1 + 1
+	sf1 <- st_sf(id = 1, pol1)
+	sf2 <- st_sf(id = 2, pol2)
+
+	expect_is(st_intersection(sf1, sf2), "sf")
+
+	# Convert to tibbles
+	sf1 <- st_as_sf(tibble::as_tibble(sf1))
+	sf2 <- st_as_sf(tibble::as_tibble(sf2))
+
+	expect_is(st_intersection(sf1, sf2), c("sf", "tbl"))
 })


### PR DESCRIPTION
I also took the liberty of replacing `dplyr::tbl_df()` with `tibble::as_tibble()`.

Apologies for the extraneous whitespace changes - that's RStudio automatically stripping trailing whitespace - didn't notice until I made the PR. I can revert them if you like.