### PR TITLE
Optimize bounding-box calculation

### DIFF
--- a/src/bbox.cpp
+++ b/src/bbox.cpp
@@ -6,10 +6,11 @@
 Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 	Rcpp::NumericVector bb(4);
 	bb(0) = bb(1) = bb(2) = bb(3) = NA_REAL;
-	switch(depth) {
+	auto n = sf.size();
 
+	switch(depth) {
 		case 0: // points:
-		for (int i = 0; i < sf.size(); i++) {
+		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericVector pt = sf[i];
 			if (i == 0) {
 				bb(0) = bb(2) = pt(0);
@@ -24,16 +25,17 @@ Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 		break;
 
 		case 1: // list of matrices:
-		for (int i = 0; i < sf.size(); i++) {
+		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericMatrix m = sf[i];
+			auto rows = m.nrow();
 			if (i == 0) { // initialize:
-				if (m.nrow() == 0)
+				if (rows == 0)
 					return bb;
 					// Rcpp::stop("CPL_get_bbox: invalid geometry");
 				bb(0) = bb(2) = m(0,0);
 				bb(1) = bb(3) = m(0,1);
 			} 
-			for (int j = 0; j < m.nrow(); j++) {
+			for (decltype(rows) j = 0; j < rows; j++) {
 				bb(0) = std::min(m(j,0),bb(0));
 				bb(1) = std::min(m(j,1),bb(1));
 				bb(2) = std::max(m(j,0),bb(2));
@@ -43,7 +45,7 @@ Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 		break;
 
 		default: // recursive list
-		for (int i = 0; i < sf.size(); i++) {
+		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericVector bbi = CPL_get_bbox(sf[i], depth - 1); // recurse
 			if (! Rcpp::NumericVector::is_na(bbi[0])) {
 				if (i == 0) {


### PR DESCRIPTION
This PR optimizes `CPL_get_bbox` (and in turn, `st_read`) by reducing the number times a vector's length is checked with `Rf_xlength`. According to [discussion elsewhere](https://github.com/RcppCore/Rcpp/issues/629#issuecomment-272170041), this time should be negligible, but I was surprised to see if occupying nearly 20% of total program runtime in a benchmark of a point-in-polygon join that included the calls to `st_read` in the benchmark (see bottom-center of image):

![image](https://user-images.githubusercontent.com/6318931/48017619-b0f49700-e0fc-11e8-8112-f3f18cdc716e.png)

Indeed, storing vector sizes in a variable seems to reduce the `st_read` runtime by a measurable amount:

```
# master
microbenchmark(st_read('basins_lev05.shp'), times=10)
                         expr      min       lq     mean   median       uq      max neval
 st_read("/basins_lev05.shp") 10.46513 10.61681 10.84794 10.81243 11.04343 11.31627    10

# this PR
microbenchmark(st_read('/basins_lev05.shp'), times=10)
                         expr      min       lq     mean   median      uq      max  neval
 st_read("/basins_lev05.shp") 8.296611 8.503919 8.714894 8.680371 8.81185 9.187567     10
```

I used `auto` and `decltype` here because R defines its own type for the length of a vector and this seemed more clear than bringing that type definition in.

Note that a similar issue is present in `write_matrix`.