### PR TITLE
Fix issue with st_sample exact

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -217,7 +217,3 @@ st_sample_exact = function(x, size, ..., type) {
 	}
 	random_pt
 }
-
-# library(sf)
-# nc = read_sf(system.file("shape/nc.shp", package="sf"))
-# system.time({p = st_sample(x = nc, size = 1:nrow(nc))})

--- a/R/sample.R
+++ b/R/sample.R
@@ -209,7 +209,7 @@ st_sample_exact = function(x, size, ..., type) {
 	random_pt = st_sample(x = x, size = size, ..., type = type, exact = FALSE)
 	while (length(random_pt) < size) {
 		diff = size - length(random_pt)
-		random_pt_new = st_sample(x, size, ..., type, exact = FALSE)
+		random_pt_new = st_sample(x, size = diff, ..., type, exact = FALSE)
 		random_pt = c(random_pt, random_pt_new)
 	}
 	if(length(random_pt) > size) {
@@ -217,3 +217,7 @@ st_sample_exact = function(x, size, ..., type) {
 	}
 	random_pt
 }
+
+# library(sf)
+# nc = read_sf(system.file("shape/nc.shp", package="sf"))
+# system.time({p = st_sample(x = nc, size = 1:nrow(nc))})


### PR DESCRIPTION
I suspect the second one will be faster and yield the same result.

```r
remotes::install_github("r-spatial/sf")
nc = sf::read_sf(system.file("shape/nc.shp", package="sf"))
system.time({p = sf::st_sample(x = nc, size = 1:nrow(nc))})
remotes::install_github("robinlovelace/sf", "update-st_sample_exact")
system.time({p = sf::st_sample(x = nc, size = 1:nrow(nc))})
```