### PR TITLE
buffer styles

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -177,8 +177,8 @@ CPL_geos_snap <- function(sfc0, sfc1, tolerance) {
     .Call('_sf_CPL_geos_snap', PACKAGE = 'sf', sfc0, sfc1, tolerance)
 }
 
-CPL_geos_op <- function(op, sfc, bufferDist, nQuadSegs, dTolerance, preserveTopology, bOnlyEdges = 1L) {
-    .Call('_sf_CPL_geos_op', PACKAGE = 'sf', op, sfc, bufferDist, nQuadSegs, dTolerance, preserveTopology, bOnlyEdges)
+CPL_geos_op <- function(op, sfc, bufferDist, nQuadSegs, dTolerance, preserveTopology, bOnlyEdges = 1L, endCapStyle = 0L, joinStyle = 0L, mitreLimit = 1L) {
+    .Call('_sf_CPL_geos_op', PACKAGE = 'sf', op, sfc, bufferDist, nQuadSegs, dTolerance, preserveTopology, bOnlyEdges, endCapStyle, joinStyle, mitreLimit)
 }
 
 CPL_geos_voronoi <- function(sfc, env, dTolerance = 0.0, bOnlyEdges = 1L) {

--- a/R/geom.R
+++ b/R/geom.R
@@ -374,18 +374,76 @@ st_is_within_distance = function(x, y, dist, sparse = TRUE) {
 #' \code{dist} is a \code{units} object, it should be convertible to \code{arc_degree} if
 #' \code{x} has geographic coordinates, and to \code{st_crs(x)$units} otherwise
 #' @param nQuadSegs integer; number of segments per quadrant (fourth of a circle), for all or per-feature
+#' @param endCapStyle character; style of line ends, one of 'ROUND', 'FLAT', 'SQUARE'
+#' @param joinStyle character; style of line joins, one of 'ROUND', 'MITRE', 'BEVEL'
+#' @param mitreLimit numeric; limit of extension for a join if \code{joinStyle} 'MITRE' is used (default 1.0, minimum 0.0)
 #' @return an object of the same class of \code{x}, with manipulated geometry.
 #' @export
-#' @details \code{st_buffer} computes a buffer around this geometry/each geometry
-st_buffer = function(x, dist, nQuadSegs = 30)
+#' @details \code{st_buffer} computes a buffer around this geometry/each geometry. If any of \code{endCapStyle},
+#' \code{joinStyle}, or \code{mitreLimit} are set to non-default values ('ROUND', 'ROUND', 1.0 respectively) then
+#' the underlying 'buffer with style' GEOS function is used.
+#' @examples
+#'
+#' ## st_buffer, style options (taken from rgeos gBuffer)
+#' l1 = st_as_sfc("LINESTRING(0 0,1 5,4 5,5 2,8 2,9 4,4 6.5)")
+#' op = par(mfrow=c(2,3))
+#' plot(st_buffer(l1, dist = 1, endCapStyle="ROUND"), reset = FALSE, main = "endCapStyle: ROUND")
+#' plot(l1,col='blue',add=TRUE)
+#' plot(st_buffer(l1, dist = 1, endCapStyle="FLAT"), reset = FALSE, main = "endCapStyle: FLAT")
+#' plot(l1,col='blue',add=TRUE)
+#' plot(st_buffer(l1, dist = 1, endCapStyle="SQUARE"), reset = FALSE, main = "endCapStyle: SQUARE")
+#' plot(l1,col='blue',add=TRUE)
+#' plot(st_buffer(l1, dist = 1, nQuadSegs=1), reset = FALSE, main = "nQuadSegs: 1")
+#' plot(l1,col='blue',add=TRUE)
+#' plot(st_buffer(l1, dist = 1, nQuadSegs=2), reset = FALSE, main = "nQuadSegs: 2")
+#' plot(l1,col='blue',add=TRUE)
+#' plot(st_buffer(l1, dist = 1, nQuadSegs= 5), reset = FALSE, main = "nQuadSegs: 5")
+#' plot(l1,col='blue',add=TRUE)
+#' par(op)
+#'
+#'
+#' l2 = st_as_sfc("LINESTRING(0 0,1 5,3 2)")
+#' op = par(mfrow = c(2, 3))
+#' plot(st_buffer(l2, dist = 1, joinStyle="ROUND"), reset = FALSE, main = "joinStyle: ROUND")
+#' plot(l2, col = 'blue', add = TRUE)
+#' plot(st_buffer(l2, dist = 1, joinStyle="MITRE"), reset = FALSE, main = "joinStyle: MITRE")
+#' plot(l2, col= 'blue', add = TRUE)
+#' plot(st_buffer(l2, dist = 1, joinStyle="BEVEL"), reset = FALSE, main = "joinStyle: BEVEL")
+#' plot(l2, col= 'blue', add=TRUE)
+#' plot(st_buffer(l2, dist = 1, joinStyle="MITRE" , mitreLimit=0.5), reset = FALSE, main = "mitreLimit: 0.5")
+#' plot(l2, col = 'blue', add = TRUE)
+#' plot(st_buffer(l2, dist = 1, joinStyle="MITRE",mitreLimit=1), reset = FALSE, main = "mitreLimit: 1")
+#' plot(l2, col = 'blue', add = TRUE)
+#' plot(st_buffer(l2, dist = 1, joinStyle="MITRE",mitreLimit=3), reset = FALSE, main = "mitreLimit: 3")
+#' plot(l2, col = 'blue', add = TRUE)
+#' par(op)
+st_buffer = function(x, dist, nQuadSegs = 30,
+					 endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0)
 	UseMethod("st_buffer")
 
 #' @export
-st_buffer.sfg = function(x, dist, nQuadSegs = 30)
-	get_first_sfg(st_buffer(st_sfc(x), dist, nQuadSegs = nQuadSegs))
+st_buffer.sfg = function(x, dist, nQuadSegs = 30,
+						 endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0)
+	get_first_sfg(st_buffer(st_sfc(x), dist, nQuadSegs = nQuadSegs,
+							endCapStyle = endCapStyle, joinStyle = joinStyle, mitreLimit = mitreLimit))
 
+.process_style_opts = function(endCapStyle, joinStyle, mitreLimit) {
+	styls = list(with_styles = FALSE, endCapStyle = NA, joinStyle = NA, mitreLimit = NA)
+	if (endCapStyle == "ROUND" && joinStyle == "ROUND" && mitreLimit == 1) return(styls)
+	ecs = match(endCapStyle, c("ROUND", "FLAT", "SQUARE"))
+	js = match(joinStyle, c("ROUND", "MITRE", "BEVEL"))
+	if (is.na(mitreLimit) || !mitreLimit > 0) stop("mitreLimit must be > 0")
+	if (is.na(ecs)) stop("endCapStyle must be 'ROUND', 'FLAT', or 'SQUARE'")
+	if (is.na(js))  stop("joinStyle must be 'ROUND', 'MITRE', or 'BEVEL'")
+	styls$with_styles = TRUE
+	styls$endCapStyle = ecs
+	styls$joinStyle = js
+	styls$mitreLimit = mitreLimit
+	styls
+}
 #' @export
-st_buffer.sfc = function(x, dist, nQuadSegs = 30) {
+st_buffer.sfc = function(x, dist, nQuadSegs = 30,
+						 endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0) {
 	if (isTRUE(st_is_longlat(x))) {
 		warning("st_buffer does not correctly buffer longitude/latitude data")
 		if (inherits(dist, "units"))
@@ -401,12 +459,29 @@ st_buffer.sfc = function(x, dist, nQuadSegs = 30) {
 	}
 	dist = rep(dist, length.out = length(x))
 	nQ = rep(nQuadSegs, length.out = length(x))
-	st_sfc(CPL_geos_op("buffer", x, dist, nQ, numeric(0), logical(0)))
+	styles = .process_style_opts(endCapStyle, joinStyle, mitreLimit)
+	if (styles$with_styles) {
+		endCapStyle = rep(styles$endCapStyle, length.out = length(x))
+		joinStyle = rep(styles$joinStyle, length.out = length(x))
+		mitreLimit = rep(styles$mitreLimit, length.out = length(x))
+		if (any(endCapStyle == 2) && (st_geometry_type(x) == "POINT" || st_geometry_type(x) == "MULTIPOINT")) {
+			stop("Flat capstyle is incompatible with POINT/MULTIPOINT geometries")
+		}
+		if (dist < 0 && !st_geometry_type(x) %in% c("POLYGON", "MULTIPOLYGON")) {
+			stop("Negative width values may only be used with POLYGON or MULTIPOLYGON geometries")
+		}
+
+		st_sfc(CPL_geos_op("buffer_with_style", x, dist, nQ, numeric(0), logical(0), endCapStyle = endCapStyle, joinStyle = joinStyle, mitreLimit = mitreLimit))
+	} else {
+		st_sfc(CPL_geos_op("buffer", x, dist, nQ, numeric(0), logical(0)))
+	}
 }
 
 #' @export
-st_buffer.sf <- function(x, dist, nQuadSegs = 30) {
-	st_geometry(x) <- st_buffer(st_geometry(x), dist, nQuadSegs)
+st_buffer.sf = function(x, dist, nQuadSegs = 30,
+						endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0) {
+	st_geometry(x) = st_buffer(st_geometry(x), dist, nQuadSegs,
+							   endCapStyle = endCapStyle, joinStyle = joinStyle, mitreLimit = mitreLimit)
 	x
 }
 

--- a/man/geos_unary.Rd
+++ b/man/geos_unary.Rd
@@ -16,7 +16,8 @@
 \alias{st_segmentize}
 \title{Geometric unary operations on simple feature geometry sets}
 \usage{
-st_buffer(x, dist, nQuadSegs = 30)
+st_buffer(x, dist, nQuadSegs = 30, endCapStyle = "ROUND",
+  joinStyle = "ROUND", mitreLimit = 1)
 
 st_boundary(x)
 
@@ -49,6 +50,12 @@ st_segmentize(x, dfMaxLength, ...)
 
 \item{nQuadSegs}{integer; number of segments per quadrant (fourth of a circle), for all or per-feature}
 
+\item{endCapStyle}{character; style of line ends, one of 'ROUND', 'FLAT', 'SQUARE'}
+
+\item{joinStyle}{character; style of line joins, one of 'ROUND', 'MITRE', 'BEVEL'}
+
+\item{mitreLimit}{numeric; limit of extension for a join if \code{joinStyle} 'MITRE' is used (default 1.0, minimum 0.0)}
+
 \item{preserveTopology}{logical; carry out topology preserving simplification? May be specified for each, or for all feature geometries.}
 
 \item{dTolerance}{numeric; tolerance parameter, specified for all or for each feature geometry.}
@@ -70,7 +77,9 @@ an object of the same class of \code{x}, with manipulated geometry.
 Geometric unary operations on simple feature geometry sets. These are all generics, with methods for \code{sfg}, \code{sfc} and \code{sf} objects, returning an object of the same class.
 }
 \details{
-\code{st_buffer} computes a buffer around this geometry/each geometry
+\code{st_buffer} computes a buffer around this geometry/each geometry. If any of \code{endCapStyle},
+\code{joinStyle}, or \code{mitreLimit} are set to non-default values ('ROUND', 'ROUND', 1.0 respectively) then
+the underlying 'buffer with style' GEOS function is used.
 
 \code{st_boundary} returns the boundary of a geometry
 
@@ -95,6 +104,40 @@ Geometric unary operations on simple feature geometry sets. These are all generi
 \code{st_segmentize} adds points to straight lines
 }
 \examples{
+
+## st_buffer, style options (taken from rgeos gBuffer)
+l1 = st_as_sfc("LINESTRING(0 0,1 5,4 5,5 2,8 2,9 4,4 6.5)")
+op = par(mfrow=c(2,3))
+plot(st_buffer(l1, dist = 1, endCapStyle="ROUND"), reset = FALSE, main = "endCapStyle: ROUND")
+plot(l1,col='blue',add=TRUE)
+plot(st_buffer(l1, dist = 1, endCapStyle="FLAT"), reset = FALSE, main = "endCapStyle: FLAT")
+plot(l1,col='blue',add=TRUE)
+plot(st_buffer(l1, dist = 1, endCapStyle="SQUARE"), reset = FALSE, main = "endCapStyle: SQUARE")
+plot(l1,col='blue',add=TRUE)
+plot(st_buffer(l1, dist = 1, nQuadSegs=1), reset = FALSE, main = "nQuadSegs: 1")
+plot(l1,col='blue',add=TRUE)
+plot(st_buffer(l1, dist = 1, nQuadSegs=2), reset = FALSE, main = "nQuadSegs: 2")
+plot(l1,col='blue',add=TRUE)
+plot(st_buffer(l1, dist = 1, nQuadSegs= 5), reset = FALSE, main = "nQuadSegs: 5")
+plot(l1,col='blue',add=TRUE)
+par(op)
+
+
+l2 = st_as_sfc("LINESTRING(0 0,1 5,3 2)")
+op = par(mfrow = c(2, 3))
+plot(st_buffer(l2, dist = 1, joinStyle="ROUND"), reset = FALSE, main = "joinStyle: ROUND")
+plot(l2, col = 'blue', add = TRUE)
+plot(st_buffer(l2, dist = 1, joinStyle="MITRE"), reset = FALSE, main = "joinStyle: MITRE")
+plot(l2, col= 'blue', add = TRUE)
+plot(st_buffer(l2, dist = 1, joinStyle="BEVEL"), reset = FALSE, main = "joinStyle: BEVEL")
+plot(l2, col= 'blue', add=TRUE)
+plot(st_buffer(l2, dist = 1, joinStyle="MITRE" , mitreLimit=0.5), reset = FALSE, main = "mitreLimit: 0.5")
+plot(l2, col = 'blue', add = TRUE)
+plot(st_buffer(l2, dist = 1, joinStyle="MITRE",mitreLimit=1), reset = FALSE, main = "mitreLimit: 1")
+plot(l2, col = 'blue', add = TRUE)
+plot(st_buffer(l2, dist = 1, joinStyle="MITRE",mitreLimit=3), reset = FALSE, main = "mitreLimit: 3")
+plot(l2, col = 'blue', add = TRUE)
+par(op)
 nc = st_read(system.file("shape/nc.shp", package="sf"))
 plot(st_convex_hull(nc))
 plot(nc, border = grey(.5))

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -543,8 +543,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // CPL_geos_op
-Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc, Rcpp::NumericVector bufferDist, Rcpp::IntegerVector nQuadSegs, Rcpp::NumericVector dTolerance, Rcpp::LogicalVector preserveTopology, int bOnlyEdges);
-RcppExport SEXP _sf_CPL_geos_op(SEXP opSEXP, SEXP sfcSEXP, SEXP bufferDistSEXP, SEXP nQuadSegsSEXP, SEXP dToleranceSEXP, SEXP preserveTopologySEXP, SEXP bOnlyEdgesSEXP) {
+Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc, Rcpp::NumericVector bufferDist, Rcpp::IntegerVector nQuadSegs, Rcpp::NumericVector dTolerance, Rcpp::LogicalVector preserveTopology, int bOnlyEdges, Rcpp::IntegerVector endCapStyle, Rcpp::IntegerVector joinStyle, Rcpp::NumericVector mitreLimit);
+RcppExport SEXP _sf_CPL_geos_op(SEXP opSEXP, SEXP sfcSEXP, SEXP bufferDistSEXP, SEXP nQuadSegsSEXP, SEXP dToleranceSEXP, SEXP preserveTopologySEXP, SEXP bOnlyEdgesSEXP, SEXP endCapStyleSEXP, SEXP joinStyleSEXP, SEXP mitreLimitSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -555,7 +555,10 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< Rcpp::NumericVector >::type dTolerance(dToleranceSEXP);
     Rcpp::traits::input_parameter< Rcpp::LogicalVector >::type preserveTopology(preserveTopologySEXP);
     Rcpp::traits::input_parameter< int >::type bOnlyEdges(bOnlyEdgesSEXP);
-    rcpp_result_gen = Rcpp::wrap(CPL_geos_op(op, sfc, bufferDist, nQuadSegs, dTolerance, preserveTopology, bOnlyEdges));
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type endCapStyle(endCapStyleSEXP);
+    Rcpp::traits::input_parameter< Rcpp::IntegerVector >::type joinStyle(joinStyleSEXP);
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type mitreLimit(mitreLimitSEXP);
+    rcpp_result_gen = Rcpp::wrap(CPL_geos_op(op, sfc, bufferDist, nQuadSegs, dTolerance, preserveTopology, bOnlyEdges, endCapStyle, joinStyle, mitreLimit));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -990,7 +993,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_sf_CPL_geos_normalize", (DL_FUNC) &_sf_CPL_geos_normalize, 1},
     {"_sf_CPL_geos_union", (DL_FUNC) &_sf_CPL_geos_union, 2},
     {"_sf_CPL_geos_snap", (DL_FUNC) &_sf_CPL_geos_snap, 3},
-    {"_sf_CPL_geos_op", (DL_FUNC) &_sf_CPL_geos_op, 7},
+    {"_sf_CPL_geos_op", (DL_FUNC) &_sf_CPL_geos_op, 10},
     {"_sf_CPL_geos_voronoi", (DL_FUNC) &_sf_CPL_geos_voronoi, 4},
     {"_sf_CPL_geos_op2", (DL_FUNC) &_sf_CPL_geos_op2, 3},
     {"_sf_CPL_geos_version", (DL_FUNC) &_sf_CPL_geos_version, 1},

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -1,11 +1,11 @@
 #define GEOS_USE_ONLY_R_API // prevents using non-thread-safe GEOSxx functions without _r extension.
 #include <geos_c.h>
 
-#if GEOS_VERSION_MAJOR == 3 
+#if GEOS_VERSION_MAJOR == 3
 # if GEOS_VERSION_MINOR >= 5
 #  define HAVE350
 # endif
-# if GEOS_VERSION_MINOR == 6 
+# if GEOS_VERSION_MINOR == 6
 #  if GEOS_VERSION_PATCH >= 1
 #   define HAVE361
 #  endif
@@ -30,7 +30,7 @@
 typedef int (* dist_fn)(GEOSContextHandle_t, const GEOSGeometry *, const GEOSGeometry *, double *);
 typedef int (* dist_parfn)(GEOSContextHandle_t, const GEOSGeometry *, const GEOSGeometry *, double, double *);
 typedef char (* log_fn)(GEOSContextHandle_t, const GEOSGeometry *, const GEOSGeometry *);
-typedef char (* log_prfn)(GEOSContextHandle_t, const GEOSPreparedGeometry *, 
+typedef char (* log_prfn)(GEOSContextHandle_t, const GEOSPreparedGeometry *,
 	const GEOSGeometry *);
 typedef GEOSGeom (* geom_fn)(GEOSContextHandle_t, const GEOSGeom, const GEOSGeom);
 
@@ -67,7 +67,7 @@ static void __warningHandler(const char *fmt, ...) {
 
 	Rcpp::Function warning("warning");
 	warning(buf);
-	
+
 	return;
 }
 
@@ -129,7 +129,7 @@ Rcpp::List sfc_from_geometry(GEOSContextHandle_t hGEOSCtxt, std::vector<GEOSGeom
 	Rcpp::List out(geom.size());
 	GEOSWKBWriter *wkb_writer = GEOSWKBWriter_create_r(hGEOSCtxt);
 	GEOSWKBWriter_setOutputDimension_r(hGEOSCtxt, wkb_writer, dim);
-	// empty point, binary, with R NA's (not NaN's); GEOS can't WKB empty points, 
+	// empty point, binary, with R NA's (not NaN's); GEOS can't WKB empty points,
 	// so we need to work around; see also https://trac.osgeo.org/postgis/ticket/3031
 	// > sf:::CPL_raw_to_hex(st_as_binary(st_point()))
 	// [1] "0101000000a20700000000f07fa20700000000f07f"
@@ -236,7 +236,7 @@ Rcpp::LogicalVector get_dense(std::vector<size_t> items, int length) {
 */
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, double par = 0.0, 
+Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, double par = 0.0,
 		std::string pattern = "", bool prepared = false) {
 
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
@@ -277,7 +277,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 #endif
 			else
 				Rcpp::stop("distance function not supported"); // #nocov
-			
+
 			for (size_t i = 0; i < gmv0.size(); i++) {
 				for (size_t j = 0; j < gmv1.size(); j++) {
 					double dist = -1.0;
@@ -339,8 +339,8 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 
 		if (op == "equals_exact") { // has it's own signature, needing `par':
 			for (int i = 0; i < sfc0.length(); i++) { // row
-				Rcpp::LogicalVector rowi(sfc1.length()); 
-				for (int j = 0; j < sfc1.length(); j++) 
+				Rcpp::LogicalVector rowi(sfc1.length());
+				for (int j = 0; j < sfc1.length(); j++)
 					rowi(j) = chk_(GEOSEqualsExact_r(hGEOSCtxt, gmv0[i], gmv1[j], par));
 				sparsemat[i] = get_which(rowi);
 				R_CheckUserInterrupt();
@@ -418,7 +418,7 @@ Rcpp::List CPL_geos_binop(Rcpp::List sfc0, Rcpp::List sfc1, std::string op, doub
 }
 
 // [[Rcpp::export]]
-Rcpp::CharacterVector CPL_geos_is_valid_reason(Rcpp::List sfc) { 
+Rcpp::CharacterVector CPL_geos_is_valid_reason(Rcpp::List sfc) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	std::vector<GEOSGeom> gmv = geometries_from_sfc(hGEOSCtxt, sfc, NULL);
@@ -438,7 +438,7 @@ Rcpp::CharacterVector CPL_geos_is_valid_reason(Rcpp::List sfc) {
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = true) { 
+Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = true) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	int notice = 0;
@@ -446,10 +446,10 @@ Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = tru
 		if (sfc.size() > 1)
 			Rcpp::stop("NA_on_exception will only work reliably with length 1 sfc objects"); // #nocov
 #ifdef HAVE350
-		GEOSContext_setNoticeMessageHandler_r(hGEOSCtxt, 
+		GEOSContext_setNoticeMessageHandler_r(hGEOSCtxt,
 			(GEOSMessageHandler_r) __emptyNoticeHandler, (void *) &notice);
-		GEOSContext_setErrorMessageHandler_r(hGEOSCtxt, 
-			(GEOSMessageHandler_r) __countErrorHandler, (void *) &notice); 
+		GEOSContext_setErrorMessageHandler_r(hGEOSCtxt,
+			(GEOSMessageHandler_r) __countErrorHandler, (void *) &notice);
 #endif
 	}
 	std::vector<GEOSGeom> gmv = geometries_from_sfc(hGEOSCtxt, sfc, NULL); // where notice might be set!
@@ -471,7 +471,7 @@ Rcpp::LogicalVector CPL_geos_is_valid(Rcpp::List sfc, bool NA_on_exception = tru
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalVector CPL_geos_is_simple(Rcpp::List sfc) { 
+Rcpp::LogicalVector CPL_geos_is_simple(Rcpp::List sfc) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	Rcpp::LogicalVector out(sfc.length());
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, NULL);
@@ -484,7 +484,7 @@ Rcpp::LogicalVector CPL_geos_is_simple(Rcpp::List sfc) {
 }
 
 // [[Rcpp::export]]
-Rcpp::LogicalVector CPL_geos_is_empty(Rcpp::List sfc) { 
+Rcpp::LogicalVector CPL_geos_is_empty(Rcpp::List sfc) {
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	Rcpp::LogicalVector out(sfc.length());
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, NULL);
@@ -513,7 +513,7 @@ Rcpp::List CPL_geos_normalize(Rcpp::List sfc) { // #nocov start
 } // #nocov end
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) { 
+Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) {
 	int dim = 2;
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	std::vector<GEOSGeom> gmv = geometries_from_sfc(hGEOSCtxt, sfc, &dim);
@@ -537,14 +537,14 @@ Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) {
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_snap(Rcpp::List sfc0, Rcpp::List sfc1, Rcpp::NumericVector tolerance) { 
+Rcpp::List CPL_geos_snap(Rcpp::List sfc0, Rcpp::List sfc1, Rcpp::NumericVector tolerance) {
 	int dim = 2;
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	std::vector<GEOSGeom> gmv0 = geometries_from_sfc(hGEOSCtxt, sfc0, &dim);
 	std::vector<GEOSGeom> gmv1 = geometries_from_sfc(hGEOSCtxt, sfc1, &dim);
 	GEOSGeom gc;
 	if (gmv1.size() > 1)
-		gc = GEOSGeom_createCollection_r(hGEOSCtxt, GEOS_GEOMETRYCOLLECTION, 
+		gc = GEOSGeom_createCollection_r(hGEOSCtxt, GEOS_GEOMETRYCOLLECTION,
 			gmv1.data(), gmv1.size());
 	else
 		gc = gmv1[0];
@@ -572,13 +572,14 @@ GEOSGeometry *chkNULL(GEOSGeometry *value) {
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc, 
-		Rcpp::NumericVector bufferDist, Rcpp::IntegerVector nQuadSegs,
-		Rcpp::NumericVector dTolerance, Rcpp::LogicalVector preserveTopology, 
-		int bOnlyEdges = 1) {
-
+Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc,
+                       Rcpp::NumericVector bufferDist, Rcpp::IntegerVector nQuadSegs,
+                       Rcpp::NumericVector dTolerance, Rcpp::LogicalVector preserveTopology,
+                       int bOnlyEdges = 1,
+                       Rcpp::IntegerVector endCapStyle = 0, Rcpp::IntegerVector joinStyle = 0, Rcpp::NumericVector mitreLimit = 1)
+{
 	int dim = 2;
-	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init(); 
+	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, &dim);
 	std::vector<GEOSGeom> out(sfc.length());
@@ -588,20 +589,24 @@ Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc,
 			Rcpp::stop("invalid dist argument"); // #nocov
 		for (size_t i = 0; i < g.size(); i++)
 			out[i] = chkNULL(GEOSBuffer_r(hGEOSCtxt, g[i], bufferDist[i], nQuadSegs[i]));
+	} else if (op == "buffer_with_style") {
+		for (size_t i = 0; i < g.size(); i++)
+			out[i] = chkNULL(GEOSBufferWithStyle_r(hGEOSCtxt, g[i], bufferDist[i], nQuadSegs[i], endCapStyle[i], joinStyle[i], mitreLimit[i]));
+
 	} else if (op == "boundary") {
 		for (size_t i = 0; i < g.size(); i++)
 			out[i] = chkNULL(GEOSBoundary_r(hGEOSCtxt, g[i]));
 	} else if (op == "convex_hull") {
 		for (size_t i = 0; i < g.size(); i++)
 			out[i] = chkNULL(GEOSConvexHull_r(hGEOSCtxt, g[i]));
-//	} else if (op == "unary_union") { // -> done by CPL_geos_union()
-//		for (size_t i = 0; i < g.size(); i++)
-//			out[i] = chkNULL(GEOSUnaryUnion_r(hGEOSCtxt, g[i]));
+		//	} else if (op == "unary_union") { // -> done by CPL_geos_union()
+		//		for (size_t i = 0; i < g.size(); i++)
+		//			out[i] = chkNULL(GEOSUnaryUnion_r(hGEOSCtxt, g[i]));
 	} else if (op == "simplify") {
 		for (size_t i = 0; i < g.size(); i++)
 			out[i] = preserveTopology[i] ?
-					chkNULL(GEOSTopologyPreserveSimplify_r(hGEOSCtxt, g[i], dTolerance[i])) :
-					chkNULL(GEOSSimplify_r(hGEOSCtxt, g[i], dTolerance[i]));
+		chkNULL(GEOSTopologyPreserveSimplify_r(hGEOSCtxt, g[i], dTolerance[i])) :
+			chkNULL(GEOSSimplify_r(hGEOSCtxt, g[i], dTolerance[i]));
 	} else if (op == "linemerge") {
 		for (size_t i = 0; i < g.size(); i++)
 			out[i] = chkNULL(GEOSLineMerge_r(hGEOSCtxt, g[i]));
@@ -622,28 +627,29 @@ Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc,
 		}
 	} else
 #if GEOS_VERSION_MAJOR >= 3 && GEOS_VERSION_MINOR >= 4
-	if (op == "triangulate") {
-		for (size_t i = 0; i < g.size(); i++)
-			out[i] = chkNULL(GEOSDelaunayTriangulation_r(hGEOSCtxt, g[i], dTolerance[i], bOnlyEdges));
-	} else
+		if (op == "triangulate") {
+			for (size_t i = 0; i < g.size(); i++)
+				out[i] = chkNULL(GEOSDelaunayTriangulation_r(hGEOSCtxt, g[i], dTolerance[i], bOnlyEdges));
+		} else
 #endif
-		Rcpp::stop("invalid operation"); // would leak g and out // #nocov
+			Rcpp::stop("invalid operation"); // would leak g and out // #nocov
 
-	for (size_t i = 0; i < g.size(); i++)
-		GEOSGeom_destroy_r(hGEOSCtxt, g[i]);
+		for (size_t i = 0; i < g.size(); i++)
+			GEOSGeom_destroy_r(hGEOSCtxt, g[i]);
 
-	Rcpp::List ret(sfc_from_geometry(hGEOSCtxt, out, dim)); // destroys out
-	CPL_geos_finish(hGEOSCtxt);
-	ret.attr("precision") = sfc.attr("precision");
-	ret.attr("crs") = sfc.attr("crs");
-	return ret;
+		Rcpp::List ret(sfc_from_geometry(hGEOSCtxt, out, dim)); // destroys out
+		CPL_geos_finish(hGEOSCtxt);
+		ret.attr("precision") = sfc.attr("precision");
+		ret.attr("crs") = sfc.attr("crs");
+		return ret;
 }
+
 
 // [[Rcpp::export]]
 Rcpp::List CPL_geos_voronoi(Rcpp::List sfc, Rcpp::List env, double dTolerance = 0.0, int bOnlyEdges = 1) {
 
 	int dim = 2;
-	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init(); 
+	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	std::vector<GEOSGeom> g = geometries_from_sfc(hGEOSCtxt, sfc, &dim);
 	std::vector<GEOSGeom> out(sfc.length());
@@ -654,7 +660,7 @@ Rcpp::List CPL_geos_voronoi(Rcpp::List sfc, Rcpp::List env, double dTolerance = 
 		case 1: {
 			std::vector<GEOSGeom> g_env = geometries_from_sfc(hGEOSCtxt, env);
 			for (size_t i = 0; i < g.size(); i++) {
-				out[i] = chkNULL(GEOSVoronoiDiagram_r(hGEOSCtxt, g[i], 
+				out[i] = chkNULL(GEOSVoronoiDiagram_r(hGEOSCtxt, g[i],
 					g_env.size() ? g_env[0] : NULL, dTolerance, bOnlyEdges));
 				GEOSGeom_destroy_r(hGEOSCtxt, g[i]);
 			}
@@ -774,7 +780,7 @@ std::string CPL_geos_version(bool b = false) {
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericMatrix CPL_geos_dist(Rcpp::List sfc0, Rcpp::List sfc1, 
+Rcpp::NumericMatrix CPL_geos_dist(Rcpp::List sfc0, Rcpp::List sfc1,
 		Rcpp::CharacterVector which, double par) {
 	Rcpp::NumericMatrix out = CPL_geos_binop(sfc0, sfc1, Rcpp::as<std::string>(which), par, "", false)[0];
 	return out;
@@ -791,7 +797,7 @@ int distance_fn(const void *item1, const void *item2, double *distance, void *us
 
 // [[Rcpp::export]]
 Rcpp::IntegerVector CPL_geos_nearest_feature(Rcpp::List sfc0, Rcpp::List sfc1) {
-	// for every feature in sf0, find the index (1-based) of the nearest feature in sfc1 
+	// for every feature in sf0, find the index (1-based) of the nearest feature in sfc1
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 
 	int dim = 2;
@@ -816,7 +822,7 @@ Rcpp::IntegerVector CPL_geos_nearest_feature(Rcpp::List sfc0, Rcpp::List sfc1) {
 			item.id = 0; // is irrelevant
 			item.g = gmv0[i];
 			// now query tree for nearest GEOM at item:
-			ret_item = (item_g *) GEOSSTRtree_nearest_generic_r(hGEOSCtxt, tree, &item, 
+			ret_item = (item_g *) GEOSSTRtree_nearest_generic_r(hGEOSCtxt, tree, &item,
 					gmv0[i], distance_fn, hGEOSCtxt);
 			if (ret_item != NULL)
 				out[i] = ret_item->id; // the index (1-based) of nearest GEOM
@@ -841,12 +847,12 @@ Rcpp::IntegerVector CPL_geos_nearest_feature(Rcpp::List sfc0, Rcpp::List sfc1) {
 #endif // HAVE_361
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_nearest_points(Rcpp::List sfc0, Rcpp::List sfc1, bool pairwise) { 
+Rcpp::List CPL_geos_nearest_points(Rcpp::List sfc0, Rcpp::List sfc1, bool pairwise) {
 	int dim = 2;
 	GEOSContextHandle_t hGEOSCtxt = CPL_geos_init();
 	std::vector<GEOSGeom> gmv0 = geometries_from_sfc(hGEOSCtxt, sfc0, &dim);
 	std::vector<GEOSGeom> gmv1 = geometries_from_sfc(hGEOSCtxt, sfc1, &dim);
-	Rcpp::List out; 
+	Rcpp::List out;
 	if (pairwise) {
 		if (gmv0.size() != gmv1.size())
 			Rcpp::stop("for pairwise nearest points, both arguments need to have the same number of geometries"); // #nocov

--- a/tests/testthat/test_geos.R
+++ b/tests/testthat/test_geos.R
@@ -46,6 +46,7 @@ test_that("geos ops give warnings and errors on longlat", {
 	expect_message(st_covered_by(x,y))
 
 	expect_warning(st_buffer(x, .1))
+	expect_warning(st_buffer(x, .1, joinStyle = "BEVEL"))
 	expect_warning(st_simplify(x, .1))
 	expect_warning(st_centroid(x))
 	expect_silent(st_segmentize(l, 1e5))
@@ -89,48 +90,53 @@ suppressWarnings(lnc <- st_cast(pnc, "MULTILINESTRING"))
 glnc <- st_geometry(lnc)
 
 test_that("geom operations work on sfg or sfc or sf", {
-  expect_silent(st_buffer(pnc, 1000))
-  expect_silent(st_buffer(gpnc, 1000))
-  expect_silent(st_buffer(gpnc[[1L]], 1000))
+	expect_silent(st_buffer(pnc, 1000))
+	expect_silent(st_buffer(gpnc, 1000))
+	expect_silent(st_buffer(gpnc[[1L]], 1000))
 
-  expect_silent(st_boundary(pnc))
-  expect_that(st_boundary(gpnc), is_a("sfc_MULTILINESTRING"))
-  expect_that(st_boundary(gpnc[[1L]]), is_a("MULTILINESTRING"))
+	expect_silent(st_buffer(pnc, 1000, endCapStyle = "SQUARE"))
+	expect_silent(st_buffer(gpnc, 1000, joinStyle = "BEVEL"))
+	expect_silent(st_buffer(gpnc[[1L]], 1000, joinStyle = "MITRE", mitreLimit = 0.2))
 
-  expect_true(inherits(st_convex_hull(pnc)$geometry, "sfc_POLYGON"))
-  expect_true(inherits(st_convex_hull(gpnc), "sfc_POLYGON"))
-  expect_true(inherits(st_convex_hull(gpnc[[1L]]), "POLYGON"))
+	expect_silent(st_boundary(pnc))
+	expect_that(st_boundary(gpnc), is_a("sfc_MULTILINESTRING"))
+	expect_that(st_boundary(gpnc[[1L]]), is_a("MULTILINESTRING"))
 
-  expect_silent(st_simplify(pnc, FALSE, 1e4))
-  expect_silent(st_simplify(gpnc, FALSE, 1e4))
-  expect_silent(st_simplify(gpnc[[1L]], FALSE, 1e4))
+	expect_true(inherits(st_convex_hull(pnc)$geometry, "sfc_POLYGON"))
+	expect_true(inherits(st_convex_hull(gpnc), "sfc_POLYGON"))
+	expect_true(inherits(st_convex_hull(gpnc[[1L]]), "POLYGON"))
 
-  if (sf:::CPL_geos_version() >= "3.4.0") {
-   expect_silent(st_triangulate(pnc))
-   expect_that(st_triangulate(gpnc), is_a("sfc_GEOMETRYCOLLECTION"))
-   expect_that(st_triangulate(gpnc[[1]]), is_a("GEOMETRYCOLLECTION"))
-  }
+	expect_silent(st_simplify(pnc, FALSE, 1e4))
+	expect_silent(st_simplify(gpnc, FALSE, 1e4))
+	expect_silent(st_simplify(gpnc[[1L]], FALSE, 1e4))
 
-  expect_silent(st_polygonize(lnc))
-  expect_silent(st_polygonize(glnc))
-  expect_silent(st_polygonize(glnc[[1]]))
+	if (sf:::CPL_geos_version() >= "3.4.0") {
+		expect_silent(st_triangulate(pnc))
+		expect_that(st_triangulate(gpnc), is_a("sfc_GEOMETRYCOLLECTION"))
+		expect_that(st_triangulate(gpnc[[1]]), is_a("GEOMETRYCOLLECTION"))
+	}
 
-  expect_that(st_line_merge(lnc), is_a("sf"))
-  expect_that(st_line_merge(glnc), is_a("sfc"))
-  expect_that(st_line_merge(glnc[[3]]), is_a("sfg"))
+	expect_silent(st_polygonize(lnc))
+	expect_silent(st_polygonize(glnc))
+	expect_silent(st_polygonize(glnc[[1]]))
 
-  expect_warning(st_centroid(lnc)) # was: silent
-  expect_that(st_centroid(glnc),  is_a("sfc_POINT"))
-  expect_that(st_centroid(glnc[[1]]),  is_a("POINT"))
+	expect_that(st_line_merge(lnc), is_a("sf"))
+	expect_that(st_line_merge(glnc), is_a("sfc"))
+	expect_that(st_line_merge(glnc[[3]]), is_a("sfg"))
 
-  expect_warning(st_point_on_surface(lnc)) # was: silent
-  expect_that(st_point_on_surface(glnc),  is_a("sfc_POINT"))
-  expect_that(st_point_on_surface(glnc[[1]]),  is_a("POINT"))
+	expect_warning(st_centroid(lnc)) # was: silent
+	expect_that(st_centroid(glnc),  is_a("sfc_POINT"))
+	expect_that(st_centroid(glnc[[1]]),  is_a("POINT"))
 
-  expect_silent(st_segmentize(lnc, 10000))
-  expect_silent(st_segmentize(glnc, 10000))
-  expect_silent(st_segmentize(glnc[[1]], 10000))
+	expect_warning(st_point_on_surface(lnc)) # was: silent
+	expect_that(st_point_on_surface(glnc),  is_a("sfc_POINT"))
+	expect_that(st_point_on_surface(glnc[[1]]),  is_a("POINT"))
+
+	expect_silent(st_segmentize(lnc, 10000))
+	expect_silent(st_segmentize(glnc, 10000))
+	expect_silent(st_segmentize(glnc[[1]], 10000))
 })
+
 
 test_that("st_union/difference/sym_difference/intersection work, for all types", {
   p = st_point(0:1)


### PR DESCRIPTION
* `st_buffer` now includes line end and join stylings using optional arguments `endCapStyle`, `joinStyle` and `mitreLimit`, https://github.com/r-spatial/sf/issues/833. 

I believe this is faithful to the support in `rgeos`, which I used as a guide. 

One issue is that these style examples are at the front of 'examples', which seems funny - I'm not sure how to fix apart from moving all the examples into one?