### PR TITLE
Use older tic version to fix deployment of docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ before_install:
   - psql -d postgis -c "GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO travis"
   - createdb empty
   - psql -d empty -c "CREATE EXTENSION postgis;"
-  - R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic"); tic::prepare_all_stages()'
+  - R -q -e 'install.packages("devtools"); devtools::install_github("ropenscilabs/tic@4ad0920c425c0e66809a1ae23837655f4dca997d"); tic::prepare_all_stages()'
 
 after_success:
   - dropdb postgis


### PR DESCRIPTION
Works: https://travis-ci.org/pat-s/sf/jobs/397207994

The most recent `tic` version seems to be broken; https://github.com/ropenscilabs/tic/issues/56

cross-ref https://github.com/r-spatial/sf/pull/687#issuecomment-400220114