### PR TITLE
Update required gdal version & fix error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -54,7 +54,7 @@ Suggests:
 	rmarkdown
 LinkingTo: Rcpp
 VignetteBuilder: knitr
-SystemRequirements: GDAL (>= 2.0.0), GEOS (>= 3.3.0), PROJ.4 (>= 4.8.0)
+SystemRequirements: GDAL (>= 2.1.0), GEOS (>= 3.3.0), PROJ.4 (>= 4.8.0)
 License: GPL-2 | MIT + file LICENSE
 URL: https://github.com/r-spatial/sf/
 BugReports: https://github.com/r-spatial/sf/issues/

--- a/src/gdal_utils.cpp
+++ b/src/gdal_utils.cpp
@@ -1,11 +1,13 @@
 #include "cpl_port.h"
 #include "cpl_conv.h" // CPLFree()
 
-#include "gdal_utils.h" // requires 2.1
+#include "gdal_version.h"
 
 #if GDAL_VERSION_MAJOR == 2 && GDAL_VERSION_MINOR < 1
-# error "Insufficient GDAL version, 2.1 required"
+#error "Insufficient GDAL version, 2.1 required"
 #endif
+
+#include "gdal_utils.h" // requires 2.1
 
 #include "Rcpp.h"
 #define NO_GDAL_CPP_HEADERS


### PR DESCRIPTION
The inclusion of gdal_utils.h requires gdal > 2.1, this was not reflected in the DESCRIPTION file.

Additionally, the ordering of version check and #include "gdal_utils.h" resulted in the compiler failing at the include rather than the more useful error message. I've just swapped those lines and included gdal_version.h to ensure the macro values are defined.

It seems like this check should be moved into configure.ac but I'm not that ambitious at the moment.