### PR TITLE
Use new_tibble

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -129,7 +129,7 @@ st_read.DBIObject = function(dsn = NULL,
     if (!quiet) print(x, n = 0) # nocov
 
     if (as_tibble) {
-        x <- tibble::as_tibble(x)
+        x <- tibble::new_tibble(x, nrow = nrow(x), class = "sf")
     }
     return(x)
 }

--- a/R/geom.R
+++ b/R/geom.R
@@ -907,7 +907,7 @@ geos_op2_df = function(x, y, geoms) {
 	if (inherits(x, "tbl_df")) {
 		if (!requireNamespace("tibble", quietly = TRUE))
 			stop("package tibble required: install first?")
-		df = tibble::as_tibble(df)
+		df = tibble::new_tibble(df, nrow = nrow(df), class = "sf")
 	}
 	df[[ attr(x, "sf_column") ]] = geoms
 	st_sf(df, sf_column_name = attr(x, "sf_column"))

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -343,7 +343,7 @@ unnest.sf = function(data, ..., .preserve = NULL) {
 	# vector of variable names, using any valid dplyr (i.e. rlang)
 	# variable selection syntax. By default, with .preserve = NULL, this will be
 	# empty. Note: the !!! is from rlang.
-	preserve = tidyselect::vars_select(names(data), !!! rlang::enquo(.preserve))
+	preserve = tidyselect::vars_select(names(data), !!rlang::enquo(.preserve))
 	# Get the name of the geometry column(s)
 	sf_column_name = attr(data, "sf_column", exact = TRUE)
 	preserve_incl_sf = c(preserve, sf_column_name)

--- a/tests/testthat/test_postgis_RPostgres.R
+++ b/tests/testthat/test_postgis_RPostgres.R
@@ -82,6 +82,13 @@ test_that("sf can read non-sf tables with geometries", {
     expect_silent(st_read(pg, query = "SELECT 'POINT(1 1)'::geometry as a, 'POINT(2 2)'::geometry as b"))
 })
 
+test_that("returns an `sf` object (#1039)", {
+    skip_if_not(can_con(pg), "could not connect to postgis database")
+    expect_is(st_read(pg, query = "SELECT 'POINT(1 1)'::geometry"), "sf")
+    expect_is(st_read(pg, query = "SELECT 'POINT(1 1)'::geometry", as_tibble = TRUE), "sf")
+    expect_is(read_sf(pg, query = "SELECT 'POINT(1 1)'::geometry"), "sf")
+})
+
 test_that("validates arguments", {
     skip_if_not(can_con(pg), "could not connect to postgis database")
     expect_error(st_read(pg), "Provide either a `layer` or a `query`")


### PR DESCRIPTION
* Silence a quoting warning (03223f3)
* Create tibbles using `new_tibble`
* Test returned class for database
* Add logic to respect `stringsAsFactors` defaults (for tibbles it should be FALSE, for data.frames it should use `default.stringsAsFactors()`, I believe)

As always, happy to make modifications if needed.