### PR TITLE
Update: enabled CRS for 'Extent' objects.

### DIFF
--- a/R/bbox.R
+++ b/R/bbox.R
@@ -177,10 +177,10 @@ st_bbox.Raster = function(obj, ...) {
 
 #' @name st_bbox
 #' @export
-st_bbox.Extent = function(obj, ...) {
+st_bbox.Extent = function(obj, ..., crs = NA_crs_) {
 	if (!requireNamespace("raster", quietly = TRUE))
 		stop("package raster required, please install it first")
-	structure(bb_wrap(c(obj@xmin, obj@ymin, obj@xmax, obj@ymax)), crs = NA_crs_)
+	structure(bb_wrap(c(obj@xmin, obj@ymin, obj@xmax, obj@ymax)), crs = st_crs(crs))
 }
 
 #' @name st_bbox


### PR DESCRIPTION
For reasons of convenience, I think that `st_bbox.Extent()` should allow the specification of a valid CRS. In its current form, no relevant information is conveyed through the 'crs' attribute of the resulting `bbox` object. 

```r
ext = raster::extent(mapview::breweries)
bbx = sf::st_bbox(ext, crs = 4326) # 'crs' is currently passed to '...', and hence ignored here
str(bbx)
#  'bbox' Named num [1:4] 9.46 48.9 11.94 50.44
#  - attr(*, "names")= chr [1:4] "xmin" "ymin" "xmax" "ymax"
#  - attr(*, "crs")=List of 2
#   ..$ epsg       : int NA
#   ..$ proj4string: chr NA
#   ..- attr(*, "class")= chr "crs"
```

However, such information might come in particularly handy when dealing with spatial extents. Using the modified code from pull request:

```r
bbx2 = st_bbox(ext, crs = 4326)
str(bbx2)
#  'bbox' Named num [1:4] 9.46 48.9 11.94 50.44
#  - attr(*, "names")= chr [1:4] "xmin" "ymin" "xmax" "ymax"
#  - attr(*, "crs")=List of 2
#   ..$ epsg       : int 4326
#   ..$ proj4string: chr "+proj=longlat +datum=WGS84 +no_defs"
#   ..- attr(*, "class")= chr "crs"
```