### PR TITLE
Fix crash in CPL_nary_intersection (fixes #867)

### DIFF
--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -1048,8 +1048,10 @@ Rcpp::List CPL_nary_intersection(Rcpp::List sfc) {
 	size_t j = 0;
 	for (size_t i = 0; i < out.size(); i++) {
 		if (! GEOSisEmpty_r(hGEOSCtxt, out[i].get())) {
-			out[j] = std::move(out[i]);
-			index[j] = index[i];
+			if (i != j) {
+				out[j] = std::move(out[i]);
+				index[j] = index[i];
+			}
 			std::sort(index[j].begin(), index[j].end());
 			j++;
 		}


### PR DESCRIPTION
Apparently self-move-assignment of STL objects results in undefined behavior. In this case, `clang` on `OS X` and apparently other platforms drops the reference to a`unique_ptr`'s deleter during self-assignment.

Some discussion/reference: https://stackoverflow.com/q/52960407/2171894