### PR TITLE
added warning in clean_columns for dropped columns

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -258,6 +258,10 @@ clean_columns = function(obj, factorsAsCharacter) {
 	ccls.ok = vapply(obj, function(x) inherits(x, permitted), TRUE)
 	if (any(!ccls.ok)) {
 		# nocov start
+                nms <- names(obj)[!ccls.ok]
+                cls <- sapply(obj, function(x) paste(class(x), collapse=";"))[!ccls.ok]
+                warning("Dropping column(s) ", paste(nms, collapse=","),
+                    " of class(es) ", paste(cls, collapse=","))
 		obj = obj[ccls.ok]
 		# nocov end
 	}


### PR DESCRIPTION
Re: https://github.com/r-spatial/sf/issues/1160. Not tested against arbitrary column classes, just `list`