### PR TITLE
harden R version check in configure for use in R devel

### DIFF
--- a/configure
+++ b/configure
@@ -2062,15 +2062,20 @@ RVER_MAJOR=`echo ${RVER} | cut  -f1 -d"."`
 RVER_MINOR=`echo ${RVER} | cut  -f2 -d"."`
 RVER_PATCH=`echo ${RVER} | cut  -f3 -d"."`
 
-if test $RVER_MAJOR -lt 3 -o $RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3; then
-    as_fn_error $? "sf is not compatible with R versions before 3.3.0" "$LINENO" 5
+if test $RVER_MAJOR = "development"; then
+    CXX11=`"${RBIN}" CMD config CXX11`
+    CXX11STD=`"${RBIN}" CMD config CXX11STD`
 else
-    if test $RVER_MINOR -eq 3; then
-        CXX11=`"${RBIN}" CMD config CXX1X`
-        CXX11STD=`"${RBIN}" CMD config CXX1XSTD`
+    if test $RVER_MAJOR -lt 3 -o $RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3; then
+        as_fn_error $? "sf is not compatible with R versions before 3.3.0" "$LINENO" 5
     else
-        CXX11=`"${RBIN}" CMD config CXX11`
-        CXX11STD=`"${RBIN}" CMD config CXX11STD`
+        if test $RVER_MINOR -eq 3; then
+            CXX11=`"${RBIN}" CMD config CXX1X`
+            CXX11STD=`"${RBIN}" CMD config CXX1XSTD`
+        else
+            CXX11=`"${RBIN}" CMD config CXX11`
+            CXX11STD=`"${RBIN}" CMD config CXX11STD`
+        fi
     fi
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -15,15 +15,20 @@ RVER_MAJOR=`echo ${RVER} | cut  -f1 -d"."`
 RVER_MINOR=`echo ${RVER} | cut  -f2 -d"."`
 RVER_PATCH=`echo ${RVER} | cut  -f3 -d"."`
 
-if test [$RVER_MAJOR -lt 3] -o [$RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3]; then
-    AC_MSG_ERROR([sf is not compatible with R versions before 3.3.0])
+if test [$RVER_MAJOR = "development"]; then
+    CXX11=`"${RBIN}" CMD config CXX11`
+    CXX11STD=`"${RBIN}" CMD config CXX11STD`
 else
-    if test [$RVER_MINOR -eq 3]; then
-        CXX11=`"${RBIN}" CMD config CXX1X`
-        CXX11STD=`"${RBIN}" CMD config CXX1XSTD`
+    if test [$RVER_MAJOR -lt 3] -o [$RVER_MAJOR -eq 3 -a $RVER_MINOR -lt 3]; then
+        AC_MSG_ERROR([sf is not compatible with R versions before 3.3.0])
     else
-        CXX11=`"${RBIN}" CMD config CXX11`
-        CXX11STD=`"${RBIN}" CMD config CXX11STD`
+        if test [$RVER_MINOR -eq 3]; then
+            CXX11=`"${RBIN}" CMD config CXX1X`
+            CXX11STD=`"${RBIN}" CMD config CXX1XSTD`
+        else
+            CXX11=`"${RBIN}" CMD config CXX11`
+            CXX11STD=`"${RBIN}" CMD config CXX11STD`
+        fi
     fi
 fi
 


### PR DESCRIPTION
The R version check of configure fails in R-devel because `"${RBIN}" --version | head -1 | cut -f3 -d" "` returns "development" instead of a version string. The following tests expect numbers and fail consequently if confronted with "development".