### PR TITLE
Add documentation of WKT and EWKT conventions used in st_as_text.

### DIFF
--- a/R/wkt.R
+++ b/R/wkt.R
@@ -69,7 +69,11 @@ prnt.GEOMETRYCOLLECTION = function(x, ..., EWKT = TRUE) {
 #' @param x object of class \code{sfg}, \code{sfc} or \code{crs}
 #' @param ... modifiers; in particular \code{digits} can be passed to control the number of digits used
 #' @name st_as_text
-#' @details To suppress printing of SRID, \code{EWKT=FALSE} can be passed as parameter.
+#' @details The returned WKT representation of simple feature geometry conforms to the
+#' \href{http://www.opengeospatial.org/standards/sfa}{simple features access} specification and extensions,
+#' \href{http://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT}{known as EWKT}, supported by
+#' PostGIS and other simple features implementations for addition of SRID to a WKT string.
+#'
 #' @export
 st_as_text = function(x, ...) UseMethod("st_as_text")
 
@@ -77,6 +81,7 @@ st_as_text = function(x, ...) UseMethod("st_as_text")
 #' @export
 #' @examples
 #' st_as_text(st_point(1:2))
+#' st_as_text(st_sfc(st_point(c(-90,40)), crs = 4326), EWKT = TRUE)
 st_as_text.sfg = function(x, ...) {
 	switch(class(x)[2],
 		POINT = prnt.POINT(x, ...),

--- a/man/st_as_text.Rd
+++ b/man/st_as_text.Rd
@@ -31,8 +31,12 @@ st_as_text(x, ...)
 Return Well-known Text representation of simple feature geometry or coordinate reference system
 }
 \details{
-To suppress printing of SRID, \code{EWKT=FALSE} can be passed as parameter.
+The returned WKT representation of simple feature geometry conforms to the
+\href{http://www.opengeospatial.org/standards/sfa}{simple features access} specification and extensions,
+\href{http://postgis.net/docs/using_postgis_dbmanagement.html#EWKB_EWKT}{known as EWKT}, supported by
+PostGIS and other simple features implementations for addition of SRID to a WKT string.
 }
 \examples{
 st_as_text(st_point(1:2))
+st_as_text(st_sfc(st_point(c(-90,40)), crs = 4326), EWKT = TRUE)
 }


### PR DESCRIPTION
Per discussion over in #653.

Note that I removed details line that `EWKT=FALSE` would suppress SRID. `EWKT=FALSE` is the default for `sfc` and `TRUE` for `sfg`. Since `sfg` doesn't carry a CRS, the `EWKT=TRUE` there doesn't cause the SRID to be included.