### PR TITLE
fix #808: field.types don't get dropped anymore

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -289,7 +289,7 @@ setMethod("dbWriteTable", c("PostgreSQLConnection", "character", "sf"),
 setMethod("dbWriteTable", c("DBIObject", "character", "sf"),
           function(conn, name, value, ..., row.names = FALSE, overwrite = FALSE,
                    append = FALSE, field.types = NULL, factorsAsCharacter = TRUE, binary = TRUE) {
-              field.types <- if (is.null(field.types)) dbDataType(conn, value)
+          	if (is.null(field.types)) field.types <- dbDataType(conn, value)
               # DBI cannot set field types with append
               if (append) field.types <- NULL
               tryCatch({

--- a/R/db.R
+++ b/R/db.R
@@ -260,7 +260,7 @@ get_new_postgis_srid <- function(conn) {
 setMethod("dbWriteTable", c("PostgreSQLConnection", "character", "sf"),
           function(conn, name, value, ..., row.names = FALSE, overwrite = FALSE,
                    append = FALSE, field.types = NULL, factorsAsCharacter = TRUE, binary = TRUE) {
-              field.types <- if (is.null(field.types)) dbDataType(conn, value)
+              if (is.null(field.types)) field.types <- dbDataType(conn, value)
               tryCatch({
                   dbWriteTable(conn, name, to_postgis(conn, value, binary),..., row.names = row.names,
                                overwrite = overwrite, append = append,


### PR DESCRIPTION


``` r
library("RPostgreSQL")
#> Loading required package: DBI
library("sf")
#> Linking to GEOS 3.6.1, GDAL 2.2.3, proj.4 4.9.3
pg_con <-
    dbConnect(RPostgreSQL::PostgreSQL(),
              host = "localhost",
              dbname = "postgis")

nc_sf <-
    st_read(system.file("shape/nc.shp", package = "sf"), 
            quiet = TRUE)[c("AREA", "NAME", "geometry")]

ft <-
    c("AREA"     = "numeric(4,3)",
      "NAME"     = "varchar(12)",
      "geometry" = "geometry(MultiPolygon,4267)") # crs is EPSG 4267, not 4326

dbWriteTable(
    conn = pg_con, 
    name = "nc_ft", 
    value = nc_sf, 
    field.types = ft,
    overwrite = TRUE
)
#> [1] TRUE

dbGetQuery(
    pg_con, 
    "SELECT a.attname as column_name, format_type(a.atttypid, a.atttypmod) AS data_type
FROM pg_attribute a
JOIN pg_class b ON (a.attrelid = b.relfilenode)
WHERE b.relname = 'nc_ft' and a.attstattarget = -1;"
)
#>   column_name                   data_type
#> 1        AREA                numeric(4,3)
#> 2        NAME       character varying(12)
#> 3    geometry geometry(MultiPolygon,4267)
#> 4        AREA                numeric(4,3)
#> 5        NAME       character varying(12)
```

Not sure why there are two entries for “AREA” and “NAME” now, but the fields are unique.

``` r
dbListFields(pg_con, "nc_ft")
#> [1] "AREA"     "NAME"     "geometry"

dbDisconnect(pg_con)
#> [1] TRUE
```
