### PR TITLE
Specify environment where to look for .stop_geos()

### DIFF
--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -41,7 +41,7 @@ static void __errorHandler(const char *fmt, ...) { // #nocov start
 	p = buf + strlen(buf) - 1;
 	if(strlen(buf) > 0 && *p == '\n') *p = '\0';
 
-	Rcpp::Function error(".stop_geos");
+	Rcpp::Function error(".stop_geos", Rcpp::Environment::namespace_env("sf"));
 	error(buf);
 
 	return; // #nocov end


### PR DESCRIPTION
Necessary if *sf* is loaded but not attached.