### PR TITLE
Parse GEOS dev version numbers

### DIFF
--- a/configure
+++ b/configure
@@ -4166,7 +4166,7 @@ GEOS_VERSION=`${GEOS_CONFIG} --version`
 $as_echo "$as_me: GEOS: ${GEOS_VERSION}" >&6;}
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking GEOS version >= 3.4.0" >&5
 $as_echo_n "checking GEOS version >= 3.4.0... " >&6; } # GDAL 2.0.1 requires GEOS 3.1.0
-GEOS_VER_DOT=`echo $GEOS_VERSION | tr -d "."`
+GEOS_VER_DOT=`echo $GEOS_VERSION | tr -d ".[:alpha:]"`
 if test ${GEOS_VER_DOT} -lt 340 ; then
   { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
 $as_echo "no" >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -674,7 +674,7 @@ fi
 GEOS_VERSION=`${GEOS_CONFIG} --version`
 AC_MSG_NOTICE([GEOS: ${GEOS_VERSION}])
 AC_MSG_CHECKING([GEOS version >= 3.4.0]) # GDAL 2.0.1 requires GEOS 3.1.0
-GEOS_VER_DOT=`echo $GEOS_VERSION | tr -d "."`
+GEOS_VER_DOT=`echo $GEOS_VERSION | tr -d ".[[:alpha:]]"`
 if test ${GEOS_VER_DOT} -lt 340 ; then
   AC_MSG_RESULT(no)
   AC_MSG_ERROR([upgrade GEOS to 3.4.0 or later])


### PR DESCRIPTION
Avoids the following error message during configure:
`checking GEOS version >= 3.4.0... ./configure: line 4170: test: 380dev: integer expression expected`