### PR TITLE
Enhance `c.sfc()` empty geometry output

### DIFF
--- a/R/sfc.R
+++ b/R/sfc.R
@@ -151,6 +151,7 @@ c.sfc = function(..., recursive = FALSE) {
 	attributes(ret) = attributes(lst[[1]]) # crs
 	class(ret) = cls
 	attr(ret, "bbox") = compute_bbox(ret) # dispatch on class
+	attr(ret, "n_empty") = sum(sapply(lst, st_is_empty))
 	if (! eq)
 		attr(ret, "classes") = vapply(ret, class, rep("", 3))[2L,]
 	ret

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -151,11 +151,7 @@ c.sfc = function(..., recursive = FALSE) {
 	attributes(ret) = attributes(lst[[1]]) # crs
 	class(ret) = cls
 	attr(ret, "bbox") = compute_bbox(ret) # dispatch on class
-	attr(ret, "n_empty") =
-		sum(unlist(
-			lapply(lapply(lst, attributes),
-				   `[[`, "n_empty"),
-			recursive = FALSE))
+	attr(ret, "n_empty") = sum(sapply(lapply(lst, attributes), `[[`, "n_empty"))
 	if (! eq)
 		attr(ret, "classes") = vapply(ret, class, rep("", 3))[2L,]
 	ret

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -151,7 +151,11 @@ c.sfc = function(..., recursive = FALSE) {
 	attributes(ret) = attributes(lst[[1]]) # crs
 	class(ret) = cls
 	attr(ret, "bbox") = compute_bbox(ret) # dispatch on class
-	attr(ret, "n_empty") = sum(sapply(lst, st_is_empty))
+	attr(ret, "n_empty") =
+		sum(unlist(
+			lapply(lapply(lst, attributes),
+				   `[[`, "n_empty"),
+			recursive = FALSE))
 	if (! eq)
 		attr(ret, "classes") = vapply(ret, class, rep("", 3))[2L,]
 	ret

--- a/tests/testthat/test_sfc.R
+++ b/tests/testthat/test_sfc.R
@@ -103,3 +103,10 @@ test_that("rep.sfc works", {
 	st_sfc(st_point(0:1), st_point(0:1), crs = 4326),
   	rep(st_sfc(st_point(0:1), crs=4326), 2))
 })
+
+test_that("c.sfc n_empty returns sum of st_is_empty(sfg)", {
+	pt1 <- st_point(c(NA_real_, NA_real_))
+	pt2 <- st_point(0:1)
+	expect_equal(attr(c(st_sfc(pt1), st_sfc(pt1)), "n_empty"), 2L)
+	expect_equal(attr(c(st_sfc(pt1), st_sfc(pt2)), "n_empty"), 1L)
+})


### PR DESCRIPTION
First proposal #773 

I modified to assign the sum of `st_is_empty()` of sfg object given to `st_sfc (...)`.

Example:

```r
library(sf)
c(st_sfc(st_point(c(NA_real_, NA_real_))),
  st_sfc(st_point(c(NA_real_, NA_real_))),
  st_sfc(st_point(c(134, 43))))
# Geometry set for 3 features  (with 2 geometries empty)
# geometry type:  POINT
# dimension:      XY
# bbox:           xmin: 134 ymin: 43 xmax: 134 ymax: 43
# epsg (SRID):    NA
# proj4string:    NA
# POINT EMPTY
# POINT EMPTY
# POINT (134 43)
```