### PR TITLE
Add `geometry_column` argument for `RPostgreSQL` connexions

### DIFF
--- a/R/db.R
+++ b/R/db.R
@@ -32,6 +32,7 @@ st_read.DBIObject = function(dsn = NULL,
                              EWKB = TRUE,
                              quiet = TRUE,
                              as_tibble = FALSE,
+                             geometry_column = NULL,
                              ...) {
     if (is.null(dsn))
         stop("no connection provided") # nocov
@@ -101,10 +102,27 @@ st_read.DBIObject = function(dsn = NULL,
         stop("Query `", query, "` returned no results.", call. = FALSE)  #nocov
     }
 
-    # check for simple features column
-    geometry_column = is_geometry_column(dsn, tbl)
-
-    tbl[geometry_column] <- lapply(tbl[geometry_column], try_postgis_as_sfc, EWKB = EWKB, conn = dsn)
+    if (is.null(geometry_column)) {
+        # scan table for simple features column
+        geometry_column = is_geometry_column(dsn, tbl)
+        tbl[geometry_column] <- lapply(tbl[geometry_column], try_postgis_as_sfc, EWKB = EWKB, conn = dsn)
+    } else {
+        if (!all(geometry_column %in% names(tbl))) {
+            nm <- names(tbl)
+            prefix <- ""
+            new_line <- ""
+            if(length(nm) > 1) {
+                prefix <- "\t *"
+                new_line <- "\n"
+            }
+            stop("Could not find `geometry_column` (", geometry_column, ") ",
+                "in column names. Available names are:",
+                new_line,
+                paste(prefix, nm, collapse = "\n", sep = " "),
+                call. = FALSE)
+        }
+        tbl[geometry_column] <- lapply(tbl[geometry_column], postgis_as_sfc, EWKB = EWKB, conn = dsn)
+    }
 
     # if there are no simple features geometries, return a data frame
     if (! any(vapply(tbl, inherits, logical(1), "sfc"))) {

--- a/man/st_read.Rd
+++ b/man/st_read.Rd
@@ -20,7 +20,8 @@ read_sf(..., quiet = TRUE, stringsAsFactors = FALSE,
   as_tibble = TRUE)
 
 \method{st_read}{DBIObject}(dsn = NULL, layer = NULL, query = NULL,
-  EWKB = TRUE, quiet = TRUE, as_tibble = FALSE, ...)
+  EWKB = TRUE, quiet = TRUE, as_tibble = FALSE,
+  geometry_column = NULL, ...)
 }
 \arguments{
 \item{dsn}{data source name (interpretation varies by driver - for some


### PR DESCRIPTION
This should provide a good solution to the problem of identifying the geometry column from an `RPostgreSQL` connexion. Removing the `type is 0` message is slightly more tricky, but I think this PR provides enough control to the user that they can avoid the problem.

close #1045