### PR TITLE
Honor crs argument for st_as_sfc.list()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -61,6 +61,7 @@ Imports:
     units (>= 0.6-0),
     utils
 Suggests:
+    blob,
     covr,
     dplyr (>= 0.7-0),
     ggplot2,

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -491,15 +491,15 @@ st_as_sfc.list = function(x, ..., crs = NA_crs_) {
 		return(st_sfc(crs = crs))
 
 	if (is.raw(x[[1]]))
-		st_as_sfc(structure(x, class = "WKB"), ...)
+		st_as_sfc.WKB(as_wkb(x), ..., crs = crs)
 	else if (inherits(x[[1]], "sfg"))
 		st_sfc(x, crs = crs)
 	else if (is.character(x[[1]])) { # hex wkb or wkt:
 		ch12 = substr(x[[1]], 1, 2)
 		if (ch12 == "0x" || ch12 == "00" || ch12 == "01") # hex wkb
-			st_as_sfc(structure(x, class = "WKB"), ...)
+			st_as_sfc.WKB(as_wkb(x), ..., crs = crs)
 		else
-			st_as_sfc(unlist(x), ...) # wkt
+			st_as_sfc(unlist(x), ..., crs = crs) # wkt
 	} else
 		stop(paste("st_as_sfc.list: don't know what to do with list with elements of class", class(x[[1]])))
 }

--- a/tests/testthat/test_wkb.R
+++ b/tests/testthat/test_wkb.R
@@ -50,3 +50,14 @@ test_that("Reading of truncated buffers results in a proper error", {
   expect_error(st_as_sfc(wkb, EWKB = TRUE), "WKB buffer too small. Input file corrupt?")
 })
 
+test_that("st_as_sfc() honors crs argument", {
+  raw = st_as_binary(st_point(c(26e5, 12e5)))
+
+  list = list(raw)
+  blob = blob::blob(raw)
+  wkb = as_wkb(list)
+
+  expect_identical(st_as_sfc(raw, crs = 2056), st_as_sfc(wkb, crs = 2056))
+  expect_identical(st_as_sfc(list, crs = 2056), st_as_sfc(wkb, crs = 2056))
+  expect_identical(st_as_sfc(blob, crs = 2056), st_as_sfc(wkb, crs = 2056))
+})


### PR DESCRIPTION
Otherwise, with bb53f02934:

``` r
library(sf)
#> Linking to GEOS 3.6.2, GDAL 2.2.3, PROJ 4.9.3

geom <- list(st_as_binary(st_point(c(25e5, 12e5))))

st_as_sfc(geom, crs = 2056)
#> Geometry set for 1 feature 
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 2500000 ymin: 1200000 xmax: 2500000 ymax: 1200000
#> epsg (SRID):    NA
#> proj4string:    NA
#> POINT (2500000 1200000)
```

<sup>Created on 2018-12-11 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>