### PR TITLE
Change autoconf tests to use C++11

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -58,7 +58,7 @@ Suggests:
 	rmarkdown
 LinkingTo: Rcpp
 VignetteBuilder: knitr
-SystemRequirements: GDAL (>= 2.0.1), GEOS (>= 3.4.0), PROJ.4 (>= 4.8.0)
+SystemRequirements: C++11, GDAL (>= 2.0.1), GEOS (>= 3.4.0), PROJ.4 (>= 4.8.0)
 License: GPL-2 | MIT + file LICENSE
 URL: https://github.com/r-spatial/sf/
 BugReports: https://github.com/r-spatial/sf/issues/

--- a/configure
+++ b/configure
@@ -2045,10 +2045,25 @@ fi
 
 RBIN="${R_HOME}/bin/R"
 
+RVER=`"${RBIN}" --version | head -1 | cut -f3 -d" "`
+RVER_MAJOR=`echo ${RVER} | cut  -f1 -d"."`
+RVER_MINOR=`echo ${RVER} | cut  -f2 -d"."`
+RVER_PATCH=`echo ${RVER} | cut  -f3 -d"."`
+
+if test $RVER_MAJOR -lt 3 -o $RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3; then
+    as_fn_error $? "sf is not compatible with R versions before 3.3.0" "$LINENO" 5
+else
+    if test $RVER_MINOR -eq 3; then
+        CXX11=`"${RBIN}" CMD config CXX1X`
+        CXX11STD=`"${RBIN}" CMD config CXX1XSTD`
+    else
+        CXX11=`"${RBIN}" CMD config CXX11`
+        CXX11STD=`"${RBIN}" CMD config CXX11STD`
+    fi
+fi
+
 # pick all flags for testing from R
 : ${CC=`"${RBIN}" CMD config CC`}
-: ${CXX11=`"${RBIN}" CMD config CXX11`}
-: ${CXX11STD=`"${RBIN}" CMD config CXX11STD`}
 : ${CXX=${CXX11} ${CXX11STD}}
 : ${CPP=`"${RBIN}" CMD config CPP`}
 : ${CFLAGS=`"${RBIN}" CMD config CFLAGS`}

--- a/configure
+++ b/configure
@@ -656,7 +656,6 @@ infodir
 docdir
 oldincludedir
 includedir
-runstatedir
 localstatedir
 sharedstatedir
 sysconfdir
@@ -734,7 +733,6 @@ datadir='${datarootdir}'
 sysconfdir='${prefix}/etc'
 sharedstatedir='${prefix}/com'
 localstatedir='${prefix}/var'
-runstatedir='${localstatedir}/run'
 includedir='${prefix}/include'
 oldincludedir='/usr/include'
 docdir='${datarootdir}/doc/${PACKAGE}'
@@ -987,15 +985,6 @@ do
   | -silent | --silent | --silen | --sile | --sil)
     silent=yes ;;
 
-  -runstatedir | --runstatedir | --runstatedi | --runstated \
-  | --runstate | --runstat | --runsta | --runst | --runs \
-  | --run | --ru | --r)
-    ac_prev=runstatedir ;;
-  -runstatedir=* | --runstatedir=* | --runstatedi=* | --runstated=* \
-  | --runstate=* | --runstat=* | --runsta=* | --runst=* | --runs=* \
-  | --run=* | --ru=* | --r=*)
-    runstatedir=$ac_optarg ;;
-
   -sbindir | --sbindir | --sbindi | --sbind | --sbin | --sbi | --sb)
     ac_prev=sbindir ;;
   -sbindir=* | --sbindir=* | --sbindi=* | --sbind=* | --sbin=* \
@@ -1133,7 +1122,7 @@ fi
 for ac_var in	exec_prefix prefix bindir sbindir libexecdir datarootdir \
 		datadir sysconfdir sharedstatedir localstatedir includedir \
 		oldincludedir docdir infodir htmldir dvidir pdfdir psdir \
-		libdir localedir mandir runstatedir
+		libdir localedir mandir
 do
   eval ac_val=\$$ac_var
   # Remove trailing slashes.
@@ -1286,7 +1275,6 @@ Fine tuning of the installation directories:
   --sysconfdir=DIR        read-only single-machine data [PREFIX/etc]
   --sharedstatedir=DIR    modifiable architecture-independent data [PREFIX/com]
   --localstatedir=DIR     modifiable single-machine data [PREFIX/var]
-  --runstatedir=DIR       modifiable per-process data [LOCALSTATEDIR/run]
   --libdir=DIR            object code libraries [EPREFIX/lib]
   --includedir=DIR        C header files [PREFIX/include]
   --oldincludedir=DIR     C header files for non-gcc [/usr/include]
