### PR TITLE
WIP: Fix corner case for st_cast()

### DIFF
--- a/R/cast_sfg.R
+++ b/R/cast_sfg.R
@@ -118,7 +118,15 @@ st_cast.MULTIPOINT <- function(x, to, ...) {
          POLYGON = st_polygon(list(unclass(ClosePol(x)))), 
          LINESTRING = st_linestring(unclass(x)),
          ## loss, drop to first coordinate
-         POINT = {warning("point from first coordinate only"); st_point(unclass(x)[1L, , drop = TRUE])},
+         POINT = {
+             if (st_is_empty(x)) {
+                 row <- NA_integer_
+             } else {
+	             warning("point from first coordinate only")
+                 row <- 1L
+             }
+             st_point(unclass(x)[row, , drop = TRUE])
+         },
 		 GEOMETRYCOLLECTION = st_geometrycollection(list(x))
   )
 }

--- a/tests/testthat/test_st_cast.R
+++ b/tests/testthat/test_st_cast.R
@@ -5,7 +5,8 @@ s <- matrix(c(2, 0), 5, 2, byrow = TRUE)
 cc <- list(
   points = list(
     single = m[1, ] %>% st_point(),
-    multi = m %>% st_multipoint()
+    multi = m %>% st_multipoint(),
+    multi_empty = st_multipoint()
   ),
   lines = list(
     single = m %>% st_linestring(), 
@@ -23,7 +24,7 @@ test_that("st_cast() can coerce to MULTI* or GEOMETRY", {
   # points
   pt <- st_sfc(cc$points$single, cc$points$single)
   expect_is(st_cast(pt), "sfc_POINT")
-  pts <- st_sfc(cc$points$single, cc$points$multi)
+  pts <- st_sfc(cc$points$single, cc$points$multi, cc$points$multi_empty)
   expect_is(st_cast(pts), "sfc_MULTIPOINT")
   expect_warning(pt <- st_cast(pts, "POINT"), "first coordinate")
   expect_is(pt, "sfc_POINT")


### PR DESCRIPTION
Otherwise:

``` r
library(sf)
#> Linking to GEOS 3.6.2, GDAL 2.2.3, PROJ 4.9.3

st_cast(st_multipoint(), "POINT")
#> Warning in st_cast.MULTIPOINT(st_multipoint(), "POINT"): point from first
#> coordinate only
#> Error in is.numeric(x): subscript out of bounds
```

<sup>Created on 2018-12-12 by the [reprex package](https://reprex.tidyverse.org) (v0.2.1.9000)</sup>

From a quick glance at the code, there are many more such corner cases lurking in the various `st_cast()` implementations. Am I missing a better alternative?