### PR TITLE
Quote numbers in graticule labels

### DIFF
--- a/R/graticule.R
+++ b/R/graticule.R
@@ -73,7 +73,7 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 
 	if (is.null(crs))
 		crs = NA_crs_
-	
+
 	if (is.null(datum))
 		datum = crs
 
@@ -220,7 +220,7 @@ trim_bb = function(bb = c(-180, -90, 180, 90), margin, wrap=c(-180,180)) {
 degreeLabelsNS = function(x) {
 	pos = sign(x) + 2
 	dir = c("*S", "", "*N")
-	paste0(abs(x), "*degree", dir[pos])
+	paste0('"', abs(x), '"', "*degree", dir[pos])
 }
 
 degreeLabelsEW = function(x) {
@@ -231,5 +231,5 @@ degreeLabelsEW = function(x) {
 	if (any(x == 180))
 		pos[x == 180] = 2
 	dir = c("*W", "", "*E")
-	paste0(abs(x), "*degree", dir[pos])
+	paste0('"', abs(x), '"', "*degree", dir[pos])
 }


### PR DESCRIPTION
This PR quotes the numbers generated in `st_graticule()`, so that these values can be safely passed to `parse()` in any locale (as reported in tidyverse/ggplot2#3365). This doesn't cause any changes in the ggplot2 doppleganger tests (tested using the re-enabled geom_sf() tests in tidyverse/ggplot2#3361), and thus I think it's unlikely that this will cause problems elsewhere (except in ggplot2's own tests, where we'll have to find a different way to test manual breaks in the graticule).