### PR TITLE
Fix compatible with tidyr 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,7 +93,8 @@ Suggests:
     tibble (>= 1.4.1),
     tidyr (>= 0.7-2),
     tidyselect,
-    tmap (>= 2.0)
+    tmap (>= 2.0),
+    vctrs
 LinkingTo: 
     Rcpp
 Remotes:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -88,7 +88,7 @@ Suggests:
     RSQLite,
     sp (>= 1.2-4),
     spatstat,
-	stars (>= 0.2-0),
+    stars (>= 0.2-0),
     testthat,
     tibble (>= 1.4.1),
     tidyr (>= 0.7-2),
@@ -96,6 +96,8 @@ Suggests:
     tmap (>= 2.0)
 LinkingTo: 
     Rcpp
+Remotes:
+    tidyverse/tidyr
 VignetteBuilder: 
     knitr
 Encoding: UTF-8

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -270,9 +270,9 @@ sample_frac.sf <- function(tbl, size = 1, replace = FALSE, weight = NULL, .env =
 #' storms.sf = st_as_sf(storms, coords = c("long", "lat"), crs = 4326)
 #' # TODO: uncomment this when https://github.com/tidyverse/tidyr/pull/729 is merged
 #' # x <- storms.sf %>% group_by(name, year) %>% nest
-#' trs = lapply(x$data, function(tr) st_cast(st_combine(tr), "LINESTRING")[[1]]) %>% st_sfc(crs = 4326)
-#' trs.sf = st_sf(x[,1:2], trs)
-#' plot(trs.sf["year"], axes = TRUE)
+#' # trs = lapply(x$data, function(tr) st_cast(st_combine(tr), "LINESTRING")[[1]]) %>% st_sfc(crs = 4326)
+#' # trs.sf = st_sf(x[,1:2], trs)
+#' # plot(trs.sf["year"], axes = TRUE)
 #' @details \code{nest} assumes that a simple feature geometry list-column was among the columns that were nested.
 nest.sf = function (data, ..., .key = "data") {
 	class(data) <- setdiff(class(data), "sf")

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -401,6 +401,10 @@ pillar_shaft.sfc <- function(x, ...) {
 	pillar::new_pillar_shaft_simple(out, align = "right", min_width = 25)
 }
 
+vec_proxy.sfc <- function(x, ...) {
+	x
+}
+
 register_all_s3_methods = function() {
 	register_s3_method("dplyr", "anti_join", "sf")
 	register_s3_method("dplyr", "arrange", "sf")
@@ -433,6 +437,7 @@ register_all_s3_methods = function() {
 	register_s3_method("pillar", "obj_sum", "sfc")
 	register_s3_method("pillar", "type_sum", "sfc")
 	register_s3_method("pillar", "pillar_shaft", "sfc")
+	register_s3_method("vctrs", "vec_proxy", "sfc")
 }
 
 # from: https://github.com/tidyverse/hms/blob/master/R/zzz.R

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -274,15 +274,14 @@ sample_frac.sf <- function(tbl, size = 1, replace = FALSE, weight = NULL, .env =
 #' plot(trs.sf["year"], axes = TRUE)
 #' @details \code{nest} assumes that a simple feature geometry list-column was among the columns that were nested.
 nest.sf = function (data, ..., .key = "data") {
-	class(data) <- setdiff(class(data), "sf")
+	class(data) = setdiff(class(data), "sf")
 
 	if (!requireNamespace("rlang", quietly = TRUE))
 		stop("rlang required: install first?")
-	key = rlang::enquo(.key)
 
 	if (!requireNamespace("tidyr", quietly = TRUE))
 		stop("tidyr required: install first?")
-	ret = tidyr::nest(data, ..., .key = !! key)
+	ret = tidyr::nest(data, ..., .key = .key)
 	# should find out first if geometry column was in ... !
 	ret[[.key]] = lapply(ret[[.key]], st_as_sf, sf_column_name = attr(data, "sf_column"))
 	ret

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -268,7 +268,8 @@ sample_frac.sf <- function(tbl, size = 1, replace = FALSE, weight = NULL, .env =
 #' @param .key see \link[tidyr]{nest}
 #' @examples
 #' storms.sf = st_as_sf(storms, coords = c("long", "lat"), crs = 4326)
-#' x <- storms.sf %>% group_by(name, year) %>% nest
+#' # TODO: uncomment this when https://github.com/tidyverse/tidyr/pull/729 is merged
+#' # x <- storms.sf %>% group_by(name, year) %>% nest
 #' trs = lapply(x$data, function(tr) st_cast(st_combine(tr), "LINESTRING")[[1]]) %>% st_sfc(crs = 4326)
 #' trs.sf = st_sf(x[,1:2], trs)
 #' plot(trs.sf["year"], axes = TRUE)

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -274,14 +274,15 @@ sample_frac.sf <- function(tbl, size = 1, replace = FALSE, weight = NULL, .env =
 #' plot(trs.sf["year"], axes = TRUE)
 #' @details \code{nest} assumes that a simple feature geometry list-column was among the columns that were nested.
 nest.sf = function (data, ..., .key = "data") {
-	class(data) = setdiff(class(data), "sf")
+	class(data) <- setdiff(class(data), "sf")
 
 	if (!requireNamespace("rlang", quietly = TRUE))
 		stop("rlang required: install first?")
+	key = rlang::enquo(.key)
 
 	if (!requireNamespace("tidyr", quietly = TRUE))
 		stop("tidyr required: install first?")
-	ret = tidyr::nest(data, ..., .key = .key)
+	ret = tidyr::nest(data, ..., .key = !! key)
 	# should find out first if geometry column was in ... !
 	ret[[.key]] = lapply(ret[[.key]], st_as_sf, sf_column_name = attr(data, "sf_column"))
 	ret

--- a/man/tidyverse.Rd
+++ b/man/tidyverse.Rd
@@ -220,7 +220,8 @@ nc \%>\% select(SID74, SID79, geometry, row) \%>\%
 	gather("VAR", "SID", -geometry, -row) \%>\%
 	spread(VAR, SID) \%>\% head()
 storms.sf = st_as_sf(storms, coords = c("long", "lat"), crs = 4326)
-x <- storms.sf \%>\% group_by(name, year) \%>\% nest
+# TODO: uncomment this when https://github.com/tidyverse/tidyr/pull/729 is merged
+# x <- storms.sf \%>\% group_by(name, year) \%>\% nest
 trs = lapply(x$data, function(tr) st_cast(st_combine(tr), "LINESTRING")[[1]]) \%>\% st_sfc(crs = 4326)
 trs.sf = st_sf(x[,1:2], trs)
 plot(trs.sf["year"], axes = TRUE)

--- a/man/tidyverse.Rd
+++ b/man/tidyverse.Rd
@@ -222,7 +222,7 @@ nc \%>\% select(SID74, SID79, geometry, row) \%>\%
 storms.sf = st_as_sf(storms, coords = c("long", "lat"), crs = 4326)
 # TODO: uncomment this when https://github.com/tidyverse/tidyr/pull/729 is merged
 # x <- storms.sf \%>\% group_by(name, year) \%>\% nest
-trs = lapply(x$data, function(tr) st_cast(st_combine(tr), "LINESTRING")[[1]]) \%>\% st_sfc(crs = 4326)
-trs.sf = st_sf(x[,1:2], trs)
-plot(trs.sf["year"], axes = TRUE)
+# trs = lapply(x$data, function(tr) st_cast(st_combine(tr), "LINESTRING")[[1]]) \%>\% st_sfc(crs = 4326)
+# trs.sf = st_sf(x[,1:2], trs)
+# plot(trs.sf["year"], axes = TRUE)
 }

--- a/tests/dplyr.R
+++ b/tests/dplyr.R
@@ -93,7 +93,8 @@ dbReadTable(con, "nc.gpkg") %>% filter(AREA > 0.2) %>% collect %>% st_sf
 
 # nest:
 storms.sf = st_as_sf(storms, coords = c("long", "lat"), crs = 4326)
-x <- storms.sf %>% group_by(name, year) %>% nest
+# TODO: uncomment this when https://github.com/tidyverse/tidyr/pull/729 is merged
+# x <- storms.sf %>% group_by(name, year) %>% nest
 
 nrow(distinct(nc[c(1,1,1,2,2,3:100),]))
 

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -79,7 +79,6 @@ test_that("unnest works", {
     slice(1:2) %>%
     transmute(y = list(c("a"), c("b", "c")))
   unnest_explicit = unnest(nc, y)
-  unnest_implicit = unnest(nc)
   # The second row is duplicated because the "b" and "c" become separate rows
   expected = nc[c(1,2,2), ] %>% mutate(y = c("a", "b", "c"))
   expected = expected[2:1]

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -84,5 +84,4 @@ test_that("unnest works", {
   expected = expected[2:1]
   # Would use expect_equal, but doesn't work with geometry cols
   expect_identical(unnest_explicit, expected)
-  expect_identical(unnest_implicit, expected)
 })

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -81,7 +81,6 @@ test_that("unnest works", {
   unnest_explicit = unnest(nc, y)
   # The second row is duplicated because the "b" and "c" become separate rows
   expected = nc[c(1,2,2), ] %>% mutate(y = c("a", "b", "c"))
-  expected = expected[2:1]
   # Would use expect_equal, but doesn't work with geometry cols
   expect_identical(unnest_explicit, expected)
 })

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -61,7 +61,9 @@ test_that("sample_n etc work", {
  d = st_sf(tbl)
  sample_n(d, 2)
  sample_frac(d, .5)
- d %>% group_by(a) %>% nest
+
+ # TODO: uncomment this when https://github.com/tidyverse/tidyr/pull/729 is merged
+ # d %>% group_by(a) %>% nest
 })
 
 test_that("st_intersection of tbl returns tbl", {


### PR DESCRIPTION
**DO NOT MERGE THIS**

Fixes https://github.com/r-spatial/sf/issues/1068

This PR will

* define `vec_proxy.sfc()` to make `unnest()` and `separate_rows()` work
* remove tests and examples that no longer work
* comment out `nest()` related codes until https://github.com/tidyverse/tidyr/pull/729 is merged