### PR TITLE
Further optimize bounding-box calculations

### DIFF
--- a/src/bbox.cpp
+++ b/src/bbox.cpp
@@ -5,7 +5,7 @@
 // [[Rcpp::export]]
 Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 	Rcpp::NumericVector bb(4);
-	bb(0) = bb(1) = bb(2) = bb(3) = NA_REAL;
+	bb[0] = bb[1] = bb[2] = bb[3] = NA_REAL;
 	auto n = sf.size();
 
 	switch(depth) {
@@ -13,13 +13,13 @@ Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericVector pt = sf[i];
 			if (i == 0) {
-				bb(0) = bb(2) = pt(0);
-				bb(1) = bb(3) = pt(1);
+				bb[0] = bb[2] = pt[0];
+				bb[1] = bb[3] = pt[1];
 			} else {
-				bb(0) = std::min(pt(0),bb(0));
-				bb(1) = std::min(pt(1),bb(1));
-				bb(2) = std::max(pt(0),bb(2));
-				bb(3) = std::max(pt(1),bb(3));
+				bb[0] = std::min(pt[0],bb[0]);
+				bb[1] = std::min(pt[1],bb[1]);
+				bb[2] = std::max(pt[0],bb[2]);
+				bb[3] = std::max(pt[1],bb[3]);
 			}
 		}
 		break;
@@ -28,18 +28,19 @@ Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericMatrix m = sf[i];
 			auto rows = m.nrow();
+
 			if (i == 0) { // initialize:
 				if (rows == 0)
 					return bb;
 					// Rcpp::stop("CPL_get_bbox: invalid geometry");
-				bb(0) = bb(2) = m(0,0);
-				bb(1) = bb(3) = m(0,1);
-			} 
+				bb[0] = bb[2] = m(0,0);
+				bb[1] = bb[3] = m(0,1);
+			}
 			for (decltype(rows) j = 0; j < rows; j++) {
-				bb(0) = std::min(m(j,0),bb(0));
-				bb(1) = std::min(m(j,1),bb(1));
-				bb(2) = std::max(m(j,0),bb(2));
-				bb(3) = std::max(m(j,1),bb(3));
+				bb[0] = std::min(m(j,0),bb[0]);
+				bb[1] = std::min(m(j,1),bb[1]);
+				bb[2] = std::max(m(j,0),bb[2]);
+				bb[3] = std::max(m(j,1),bb[3]);
 			}
 		}
 		break;
@@ -49,15 +50,15 @@ Rcpp::NumericVector CPL_get_bbox(Rcpp::List sf, int depth = 0) {
 			Rcpp::NumericVector bbi = CPL_get_bbox(sf[i], depth - 1); // recurse
 			if (! Rcpp::NumericVector::is_na(bbi[0])) {
 				if (i == 0) {
-					bb(0) = bbi(0);
-					bb(1) = bbi(1);
-					bb(2) = bbi(2);
-					bb(3) = bbi(3);
+					bb[0] = bbi[0];
+					bb[1] = bbi[1];
+					bb[2] = bbi[2];
+					bb[3] = bbi[3];
 				} else {
-					bb(0) = std::min(bbi(0),bb(0));
-					bb(1) = std::min(bbi(1),bb(1));
-					bb(2) = std::max(bbi(2),bb(2));
-					bb(3) = std::max(bbi(3),bb(3));
+					bb[0] = std::min(bbi[0],bb[0]);
+					bb[1] = std::min(bbi[1],bb[1]);
+					bb[2] = std::max(bbi[2],bb[2]);
+					bb[3] = std::max(bbi[3],bb[3]);
 				}
 			}
 		}


### PR DESCRIPTION
So this is interesting.

I've been working with a shapefile of ~5500 multipolygons comprising 38000 polygons and 58000 rings. I'm using callgrind to inspect a single `st_read` call:

`R -d "valgrind --tool=callgrind" -e "library(sf); st_read('/tmp/basins_lev05.shp')"
`

The callgrind output shows that, even after the changes recently committed, `CPL_get_bbox` remains at 25% of total program runtime (compared to `CPL_read_ogr` at 43%). `CPL_get_bbox` is still calling `Rf_xlength` an astonishing 69 million times!

Some more digging pins this on the use of `operator()` for vector access instead of `operator[]`. Apparently `NumericVector::operator()` does a bounds-check (and hence, a call to `Rf_xlength`), while `NumericVector::operator[]` does not. So a simple statement like `bb(0) = std::min(bbi(0),bb(0))` results in at least 3 bounds checks.

This PR simply switches access to `operator[]`.

After this PR, `Rf_xlength` is called 341k times, and CPL_get_bbox is reduced to 3.2% of program runtime. Total time for `st_read` is reduced by about 40%.

```
# Master
                            expr      min       lq     mean   median       uq      max neval
st_read("/tmp/basins_lev05.shp") 1.768442 2.005508 2.487873 2.670088 2.725343 3.159911    10

# This PR
                            expr      min       lq     mean   median       uq      max neval
st_read("/tmp/basins_lev05.shp") 1.173727 1.390973 1.456033 1.411426 1.449768 2.001311    10


```