### PR TITLE
Sample man - type arg

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -13,7 +13,7 @@
 #' @param x object of class \code{sf} or \code{sfc}
 #' @param size sample size(s) requested; either total size, or a numeric vector with sample sizes for each feature geometry. When sampling polygons, the returned sampling size may differ from the requested size, as the bounding box is sampled, and sampled points intersecting the polygon are returned.
 #' @param ... ignored, or passed on to \link[base]{sample} for \code{multipoint} sampling
-#' @param type character; indicates the spatial sampling type; only \code{random} is implemented right now
+#' @param type character; indicates the spatial sampling type; one of \code{regular}, \code{hexagonal} and \code{regular}.
 #' @param exact logical; should the length of output be exactly
 #' the same as specified by \code{size}? \code{FALSE} by default. Only applies to polygons, and
 #' when \code{type = "random"}.

--- a/R/sample.R
+++ b/R/sample.R
@@ -15,7 +15,7 @@
 #' @param ... ignored, or passed on to \link[base]{sample} for \code{multipoint} sampling
 #' @param type character; indicates the spatial sampling type; only \code{random} is implemented right now
 #' @param exact logical; should the length of output be exactly
-#' the same as specified by \code{size}? \code{TRUE} by default. Only applies to polygons, and
+#' the same as specified by \code{size}? \code{FALSE} by default. Only applies to polygons, and
 #' when \code{type = "random"}.
 #' @return an \code{sfc} object containing the sampled \code{POINT} geometries
 #' @details if \code{x} has dimension 2 (polygons) and geographical coordinates (long/lat), uniform random sampling on the sphere is applied, see e.g. \url{http://mathworld.wolfram.com/SpherePointPicking.html}

--- a/man/st_sample.Rd
+++ b/man/st_sample.Rd
@@ -13,10 +13,10 @@ st_sample(x, size, ..., type = "random", exact = FALSE)
 
 \item{...}{ignored, or passed on to \link[base]{sample} for \code{multipoint} sampling}
 
-\item{type}{character; indicates the spatial sampling type; only \code{random} is implemented right now}
+\item{type}{character; indicates the spatial sampling type; one of \code{regular}, \code{hexagonal} and \code{regular}.}
 
 \item{exact}{logical; should the length of output be exactly
-the same as specified by \code{size}? \code{TRUE} by default. Only applies to polygons, and
+the same as specified by \code{size}? \code{FALSE} by default. Only applies to polygons, and
 when \code{type = "random"}.}
 }
 \value{

--- a/man/st_write.Rd
+++ b/man/st_write.Rd
@@ -72,13 +72,10 @@ to update (append to) the existing data source, e.g. adding a table to an existi
 
 \item{conn}{DBIObject}
 
-\item{name}{
-   character vector of names (table names, fields, keywords).
-}
+\item{name}{A character string specifying the unquoted DBMS table name,
+or the result of a call to \code{\link[=dbQuoteIdentifier]{dbQuoteIdentifier()}}.}
 
-\item{value}{
-   a data.frame.
-}
+\item{value}{a \link{data.frame} (or coercible to data.frame).}
 
 \item{row.names}{Add a \code{row.name} column, or a vector of length \code{nrow(obj)}
 containing row.names; default \code{FALSE}.}


### PR DESCRIPTION
Just a quick PR for the sampling type options in the man. 
It said "only random is implemented right now" despite examples and underlying code for types hexagonal, regular. 