### PR TITLE
tmap v2.* does not convert to `Spatial*` anymore, uses `sf` internally

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -86,7 +86,7 @@ Suggests:
     tibble (>= 1.4.1),
     tidyr (>= 0.7-2),
     tidyselect,
-    tmap
+    tmap (>= 2.0)
 LinkingTo: 
     Rcpp
 VignetteBuilder: 

--- a/vignettes/sf5.Rmd
+++ b/vignettes/sf5.Rmd
@@ -225,7 +225,3 @@ ttm()
 last_map()
 ```
 
-Unlike `mapview`, `tmap` currently converts `sf` objects first to `Spatial*` objects using `as(obj, "Spatial")`. For sf objects that do not have an equivalent representation in `sp`, this fails. Examples of this are objects with `GEOMETRYCOLLECTION` geometries, or mixed geometries such as obtained by
-```{r}
-st_sf(a = 1:2, geom = st_sfc(st_point(0:1), st_linestring(rbind(c(1,1), c(2,2)))))
-```


### PR DESCRIPTION
Since v2.0, tmap does not convert to `Spatial*` anymore, but uses `sf` internally (see tmap's [NEWS](https://github.com/mtennekes/tmap/blob/3e78bd8e0406f779374d155799247010cebb732d/NEWS#L15), so I deleted the relevant paragraph about the former incompatibility from the sf5 vignette.

I opted for suggesting `tmap (>= 2.0)` in DESCRIPTION. A milder approach would be to state that v2.* is preferred or else there might be limitations (i.e. edit not delete the relevant paragraph in sf5.Rmd). 

I have not yet build the vignette.