### PR TITLE
Allow `filter()` to sfc directly

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -20,14 +20,9 @@ group_split.sf <- function(.tbl, ..., keep = TRUE) {
 #' nc = st_read(system.file("shape/nc.shp", package="sf"))
 #' nc %>% filter(AREA > .1) %>% plot()
 filter.sf <- function(.data, ..., .dots) {
-	#st_as_sf(NextMethod())
-	sf_column = attr(.data, "sf_column")
-	geom = .data[[sf_column]]
-	.data[[sf_column]] = seq_len(nrow(.data))
-	ret = NextMethod()
-	sel = ret[[sf_column]]
-	ret[[sf_column]] = geom[sel]
-	st_as_sf(ret, sf_column_name = sf_column)
+	agr = st_agr(.data)
+	class(.data) <- setdiff(class(.data), "sf")
+	.re_sf(NextMethod(), sf_column_name = attr(.data, "sf_column"), agr)
 }
 
 #' @name tidyverse

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -8,6 +8,18 @@ test_that("select works", {
   expect_true(nc %>% select(AREA) %>% inherits("sf"))
 })
 
+test_that("filter to sfc works", {
+  tbl = tibble(a = c("A", "B", "C"),
+              geometry = st_sfc(st_point(c(1, 1)),
+                                st_point(),
+                                st_linestring()))
+  d = st_sf(tbl)
+  expect_identical(d %>% filter(!st_is_empty(geometry)),
+                   d[1, ])
+  expect_identical(d %>% filter(st_is(geometry, "POINT")),
+                   d[1:2, ])
+})
+
 suppressMessages(library(tidyr))
 test_that("separate and unite work", {
   expect_true(nc %>% separate(CNTY_ID, c("a", "b"), sep = 2) %>% inherits("sf"))


### PR DESCRIPTION
`sf::filter.sf()` cannot specify sfc directly.

``` r
library(dplyr, warn.conflicts = FALSE)
library(sf)
#> Linking to GEOS 3.7.2, GDAL 2.4.1, PROJ 6.0.0
d = tibble:::tibble(a = c("A", "B", "C"),
             geometry = st_sfc(st_point(c(1, 1)),
                              st_point(),
                              st_linestring())) %>% 
    st_sf()

d %>% filter(st_is_empty(geometry))
#> Error in UseMethod("st_geometry"): no applicable method for 'st_geometry' applied to an object of class "c('integer', 'numeric')"
```

It can be realized by reference by `.$`

``` r
# Just works with .$
d %>% filter(st_is_empty(.$geometry))
#> Simple feature collection with 2 features and 1 field (with 2 geometries empty)
#> geometry type:  GEOMETRY
#> dimension:      XY
#> bbox:           xmin: NA ymin: NA xmax: NA ymax: NA
#> epsg (SRID):    NA
#> proj4string:    NA
#> # A tibble: 2 x 2
#>   a             geometry
#>   <chr>       <GEOMETRY>
#> 1 B          POINT EMPTY
#> 2 C     LINESTRING EMPTY
```

<sup>Created on 2019-05-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This PR is useful for extracting the following EMPTY geometry and specific geometry types. The behavior does not change when a column other than sfc is subject to `filter()`.

<details>

``` r
d %>% filter(!st_is_empty(geometry))
#> Simple feature collection with 1 feature and 1 field
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 1 ymin: 1 xmax: 1 ymax: 1
#> epsg (SRID):    NA
#> proj4string:    NA
#> # A tibble: 1 x 2
#>   a     geometry
#> * <chr>  <POINT>
#> 1 A        (1 1)

d %>% filter(st_is(geometry, "POINT"))
#> Simple feature collection with 2 features and 1 field (with 1 geometry empty)
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 1 ymin: 1 xmax: 1 ymax: 1
#> epsg (SRID):    NA
#> proj4string:    NA
#> # A tibble: 2 x 2
#>   a     geometry
#> * <chr>  <POINT>
#> 1 A        (1 1)
#> 2 B        EMPTY
```

</detail>