### PR TITLE
preserve column names in data.frames

### DIFF
--- a/R/sfc.R
+++ b/R/sfc.R
@@ -222,8 +222,8 @@ summary.sfc = function(object, ..., maxsum = 7L, maxp4s = 10L) {
 #' @export
 as.data.frame.sfc = function(x, ...) {
 	ret = data.frame(row.names = seq_along(x))
-	ret$geometry = x
-	ret
+	ret[["geometry"]] = x
+	setNames(ret, NULL)
 }
 
 

--- a/tests/testthat/test_postgis_RPostgreSQL.R
+++ b/tests/testthat/test_postgis_RPostgreSQL.R
@@ -44,9 +44,9 @@ test_that("can write to db", {
 
 test_that("can handle multiple geom columns", {
 	skip_if_not(can_con(pg), "could not connect to postgis database")
-	multi <- cbind(pts[["geometry"]], st_transform(pts, 4326))
+	multi <- cbind(geometry_2 = pts[["geometry"]], st_transform(pts, 4326))
 	expect_silent(st_write(multi, pg, "meuse_multi", overwrite = TRUE))
-	multi2 <- cbind(pts[["geometry"]], st_set_crs(st_transform(pts, 4326), NA))
+	multi2 <- cbind(geometry_2 = pts[["geometry"]], st_set_crs(st_transform(pts, 4326), NA))
 	expect_silent(st_write(multi2, pg, "meuse_multi2", overwrite = TRUE))
 	skip_on_travis()
 	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE))
@@ -55,14 +55,14 @@ test_that("can handle multiple geom columns", {
 	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, type = c(1,4)))
 	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, type = c(4,4)))
 	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, promote_to_multi = FALSE))
-	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, geometry_column = "geometry.1"))
+	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, geometry_column = "geometry_2"))
 	x <- st_layers("PG:host=localhost dbname=postgis")
 	expect_silent(x <- st_read(pg, "meuse_multi2"))
 	# expect_equal(st_crs(x[["geometry"]]), st_crs(multi2[["geometry"]])) #-->> not generally the case, this CRS varies accross installations (EPSG db versions)
-	expect_equal(st_crs(x[["geometry.1"]]), st_crs(multi2[["geometry.1"]]))
+	expect_equal(st_crs(x[["geometry"]]), st_crs(multi2[["geometry"]]))
 	expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi2", quiet = TRUE))
 	#expect_equal(st_crs(x[["geometry"]]), st_crs(multi2[["geometry"]]))
-	expect_equal(st_crs(x[["geometry.1"]]), st_crs(multi2[["geometry.1"]]))
+	expect_equal(st_crs(x[["geometry_2"]]), st_crs(multi2[["geometry_2"]]))
 })
 
 test_that("RPostgreSQL driver can use `geometry_column` (#1045)", {

--- a/tests/testthat/test_postgis_RPostgres.R
+++ b/tests/testthat/test_postgis_RPostgres.R
@@ -43,7 +43,7 @@ test_that("can write to db", {
 
 test_that("can handle multiple geom columns", {
     skip_if_not(can_con(pg), "could not connect to postgis database")
-    multi <- cbind(pts[["geometry"]], st_transform(pts, 4326))
+    multi <- cbind(geometry_2 = pts[["geometry"]], st_transform(pts, 4326))
     expect_silent(st_write(multi, pg, "meuse_multi", overwrite = TRUE))
     expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE))
     # expect_equal(st_crs(x[["geometry"]]), st_crs(multi[["geometry"]])) -> fails if EPSG databases differ
@@ -51,13 +51,13 @@ test_that("can handle multiple geom columns", {
     expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, type = c(1,4)))
     expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, type = c(4,4)))
     expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, promote_to_multi = FALSE))
-    expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, geometry_column = "geometry.1"))
+    expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi", quiet = TRUE, geometry_column = "geometry_2"))
     x <- st_layers("PG:host=localhost dbname=postgis")
-    multi2 <- cbind(pts[["geometry"]], st_set_crs(st_transform(pts, 4326), NA))
+    multi2 <- cbind(geometry_2 = pts[["geometry"]], st_set_crs(st_transform(pts, 4326), NA))
     expect_silent(st_write(multi2, pg, "meuse_multi2", overwrite = TRUE))
     expect_silent(x <- st_read(pg, "meuse_multi2"))
     expect_equal(st_crs(x[["geometry"]]), st_crs(multi2[["geometry"]]))
-    expect_equal(st_crs(x[["geometry.1"]]), st_crs(multi2[["geometry.1"]]))
+    expect_equal(st_crs(x[["geometry_2"]]), st_crs(multi2[["geometry_2"]]))
     expect_silent(x <- st_read("PG:host=localhost dbname=postgis", "meuse_multi2", quiet = TRUE))
     #expect_equal(st_crs(x[["geometry"]]), st_crs(multi2[["geometry"]]))
     expect_equal(st_crs(x[["geometry.1"]]), st_crs(multi2[["geometry.1"]]))

--- a/tests/testthat/test_sfc.R
+++ b/tests/testthat/test_sfc.R
@@ -121,3 +121,13 @@ test_that("c.sfc n_empty returns sum of st_is_empty(sfg)", {
 test_that("st_is_longlat warns on invalid bounding box", {
 	expect_warning(st_is_longlat(st_sfc(st_point(c(0,-95)), crs = 4326)))
 })
+
+test_that("Geometry column name is preserved (#1097)", {
+	# automatically renamed to geometry
+	x <- data.frame(
+		a = st_sfc(st_point(c(0, 0)))
+	)
+	expect_equal(names(x), "a")
+	y <- st_sf(x)
+	expect_equal(attributes(y)[["sf_column"]], "a")
+})


### PR DESCRIPTION
I found an hacky way, but it seems to work.
``` r
library(sf)
#> Linking to GEOS 3.7.0, GDAL 2.4.0, PROJ 5.2.0

# works
st_as_sf(
    data.frame(
        a = st_sfc(st_point(c(0, 0))),
        b = st_sfc(st_point(c(1, 0)))
    ), 
    sf_column_name = "b"
)
#> Simple feature collection with 1 feature and 0 fields
#> Active geometry column: b
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 1 ymin: 0 xmax: 1 ymax: 0
#> epsg (SRID):    NA
#> proj4string:    NA
#>             a           b
#> 1 POINT (0 0) POINT (1 0)
```
But unnamed columns are now ugly (default data.frame behavior)
``` r
st_as_sf(data.frame(st_sfc(st_point(c(0, 0)))))
#> Simple feature collection with 1 feature and 0 fields
#> geometry type:  POINT
#> dimension:      XY
#> bbox:           xmin: 0 ymin: 0 xmax: 0 ymax: 0
#> epsg (SRID):    NA
#> proj4string:    NA
#>   st_sfc.st_point.c.0..0...
#> 1               POINT (0 0)
```

The other option would be to build the data.frame from scratch with something like
``` r
as.data.frame.sfc = function(x, ...) {
	structure(list(x), row.names = seq_along(x), class = "data.frame")
}
```
But it might be more brittle since it doesn't use default `data.frame` constructor?