### PR TITLE
test drivers' write mode

### DIFF
--- a/tests/testthat/test_write.R
+++ b/tests/testthat/test_write.R
@@ -6,7 +6,7 @@ meuse <- st_as_sf(meuse, coords = c("x", "y"), crs = 28992)
 test_that("sf can write to all writable formats", {
     # write to all formats available
     tf <- tempfile()
-    drvs <- st_drivers()$name[sapply(st_drivers()$name, 
+    drvs <- st_drivers()$name[sapply(st_drivers()$name,
 		function(x) is_driver_can(x, operation = "write"))] %>% as.character()
     excluded_drivers = c("gps", # requires options
                          "gtm", # doesn't handle attributes
@@ -14,12 +14,10 @@ test_that("sf can write to all writable formats", {
                          "map", # doesn't support points
 						 "ods") # generates valgrind error
     for (ext in setdiff(names(extension_map[extension_map %in% drvs]), excluded_drivers)) {
-        st_write(meuse, paste0(tf, ".", ext), quiet = TRUE)
-		cat(paste(ext, "\n"))
+        expect_silent(st_write(meuse, paste0(tf, ".", ext), quiet = TRUE))
 	}
 	if ("netCDF" %in% drvs) {
-		st_write(st_transform(meuse, st_crs(4326)), paste0(tf, ".nc"), quiet = TRUE)
-		cat(paste(".nc", "\n"))
+		expect_silent(st_write(st_transform(meuse, st_crs(4326)), paste0(tf, ".nc"), quiet = TRUE))
 	}
 })
 


### PR DESCRIPTION
I wonder if there was a reason to not put expectations on the `st_write()`, but there should be expectations. It seems to pass locally...