### PR TITLE
`check_join()`: Typo in `stop()`?

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -1,6 +1,6 @@
 check_join = function(x, y) {
 	if (inherits(y, "sf"))
-		stop("y should be a data.frame; for spatial joins, use st_join", .call = FALSE)
+		stop("y should be a data.frame; for spatial joins, use st_join", call. = FALSE)
 }
 
 sf_join = function(g, sf_column) {


### PR DESCRIPTION
Trivial remarks. Please close if it is my misreads.
`stop()` has no argument *.call*.  I think this is possibly a typo in *call.*.

Currently, this message is output as follows. (including a redundant text of `FALSE`)

```r
library(sf)
# Linking to GEOS 3.5.1, GDAL 2.1.2, proj.4 4.9.3

a = st_sf(a = 1:3,
          geom = st_sfc(st_point(c(1, 1)),
                        st_point(c(2, 2)),
                        st_point(c(3, 3))))
b = st_sf(a = 11:14,
          geom = st_sfc(st_point(c(10, 10)),
                        st_point(c(2, 2)),
                        st_point(c(2, 2)),
                        st_point(c(3, 3))))

dplyr::left_join(a, b)
# Error in check_join(x, y) : 
#  y should be a data.frame; for spatial joins, use st_joinFALSE
```

After applying this patch, it becomes as below.

```r
dplyr::left_join(a, b)
# Error: y should be a data.frame; for spatial joins, use st_join
```