### PR TITLE
geos 3.7.0rc1 workaround; GEOS_VERSION_PATCH is 0rc1

### DIFF
--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -5,8 +5,10 @@
 # if GEOS_VERSION_MINOR >= 5
 #  define HAVE350
 # endif
-# if GEOS_VERSION_MINOR == 6 && GEOS_VERSION_PATCH >= 1
-#  define HAVE361
+# if GEOS_VERSION_MINOR == 6 
+#  if GEOS_VERSION_PATCH >= 1
+#   define HAVE361
+#  endif
 # endif
 # if GEOS_VERSION_MINOR >= 7
 #  define HAVE361


### PR DESCRIPTION
When GEOS_VERSION_MINOR is 6, the test for PATCH >= 1 fails in 3.7.0rc1 because PATCH is 0rc1. Testing for MINOR first avoids looking at PATCH.