### PR TITLE
Fix st_difference on a single sfc so it works on entirely contained geometries correctly.

### DIFF
--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -956,8 +956,8 @@ Rcpp::List CPL_nary_difference(Rcpp::List sfc) {
 					contained = chk_(GEOSContains_r(hGEOSCtxt, out[tree_sel[j]].get(), geom.get()));
 					if (contained)
 						break;
-					// test if the items overlap with geom
-					if (chk_(GEOSOverlaps_r(hGEOSCtxt, geom.get(), out[tree_sel[j]].get()))) {
+					// test if the items intersect with geom
+					if (chk_(GEOSIntersects_r(hGEOSCtxt, geom.get(), out[tree_sel[j]].get()))) {
 						// if they do then erase overlapping parts from geom
 						geom = geos_ptr(GEOSDifference_r(hGEOSCtxt, geom.get(), out[tree_sel[j]].get()), hGEOSCtxt);
 						if (geom == nullptr)

--- a/tests/testthat/test_geos.R
+++ b/tests/testthat/test_geos.R
@@ -240,6 +240,12 @@ test_that("st_difference works with fully contained geometries", {
 	#expect_equal(out1[[2]][[1]], correct_geom[[2]][[1]])
 	#expect_equal(out2[[1]][[1]], correct_geom[[1]][[1]])
 	#expect_equal(out2[[2]][[1]], correct_geom[[2]][[1]])
+	# check change in order
+	in3 = st_sfc(list(pl2, pl1))
+	correct_geom = list(pl2, st_difference(pl1, pl2))
+	out3 = st_difference(in3)
+	expect_equal(correct_geom[[1]], out3[[1]])
+	expect_equal(correct_geom[[2]], out3[[2]])
 })
 
 test_that("binary operations work on sf objects with common column names", {


### PR DESCRIPTION
In playing around with `sf` and some very simple geometries, I noticed that `st_difference` when run on a single `sfc` returned unexpected results in the case where earlier geometries are entirely contained in later geometries. e.g. in the existing test for `st_difference` with fully contained geometries, if we change the order of `pl1` and `pl2` (`pl2` is entirely contained within `pl1`) then
```{r}
library(sf)
pl1 = st_polygon(list(matrix(c(0, 0, 2, 0, 2, 2, 0, 2, 0, 0), byrow = TRUE, ncol=2)))
pl2 = st_polygon(list(matrix(c(0.5, 0.5, 1.5, 0.5, 1.5, 1.5, 0.5, 1.5, 0.5, 0.5), byrow = TRUE, ncol = 2)))
st_contains(pl1, pl2, sparse=FALSE)
out = st_difference(st_sfc(list(pl2, pl1)))
all.equal(out[[2]], pl1)
```
returns `pl1` in it's second geometry, where we'd expect `pl1` with a hole where `pl2` is, as the usual `st_difference` gives the correct geometry with a hole:
```{r}
out2 = st_difference(pl2, pl1)
all.equal(out2, out[[2]])
```
This is primarily due to `GEOSOverlaps_r` being called before we call `GEOSDifference_r` in `CPL_nary_difference`. Overlaps returns false in the case that one of the geometries are entirely contained (and in my understanding is symmetric, so that Overlaps(a,b) == Overlaps(b,a)).

The patch changes this to use `GEOSIntersects_r` which I'm guessing might be equivalent to `Overlaps || Contains`.

First commit adds to the existing test for entirely contained geometries, second fixes it :)