### PR TITLE
accelerate printing

### DIFF
--- a/tests/testthat/test_sfg.R
+++ b/tests/testthat/test_sfg.R
@@ -41,11 +41,11 @@ test_that("xx2multixx works", {
 test_that("format works", {
 	digits = options("digits")[[1]]
 	options(digits = 16)
-	expect_identical(format(st_multipoint(matrix(1:6/6,3))), "MULTIPOINT (0.1666666666666...")
-	expect_identical(format(st_sfc(st_multipoint(matrix(1:6/6,3)))), 
+	expect_identical(format(st_multipoint(matrix(1:6/6,3)), digits = 16), "MULTIPOINT (0.1666666666666...")
+	expect_identical(format(st_sfc(st_multipoint(matrix(1:6/6,3))), digits = 16),
 		"MULTIPOINT (0.1666666666666...")
 	options(digits = digits)
-	expect_identical(obj_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))), 
+	expect_identical(obj_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))),
 		"MULTIPOINT (...")
 	expect_identical(type_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))), "MULTIPOINT")
 })


### PR DESCRIPTION
This PR uses `formatC` to accelerate printing of geometries. It also has the same behavior than the `digits` option in base R (`lwgeom` only offers control for the number of decimals).  

@harryprince, @JanMarvin, @adrfantini, if you could test your use case and report, that would be super useful. (I did test with the #703 data.)

close #800, #947, #703, #747, #703 
related #713  