### PR TITLE
Read wkt containing new lines

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,14 @@
 # version 0.7-5
 
+
+* `st_union` no longer segfaults on zero row `sf` objects; #1077
+
+* `st_transform` no longer breaks on zero row `sf` objects; #1075
+
+* when PROJ >= 6.1.0 is available and sf comes with datum files (as is the case with statically linked Windows and OSX CRAN binaries), `PROJ_LIB` is no longer temporarily overwritten, but the PROJ C api is used to set the datum path; #1074
+
+* sf now compiles against GDAL 3.x and PROJ 6.1.0, using the `proj.h` interface; #1070
+
 * `st_distance` returns `NA` for empty geometries, rather than 0; #1055
 
 # version 0.7-4

--- a/R/read.R
+++ b/R/read.R
@@ -134,9 +134,12 @@ process_cpl_read_ogr = function(x, quiet = FALSE, ..., check_ring_dir = FALSE,
 	if (length(which.geom) == 0) {
 		warning("no simple feature geometries present: returning a data.frame or tbl_df",
 			call. = FALSE)
-		x <- as.data.frame(x , stringsAsFactors = stringsAsFactors)
-		if (as_tibble)
-			x <- tibble::new_tibble(x, nrow = nrow(x))
+		if ("list" %in% sapply(x, class) && !as_tibble)
+			warning("list-column present: in case of failure, try read_sf or as_tibble=TRUE") # nocov
+		x = if (as_tibble)
+				tibble::as_tibble(x)
+			else
+				as.data.frame(x , stringsAsFactors = stringsAsFactors)
 		return(x)
 	}
 

--- a/R/wkt.R
+++ b/R/wkt.R
@@ -160,6 +160,9 @@ st_as_sfc.character = function(x, crs = NA_integer_, ..., GeoJSON = FALSE) {
 			}
 			x = ewkt_to_wkt(x)
 		}
+		# sanitize WKT to remove newlines
+		x <- gsub("\r?\n|\r", " ", x)
+
 		ret = st_sfc(CPL_sfc_from_wkt(x))
 		st_crs(ret) = crs
 		ret

--- a/tests/testthat/test_wkt.R
+++ b/tests/testthat/test_wkt.R
@@ -13,6 +13,12 @@ test_that("well-known text", {
   expect_equal(st_sfc(gcol), st_as_sfc(list("GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 3, 2 4))")))
 })
 
+test_that("Can read wkt with newlines", {
+	x <- st_as_sfc('POINT(-71.1776585052917\n\r42.3902909739571)')
+	expect_is(x, "sfc")
+	expect_is(x, "sfc_POINT")
+})
+
 test_that("detect ewkt", {
 	expect_equal(is_ewkt(c("LINESTRING(1663106 -105415,1664320 -104617)",
 			  "SRID=4326;POLYGON(1.0 -2.5,3.2 -5.70000)")),


### PR DESCRIPTION
I ran into the issue than long `WKT` couldn't be parsed in `sf`. Apparently line breaks are rejected by OGR.

I wonder if this line should be in `CPL_sfc_from_wkt` or if it's fine to keep it `st_as_sfc.character` since it's the only function calling it?