@@ -2059,7 +2047,9 @@ RBIN="${R_HOME}/bin/R"
 
 # pick all flags for testing from R
 : ${CC=`"${RBIN}" CMD config CC`}
-: ${CXX=`"${RBIN}" CMD config CXX`}
+: ${CXX11=`"${RBIN}" CMD config CXX11`}
+: ${CXX11STD=`"${RBIN}" CMD config CXX11STD`}
+: ${CXX=${CXX11} ${CXX11STD}}
 : ${CPP=`"${RBIN}" CMD config CPP`}
 : ${CFLAGS=`"${RBIN}" CMD config CFLAGS`}
 : ${CPPFLAGS=`"${RBIN}" CMD config CPPFLAGS`}

--- a/configure.ac
+++ b/configure.ac
@@ -12,7 +12,9 @@ RBIN="${R_HOME}/bin/R"
 
 # pick all flags for testing from R
 : ${CC=`"${RBIN}" CMD config CC`}
-: ${CXX=`"${RBIN}" CMD config CXX`}
+: ${CXX11=`"${RBIN}" CMD config CXX11`}
+: ${CXX11STD=`"${RBIN}" CMD config CXX11STD`}
+: ${CXX=${CXX11} ${CXX11STD}}
 : ${CPP=`"${RBIN}" CMD config CPP`}
 : ${CFLAGS=`"${RBIN}" CMD config CFLAGS`}
 : ${CPPFLAGS=`"${RBIN}" CMD config CPPFLAGS`}

--- a/configure.ac
+++ b/configure.ac
@@ -10,10 +10,25 @@ fi
 
 RBIN="${R_HOME}/bin/R"
 
+RVER=`"${RBIN}" --version | head -1 | cut -f3 -d" "`
+RVER_MAJOR=`echo ${RVER} | cut  -f1 -d"."`
+RVER_MINOR=`echo ${RVER} | cut  -f2 -d"."`
+RVER_PATCH=`echo ${RVER} | cut  -f3 -d"."`
+
+if test [$RVER_MAJOR -lt 3] -o [$RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3]; then
+    AC_MSG_ERROR([sf is not compatible with R versions before 3.3.0])
+else
+    if test [$RVER_MINOR -eq 3]; then
+        CXX11=`"${RBIN}" CMD config CXX1X`
+        CXX11STD=`"${RBIN}" CMD config CXX1XSTD`
+    else
+        CXX11=`"${RBIN}" CMD config CXX11`
+        CXX11STD=`"${RBIN}" CMD config CXX11STD`
+    fi
+fi
+
 # pick all flags for testing from R
 : ${CC=`"${RBIN}" CMD config CC`}
-: ${CXX11=`"${RBIN}" CMD config CXX11`}
-: ${CXX11STD=`"${RBIN}" CMD config CXX11STD`}
 : ${CXX=${CXX11} ${CXX11STD}}
 : ${CPP=`"${RBIN}" CMD config CPP`}
 : ${CFLAGS=`"${RBIN}" CMD config CFLAGS`}


### PR DESCRIPTION
I just had a failure when attempting to install sf on my macbook. Homebrew recently updated gdal to 2.3.0 which apparently requires C++11 within some of its headers. This was causing a failure with the gdal linking checks.

```
checking GDAL: linking with --libs and --dep-libs... no
In file included from gdal_test.cpp:1:
In file included from /usr/local/Cellar/gdal/2.3.0/include/gdal.h:45:
/usr/local/Cellar/gdal/2.3.0/include/cpl_port.h:187:6: error: Must have C++11 or newer.
#    error Must have C++11 or newer.
     ^
1 error generated.
In file included from gdal_test.cpp:1:
In file included from /usr/local/Cellar/gdal/2.3.0/include/gdal.h:45:
/usr/local/Cellar/gdal/2.3.0/include/cpl_port.h:187:6: error: Must have C++11 or newer.
#    error Must have C++11 or newer.
     ^
1 error generated.
```

Since a C++ standard isn't specified my compiler was defaulting to C++98 and hence the failure.

I've updated configure.ac to construct CXX from R CMD config's CXX11 and CXX11STD and also added C++11 to SystemRequirements in the DESCRIPTION file (Writing R Extensions states that either this **or** CXX_STD=CXX11 in Makevars should be included  but that seems a  bit silly).

It may be worth including an explicit test for C++11 compatibility within configure.ac, I have not tested on a system with an older compiler -- it seems like everything will fail at some point  but the error messages may be confusing.

This is also likely going to affect rgdal at somepoint (@rsbivand).