### PR TITLE
Avoid PPA for newer Ubuntu versions?

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,12 @@ Alternatively [these instructions](https://stat.ethz.ch/pipermail/r-sig-mac/2017
 For Unix-alikes, GDAL (>= 2.0.1), GEOS (>= 3.4.0) and Proj.4 (>= 4.8.0) are required.
 
 #### Ubuntu
-To install the dependencies on Ubuntu, either add [ubuntugis-unstable](http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/) to the package repositories:
+Dependencies for recent versions of Ubuntu are available in the official repositories.
+```sh
+sudo apt-get install libudunits2-dev libgdal-dev libgeos-dev libproj-dev 
+```
+
+To install the dependencies on older versions of Ubuntu, either add [ubuntugis-unstable](http://ppa.launchpad.net/ubuntugis/ubuntugis-unstable/ubuntu/) to the package repositories:
 ```sh
 sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable
 sudo apt-get update


### PR DESCRIPTION
It isn't necessary for 19.10 eoan, is it?  Please triple-check me, because I'm making some guesses.

It appears to install fine for me without the PPA.  

```sh
E: Failed to fetch http://ppa.launchpad.net/ubuntugis/ubuntugis/ubuntu/dists/eoan/InRelease  403  Forbidden
```

* https://packages.ubuntu.com/eoan/libudunits2-dev
* https://packages.ubuntu.com/eoan/libgdal-dev
* https://packages.ubuntu.com/eoan/libgeos-dev
* https://packages.ubuntu.com/eoan/libproj-dev