### PR TITLE
adds runifpoint

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -130,6 +130,20 @@ st_poly_sample = function(x, size, ..., type = "random",
 			runif(size, bb[2], bb[4])
 		m = cbind(lon, lat)
 		st_sfc(lapply(seq_len(nrow(m)), function(i) st_point(m[i,])), crs = st_crs(x))
+	} else if (type == "runifpoint"){
+		if (!requireNamespace("spatstat", quietly = TRUE)){
+			stop("package spatstat required, please install it first")
+		}
+		if (!requireNamespace("maptools", quietly = TRUE)){
+			stop("package maptools required, please install it first")
+		}
+		window_spatstat = maptools::as.owin.SpatialPolygons(as(x, "Spatial"))
+
+		pp = spatstat::runifpoint(n = size, win = window_spatstat, ...)
+		pp = st_as_sf(pp)
+		pp = st_collection_extract(pp, "POINT")
+		pp = st_geometry(pp)
+		return(pp)
 	} else
 		stop(paste("sampling type", type, "not implemented for polygons"))
 	pts[lengths(st_intersects(pts, x)) > 0]


### PR DESCRIPTION
@edzer this PR adds the spatstat::runifpoint function's support to **sf**. Please take a look at the code and let me know if this implementation is ok. If so, I can add some documentation, etc.

The second thing is to decide which sampling types from **spatstat** are worth adding - see pages 3 and 4 at https://spatstat.org/resources/spatstatQuickref.pdf for the complete list.

Example of use:

``` r
library(sf)
#> Linking to GEOS 3.7.1, GDAL 2.3.2, PROJ 5.2.0

window = read_sf(system.file("shape/nc.shp", package = "sf"))
p1 = st_sample(window, size = 20, type = "runifpoint")
plot(p1)
```

![](https://i.imgur.com/Thu6BmB.png)

<sup>Created on 2019-11-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>