### PR TITLE
Add `separate_rows` method for sf class

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -316,6 +316,8 @@ separate.sf = function(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
 #' @param sep see \link[tidyr]{separate_rows}
 #' @param convert see \link[tidyr]{separate_rows}
 separate_rows.sf <- function(data, ..., sep = "[^[:alnum:]]+", convert = FALSE) {
+	if (!requireNamespace("tidyr", quietly = TRUE))
+		stop("tidyr required: install first?")
 	class(data) <- setdiff(class(data), "sf")
 	ret = tidyr::separate_rows(data, ..., sep = sep, convert = convert)
 	st_as_sf(ret, sf_column_name = attr(data, "sf_column"))

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -313,6 +313,15 @@ separate.sf = function(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
 }
 
 #' @name tidyverse
+#' @param sep see \link[tidyr]{separate_rows}
+#' @param convert see \link[tidyr]{separate_rows}
+separate_rows.sf <- function(data, ..., sep = "[^[:alnum:]]+", convert = FALSE) {
+	class(data) <- setdiff(class(data), "sf")
+	ret = tidyr::separate_rows(data, ..., sep = sep, convert = convert)
+	st_as_sf(ret, sf_column_name = attr(data, "sf_column"))
+}
+
+#' @name tidyverse
 unite.sf <- function(data, col, ..., sep = "_", remove = TRUE) {
 	class(data) <- setdiff(class(data), "sf")
 	if (!requireNamespace("rlang", quietly = TRUE))
@@ -419,6 +428,7 @@ register_all_s3_methods = function() {
 	register_s3_method("tidyr", "spread", "sf")
 	register_s3_method("tidyr", "nest", "sf")
 	register_s3_method("tidyr", "separate", "sf")
+	register_s3_method("tidyr", "separate_rows", "sf")
 	register_s3_method("tidyr", "unite", "sf")
 	register_s3_method("tidyr", "unnest", "sf")
 	register_s3_method("pillar", "obj_sum", "sfc")

--- a/man/tidyverse.Rd
+++ b/man/tidyverse.Rd
@@ -20,6 +20,7 @@
 \alias{sample_frac.sf}
 \alias{nest.sf}
 \alias{separate.sf}
+\alias{separate_rows.sf}
 \alias{unite.sf}
 \alias{unnest.sf}
 \alias{inner_join.sf}
@@ -68,6 +69,8 @@ nest.sf(data, ..., .key = "data")
 
 separate.sf(data, col, into, sep = "[^[:alnum:]]+", remove = TRUE,
   convert = FALSE, extra = "warn", fill = "warn", ...)
+
+separate_rows.sf(data, ..., sep = "[^[:alnum:]]+", convert = FALSE)
 
 unite.sf(data, col, ..., sep = "_", remove = TRUE)
 
@@ -164,6 +167,10 @@ it is a potentially expensive operation so you must opt into it.}
 \item{suffix}{If there are non-joined duplicate variables in \code{x} and
 \code{y}, these suffixes will be added to the output to disambiguate them.
 Should be a character vector of length 2.}
+
+\item{sep}{see \link[tidyr]{separate_rows}}
+
+\item{convert}{see \link[tidyr]{separate_rows}}
 }
 \value{
 an object of class \link{sf}

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -27,6 +27,28 @@ test_that("separate and unite work", {
 	unite(CNTY_ID_NEW, c("a", "b"), sep = "") %>% inherits("sf"))
 })
 
+test_that("separate_rows work", {
+  d <- st_as_sf(data.frame(
+    x = seq_len(3),
+    y = c("a", "d,e,f", "g,h"),
+    geometry = st_sfc(st_point(c(1, 1)),
+                      st_point(c(2, 2)),
+                      st_point(c(3, 3))),
+    stringsAsFactors = FALSE))
+  expect_true(d %>%
+                separate_rows(y, convert = TRUE) %>%
+                inherits("sf"))
+  expect_identical(d %>%
+      separate_rows(y, convert = TRUE) %>%
+      st_geometry(),
+    st_sfc(st_point(c(1, 1)),
+           st_point(c(2, 2)),
+           st_point(c(2, 2)),
+           st_point(c(2, 2)),
+           st_point(c(3, 3)),
+           st_point(c(3, 3))))
+})
+
 test_that("group/ungroup works", {
  tbl = tibble(a = c(1,1,2,2), g = st_sfc(st_point(0:1), st_point(1:2), st_point(2:3), st_point(3:4)))
  d = st_sf(tbl)


### PR DESCRIPTION
**Edited**:

When importing the development version of [tidyr@56fb136a12594c527050357a8b6893509b9fc15b](https://github.com/tidyverse/tidyr/commit/56fb136a12594c527050357a8b6893509b9fc15b), `separate_rows()` fails for sf (it was added in tidyr 0.5.0).

``` r
library(sf)
#> Linking to GEOS 3.7.2, GDAL 2.4.1, PROJ 6.0.0
library(dplyr, warn.conflicts = FALSE)
library(tidyr)
d <- st_as_sf(data.frame(
  x = seq_len(3),
  y = c("a", "d,e,f", "g,h"),
  geometry = st_sfc(st_point(c(1, 1)),
                    st_point(c(2, 2)),
                    st_point(c(3, 3))),
  stringsAsFactors = FALSE))

d %>% 
  separate_rows(y, convert = TRUE)
#> Error: Can't slice a scalar
```

This PR supports `separate_rows()` for sf objects. For a variable with multiple attributes, duplicate lines given the same geometry. 
The previous code is processed as follows.

``` r
d %>% 
    separate_rows(y, convert = TRUE)
#> Simple feature collection with 6 features and 2 fields
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 1 ymin: 1 xmax: 3 ymax: 3
#> epsg (SRID):    NA
#> proj4string:    NA
#>   x y    geometry
#> 1 1 a POINT (1 1)
#> 2 2 d POINT (2 2)
#> 3 2 e POINT (2 2)
#> 4 2 f POINT (2 2)
#> 5 3 g POINT (3 3)
#> 6 3 h POINT (3 3)
```

As a practical example, here is the code that processes data registered in OpenStreetMap. 
Values in the `cuisine` column containing restaurant categories are allowed to contain multiple values separated by a semicolon.

