### PR TITLE
Fix use of uninitialized memory for tolerance in st_triangulate

### DIFF
--- a/R/geom.R
+++ b/R/geom.R
@@ -576,7 +576,7 @@ st_triangulate.sfc = function(x, dTolerance = 0.0, bOnlyEdges = FALSE) {
 		if (isTRUE(st_is_longlat(x)))
 			warning("st_triangulate does not correctly triangulate longitude/latitude data")
 		st_sfc(CPL_geos_op("triangulate", x, numeric(0), integer(0),
-			dTolerance = rep(as.double(dTolerance), lenght.out = length(x)), logical(0), 
+			dTolerance = rep(as.double(dTolerance), length.out = length(x)), logical(0),
 			bOnlyEdges = as.integer(bOnlyEdges)))
 	} else
 		stop("for triangulate, GEOS version 3.4.0 or higher is required")


### PR DESCRIPTION
Typo prevented tolerance from being copied to length of geometry inputs.

This should remove the following valgrind errors reported at https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/sf/tests/gdal_geom.Rout: 

```
> if (sf:::CPL_geos_version() >= "3.4.0")
+ 	x = st_triangulate(nc_tr)
==4058== Conditional jump or move depends on uninitialised value(s)
==4058==    at 0x1B0E56E9: geos::triangulate::quadedge::QuadEdgeSubdivision::isVertexOfEdge(geos::triangulate::quadedge::QuadEdge const&, geos::triangulate::quadedge::Vertex const&) const (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E2058: geos::triangulate::IncrementalDelaunayTriangulator::insertSite(geos::triangulate::quadedge::Vertex const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E226B: geos::triangulate::IncrementalDelaunayTriangulator::insertSites(std::__cxx11::list<geos::triangulate::quadedge::Vertex, std::allocator<geos::triangulate::quadedge::Vertex> > const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E24FF: geos::triangulate::DelaunayTriangulationBuilder::create() (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E261C: geos::triangulate::DelaunayTriangulationBuilder::getTriangles(geos::geom::GeometryFactory const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1AD6803E: GEOSDelaunayTriangulation_r (in /usr/lib64/libgeos_c.so.1.10.1)
==4058==    by 0x1939F8F8: CPL_geos_op(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Rcpp::Vector<19, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>, Rcpp::Vector<10, Rcpp::PreserveStorage>, int, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>) (packages/tests-vg/sf/src/geos.cpp:664)
==4058==    by 0x19377B84: _sf_CPL_geos_op (packages/tests-vg/sf/src/RcppExports.cpp:562)
==4058==    by 0x493BEF: R_doDotCall (svn/R-devel/src/main/dotcode.c:606)
==4058==    by 0x494163: do_dotcall (svn/R-devel/src/main/dotcode.c:1252)
==4058==    by 0x4C735D: bcEval (svn/R-devel/src/main/eval.c:6875)
==4058==    by 0x4D689F: Rf_eval (svn/R-devel/src/main/eval.c:620)
==4058== 
==4058== Conditional jump or move depends on uninitialised value(s)
==4058==    at 0x1B0E205B: geos::triangulate::IncrementalDelaunayTriangulator::insertSite(geos::triangulate::quadedge::Vertex const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E226B: geos::triangulate::IncrementalDelaunayTriangulator::insertSites(std::__cxx11::list<geos::triangulate::quadedge::Vertex, std::allocator<geos::triangulate::quadedge::Vertex> > const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E24FF: geos::triangulate::DelaunayTriangulationBuilder::create() (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E261C: geos::triangulate::DelaunayTriangulationBuilder::getTriangles(geos::geom::GeometryFactory const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1AD6803E: GEOSDelaunayTriangulation_r (in /usr/lib64/libgeos_c.so.1.10.1)
==4058==    by 0x1939F8F8: CPL_geos_op(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Rcpp::Vector<19, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>, Rcpp::Vector<10, Rcpp::PreserveStorage>, int, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>) (packages/tests-vg/sf/src/geos.cpp:664)
==4058==    by 0x19377B84: _sf_CPL_geos_op (packages/tests-vg/sf/src/RcppExports.cpp:562)
==4058==    by 0x493BEF: R_doDotCall (svn/R-devel/src/main/dotcode.c:606)
==4058==    by 0x494163: do_dotcall (svn/R-devel/src/main/dotcode.c:1252)
==4058==    by 0x4C735D: bcEval (svn/R-devel/src/main/eval.c:6875)
==4058==    by 0x4D689F: Rf_eval (svn/R-devel/src/main/eval.c:620)
==4058==    by 0x4D81FE: R_execClosure (svn/R-devel/src/main/eval.c:1780)
==4058== 
==4058== Conditional jump or move depends on uninitialised value(s)
==4058==    at 0x1B0E209A: geos::triangulate::IncrementalDelaunayTriangulator::insertSite(geos::triangulate::quadedge::Vertex const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E226B: geos::triangulate::IncrementalDelaunayTriangulator::insertSites(std::__cxx11::list<geos::triangulate::quadedge::Vertex, std::allocator<geos::triangulate::quadedge::Vertex> > const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E24FF: geos::triangulate::DelaunayTriangulationBuilder::create() (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1B0E261C: geos::triangulate::DelaunayTriangulationBuilder::getTriangles(geos::geom::GeometryFactory const&) (in /usr/lib64/libgeos-3.6.1.so)
==4058==    by 0x1AD6803E: GEOSDelaunayTriangulation_r (in /usr/lib64/libgeos_c.so.1.10.1)
==4058==    by 0x1939F8F8: CPL_geos_op(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >, Rcpp::Vector<19, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>, Rcpp::Vector<10, Rcpp::PreserveStorage>, int, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<13, Rcpp::PreserveStorage>, Rcpp::Vector<14, Rcpp::PreserveStorage>) (packages/tests-vg/sf/src/geos.cpp:664)
==4058==    by 0x19377B84: _sf_CPL_geos_op (packages/tests-vg/sf/src/RcppExports.cpp:562)
==4058==    by 0x493BEF: R_doDotCall (svn/R-devel/src/main/dotcode.c:606)
==4058==    by 0x494163: do_dotcall (svn/R-devel/src/main/dotcode.c:1252)
==4058==    by 0x4C735D: bcEval (svn/R-devel/src/main/eval.c:6875)
==4058==    by 0x4D689F: Rf_eval (svn/R-devel/src/main/eval.c:620)
==4058==    by 0x4D81FE: R_execClosure (svn/R-devel/src/main/eval.c:1780)
==4058== 

```