### PR TITLE
Add pkgdown website to description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -44,7 +44,7 @@ Description: Support for simple features, a standardized way to
     data, to 'GEOS' for geometrical operations, and to 'PROJ' for
     projection conversions and datum transformations.
 License: GPL-2 | MIT + file LICENSE
-URL: https://github.com/r-spatial/sf/
+URL: https://github.com/r-spatial/sf/, https://r-spatial.github.io/sf/
 BugReports: https://github.com/r-spatial/sf/issues/
 Depends:
     methods,


### PR DESCRIPTION
- Users can now directly visit the pkgdown website from the CRAN landing page for sf
- Other pkgdown websites that reference sf functions will now link to the https://r-spatial.github.io/sf/ instead of https://rdrr.io/