### PR TITLE
Remove Remotes field from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -97,8 +97,6 @@ Suggests:
     vctrs
 LinkingTo: 
     Rcpp
-Remotes:
-    tidyverse/tidyr
 VignetteBuilder: 
     knitr
 Encoding: UTF-8


### PR DESCRIPTION
I added this in #1145 to test with tidyr 1.0.0. Now that it's released on CRAN, these lines are no more needed (sorry that I didn't do this soon...).