### PR TITLE
Change output of st_as_text() for MULTIPOINT to include inner parens. #1219

### DIFF
--- a/R/wkt.R
+++ b/R/wkt.R
@@ -28,10 +28,12 @@ prnt.POINT = function(x, ..., EWKT = TRUE) {
 	paste(WKT_name(x, EWKT = EWKT), pt)
 }
 
-prnt.Matrix = function(x, ...) {
+prnt.Matrix = function(x, nested_parens = FALSE, ...) {
 	pf = function(x, ..., collapse) paste0(fmt(x, ...), collapse = collapse)
 	if (nrow(x) == 0)
 		empty
+	else if (nested_parens)
+		paste0("((", paste0(apply(x, 1, pf, collapse = " ", ...), collapse = "), ("), "))")
 	else
 		paste0("(", paste0(apply(x, 1, pf, collapse = " ", ...), collapse = ", "), ")")
 }
@@ -50,7 +52,7 @@ prnt.MatrixListList = function(x, ...) {
 		paste0("(", paste0(unlist(lapply(x, prnt.MatrixList, ...)), collapse = ", "), ")")
 }
 
-prnt.MULTIPOINT = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.Matrix(x, ...))
+prnt.MULTIPOINT = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.Matrix(x, nested_parens = TRUE, ...))
 prnt.LINESTRING = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.Matrix(x, ...))
 prnt.POLYGON = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.MatrixList(x, ...))
 prnt.MULTILINESTRING = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.MatrixList(x, ...))
@@ -85,7 +87,7 @@ st_as_text = function(x, ...) UseMethod("st_as_text")
 st_as_text.sfg = function(x, ...) {
 	if (Sys.getenv("LWGEOM_WKT") == "true" && requireNamespace("lwgeom", quietly = TRUE) && utils::packageVersion("lwgeom") >= "0.1-5")
 		lwgeom::st_astext(x, ...)
-	else 
+	else
 	  switch(class(x)[2],
 		POINT = prnt.POINT(x, ...),
 		MULTIPOINT =        prnt.MULTIPOINT(x, ...),

--- a/R/wkt.R
+++ b/R/wkt.R
@@ -5,7 +5,7 @@ WKT_name = function(x, EWKT = TRUE) {
 
 	retval = if (zm == "")
 		cls[2]
-	else 
+	else
 		paste(cls[2], substr(cls[1], 3, 4))
 
 	if (EWKT && !is.null(attr(x, "epsg")) && !is.na(attr(x, "epsg")))
@@ -23,7 +23,7 @@ fmt = function(x, ...) sub("^[ ]+", "", sapply(unclass(x), format, ...))
 prnt.POINT = function(x, ..., EWKT = TRUE) {
 	pt = if (any(!is.finite(x)))
 		empty
-	else 
+	else
 		paste0("(", paste0(fmt(x, ...), collapse = " "), ")")
 	paste(WKT_name(x, EWKT = EWKT), pt)
 }
@@ -52,7 +52,10 @@ prnt.MatrixListList = function(x, ...) {
 		paste0("(", paste0(unlist(lapply(x, prnt.MatrixList, ...)), collapse = ", "), ")")
 }
 
-prnt.MULTIPOINT = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.Matrix(x, nested_parens = TRUE, ...))
+prnt.MULTIPOINT = function(x, ..., EWKT = TRUE, nested_parens = FALSE) {
+	paste(WKT_name(x, EWKT = EWKT),
+		  prnt.Matrix(x, nested_parens = nested_parens, ...))
+}
 prnt.LINESTRING = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.Matrix(x, ...))
 prnt.POLYGON = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.MatrixList(x, ...))
 prnt.MULTILINESTRING = function(x, ..., EWKT = TRUE) paste(WKT_name(x, EWKT = EWKT), prnt.MatrixList(x, ...))
@@ -90,7 +93,7 @@ st_as_text.sfg = function(x, ...) {
 	else
 	  switch(class(x)[2],
 		POINT = prnt.POINT(x, ...),
-		MULTIPOINT =        prnt.MULTIPOINT(x, ...),
+		MULTIPOINT =        prnt.MULTIPOINT(x, ..., nested_parens = TRUE),
 		LINESTRING =        prnt.LINESTRING(x, ...),
 		POLYGON =           prnt.POLYGON(x, ...),
 		MULTILINESTRING =   prnt.MULTILINESTRING(x, ...),

--- a/tests/testthat/test_deprecated-db.R
+++ b/tests/testthat/test_deprecated-db.R
@@ -154,7 +154,7 @@ test_that("round trips", {
 	round_trip(pg, "POINT ZM (0 0 0 0)")
 	round_trip(pg, "POINT (0 0)")
 	round_trip(pg, "LINESTRING (0 0, 1 1, 2 2)")
-	round_trip(pg, "MULTIPOINT (0 0, 1 1, 2 2)")
+	round_trip(pg, "MULTIPOINT ((0 0), (1 1), (2 2))")
 	round_trip(pg, "POLYGON ((0 0, 1 0, 1 1, 0 0))")
 	round_trip(pg, "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))")
 	round_trip(pg, paste("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0),",

--- a/tests/testthat/test_postgis_RPostgreSQL.R
+++ b/tests/testthat/test_postgis_RPostgreSQL.R
@@ -236,7 +236,7 @@ test_that("round trips", {
 	round_trip(pg, "POINT ZM (0 0 0 0)")
 	round_trip(pg, "POINT (0 0)")
 	round_trip(pg, "LINESTRING (0 0, 1 1, 2 2)")
-	round_trip(pg, "MULTIPOINT (0 0, 1 1, 2 2)")
+	round_trip(pg, "MULTIPOINT ((0 0), (1 1), (2 2))")
 	round_trip(pg, "POLYGON ((0 0, 1 0, 1 1, 0 0))")
 	round_trip(pg, "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))")
 	round_trip(pg, paste("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0),",

--- a/tests/testthat/test_postgis_RPostgres.R
+++ b/tests/testthat/test_postgis_RPostgres.R
@@ -262,7 +262,7 @@ test_that("round trips", {
     round_trip(pg, "POINT ZM (0 0 0 0)")
     round_trip(pg, "POINT (0 0)")
     round_trip(pg, "LINESTRING (0 0, 1 1, 2 2)")
-    round_trip(pg, "MULTIPOINT (0 0, 1 1, 2 2)")
+    round_trip(pg, "MULTIPOINT ((0 0), (1 1), (2 2))")
     round_trip(pg, "POLYGON ((0 0, 1 0, 1 1, 0 0))")
     round_trip(pg, "MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0)), ((2 2, 3 2, 3 3, 2 2)))")
     round_trip(pg, paste("MULTIPOLYGON (((0 0, 1 0, 1 1, 0 0),",

--- a/tests/testthat/test_sfg.R
+++ b/tests/testthat/test_sfg.R
@@ -41,11 +41,11 @@ test_that("xx2multixx works", {
 test_that("format works", {
 	digits = options("digits")[[1]]
 	options(digits = 16)
-	expect_identical(format(st_multipoint(matrix(1:6/6,3))), "MULTIPOINT (0.1666666666666...")
-	expect_identical(format(st_sfc(st_multipoint(matrix(1:6/6,3)))), 
-		"MULTIPOINT (0.1666666666666...")
+	expect_identical(format(st_multipoint(matrix(1:6/6,3))), "MULTIPOINT ((0.166666666666...")
+	expect_identical(format(st_sfc(st_multipoint(matrix(1:6/6,3)))),
+		"MULTIPOINT ((0.166666666666...")
 	options(digits = digits)
-	expect_identical(obj_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))), 
+	expect_identical(obj_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))),
 		"MULTIPOINT (...")
 	expect_identical(type_sum.sfc(st_sfc(st_multipoint(matrix(1:6/6,3)))), "MULTIPOINT")
 })


### PR DESCRIPTION
If merged, closes #1219.

As stated in the linked issue, the output of `lwgeom::st_astext()` will continue to omit the inner parens, which will cause an inconsistency unless PostGIS decides to go the same way. 

I know you're working on other higher priority issues (i.e., the `proj` stuff), so no big rush on this.

I have run `revdepcheck::revdep_check()` on all 214 reverse dependencies and found no issues:

``` r
library(revdepcheck)
revdep_report_summary()
#> # Platform
#> 
#> field      value                        
#> ---------  -----------------------------
#> version    R version 3.6.2 (2019-12-12) 
#> os         macOS Mojave 10.14.6         
#> system     x86_64, darwin15.6.0         
#> ui         X11                          
#> language   (EN)                         
#> collate    en_CA.UTF-8                  
#> ctype      en_CA.UTF-8                  
#> tz         America/Vancouver            
#> date       2019-12-19                   
#> 
#> # Dependencies
#> 
#> package    old     new       Δ  
#> ---------  ------  --------  ---
#> sf         0.8-0   0.8-999   *  
#> classInt   0.4-2   0.4-2        
#> DBI        1.1.0   1.1.0        
#> e1071      1.7-3   1.7-3        
#> magrittr   1.5     1.5          
#> Rcpp       1.0.3   1.0.3        
#> units      0.6-5   0.6-5        
#> 
#> # Revdeps
revdep_summary()
#> ✓ adklakedata 0.6.1                      ── E: 0     | W: 0     | N: 0    
#> ✓ amt 0.0.7                              ── E: 0     | W: 0     | N: 0    
#> ✓ arcos 0.8.2                            ── E: 0     | W: 0     | N: 0    
#> ✓ areal 0.1.5                            ── E: 0     | W: 0     | N: 0    
#> ✓ bcdata 0.1.2                           ── E: 0     | W: 0     | N: 0    
#> ✓ bcmaps 0.18.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ bcmaps.rdata 0.1.5                     ── E: 0     | W: 0     | N: 0    
#> ✓ bcmapsdata 0.3.1                       ── E: 0     | W: 0     | N: 0    
#> ✓ BIOMASS 2.1.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ biscale 0.1.2                          ── E: 0     | W: 0     | N: 0    
#> ✓ bnspatial 1.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ brazilmaps 0.1.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ btb 0.1.30                             ── E: 0     | W: 0     | N: 0    
#> ✓ c14bazAAR 1.0.3                        ── E: 0     | W: 0     | N: 0    
#> ✓ cancensus 0.2.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ capm 0.14.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ cartogram 0.2.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ cartography 2.2.1                      ── E: 0     | W: 0     | N: 0    
#> ✓ cdcfluview 0.9.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ censusxy 0.1.2                         ── E: 0     | W: 0     | N: 0    
#> ✓ ckanr 0.4.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ compstatr 0.2.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ concaveman 1.0.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ contact 1.0.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ crawl 2.2.1                            ── E: 0     | W: 0     | N: 0    
#> ✓ crimedata 0.2.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ csodata 0.1.5.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ cyclestreets 0.1.5                     ── E: 0     | W: 0     | N: 0    
#> ✓ DeclareDesign 0.20.0                   ── E: 0     | W: 0     | N: 0    
#> ✓ diffman 0.1.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ dodgr 0.2.5                            ── E: 0     | W: 0     | N: 0    
#> ✓ dssd 0.1.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ ebirdst 0.1.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ echor 0.1.3                            ── E: 0     | W: 0     | N: 0    
#> ✓ EcoIndR 1.6                            ── E: 0     | W: 0     | N: 0    
#> ✓ eddi 0.0.1                             ── E: 0     | W: 0     | N: 0    
#> ✓ eixport 0.4.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ elevatr 0.2.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ EmissV 0.665.1.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ eRTG3D 0.6.2                           ── E: 0     | W: 0     | N: 0    
#> ✓ eSDM 0.3.2                             ── E: 0     | W: 0     | N: 0    
#> ✓ eurostat 3.3.55                        ── E: 0     | W: 0     | N: 0    
#> ✓ exactextractr 0.1.1                    ── E: 0     | W: 0     | N: 0    
#> ✓ fasterize 1.0.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ FedData 2.5.7                          ── E: 0     | W: 0     | N: 0    
#> ✓ fgdr 1.0.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ finbif 0.1.0                           ── E: 0     | W: 0     | N: 0    
#> ✓ fingertipscharts 0.0.10                ── E: 0     | W: 0     | N: 0    
#> ✓ foieGras 0.4.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ GADMTools 3.7-2                        ── E: 0     | W: 0     | N: 0    
#> ✓ gdalUtilities 1.0.0                    ── E: 0     | W: 0     | N: 0    
#> ✓ geobr 1.1                              ── E: 0     | W: 0     | N: 0    
#> ✓ geogrid 0.1.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ geohashTools 0.3.0                     ── E: 0     | W: 0     | N: 0    
#> ✓ geojson 0.3.2                          ── E: 0     | W: 0     | N: 0    
#> ✓ geojsonio 0.8.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ geometa 0.6-1                          ── E: 0     | W: 0     | N: 0    
#> ✓ geometr 0.1.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ geonetwork 0.3                         ── E: 0     | W: 0     | N: 0    
#> ✓ geosample 0.2.1                        ── E: 0     | W: 0     | N: 0    
#> ✓ geoviz 0.2.1                           ── E: 0     | W: 0     | N: 0    
#> ✓ ggformula 0.9.2                        ── E: 0     | W: 0     | N: 0    
#> ✓ ggiraph 0.7.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ ggplot2 3.2.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ ggsn 0.5.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ ggspatial 1.0.3                        ── E: 0     | W: 0     | N: 0    
#> ✓ ggVennDiagram 0.3                      ── E: 0     | W: 0     | N: 0    
#> ✓ googlePolylines 0.7.2                  ── E: 0     | W: 0     | N: 0    
#> ✓ graph4lg 0.2.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ GSODR 2.0.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ gstat 2.0-3                            ── E: 0     | W: 0     | N: 0    
#> ✓ gtfsrouter 0.0.1                       ── E: 0     | W: 0     | N: 0    
#> ✓ GWSDAT 3.0.3                           ── E: 0     | W: 0     | N: 0    
#> ✓ hereR 0.2.1                            ── E: 0     | W: 0     | N: 0    
#> ✓ hydrolinks 0.10.0                      ── E: 0     | W: 0     | N: 0    
#> ✓ ipumsr 0.4.2                           ── E: 0     | W: 0     | N: 0    
#> ✓ isoband 0.2.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ janitor 1.2.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ jpmesh 1.1.3                           ── E: 0     | W: 0     | N: 0    
#> ✓ jpndistrict 0.3.4                      ── E: 0     | W: 0     | N: 0    
#> ✓ kokudosuuchi 0.4.2                     ── E: 0     | W: 0     | N: 0    
#> ✓ LAGOSNE 2.0.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ landsepi 0.0.8                         ── E: 0     | W: 0     | N: 0    
#> ✓ lconnect 0.1.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ leafem 0.0.1                           ── E: 0     | W: 0     | N: 0    
#> ✓ leaflet 2.0.3                          ── E: 0     | W: 0     | N: 0    
#> ✓ leafpm 0.1.0                           ── E: 0     | W: 0     | N: 0    
#> ✓ leafpop 0.0.5                          ── E: 0     | W: 0     | N: 0    
#> ✓ leri 0.0.1                             ── E: 0     | W: 0     | N: 0    
#> ✓ lidR 2.1.4                             ── E: 0     | W: 0     | N: 0    
#> ✓ linemap 0.1.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ link2GI 0.4.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ lutz 0.3.1                             ── E: 0     | W: 0     | N: 0    
#> ✓ lwgeom 0.1-7                           ── E: 0     | W: 0     | N: 0    
#> ✓ macleish 0.3.4                         ── E: 0     | W: 0     | N: 0    
#> ✓ mapdeck 0.2.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ mapedit 0.5.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ mapi 1.0.1                             ── E: 0     | W: 0     | N: 0    
#> ✓ mapsapi 0.4.2                          ── E: 0     | W: 0     | N: 0    
#> ✓ mapview 2.7.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ mlr 2.16.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ MODIS 1.1.6                            ── E: 0     | W: 0     | N: 0    
#> ✓ MODISTools 1.1.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ MODIStsp 1.3.9                         ── E: 0     | W: 0     | N: 0    
#> ✓ moveVis 0.10.3                         ── E: 0     | W: 0     | N: 0    
#> ✓ MTA 0.2.0                              ── E: 0     | W: 0     | N: 0    
#> ✓ nasapower 1.1.3                        ── E: 0     | W: 0     | N: 0    
#> ✓ ncdfgeom 1.1.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ NetLogoR 0.3.6                         ── E: 0     | W: 0     | N: 0    
#> ✓ nhdplusTools 0.3.11                    ── E: 0     | W: 0     | N: 0    
#> ✓ nhdR 0.5.2                             ── E: 0     | W: 0     | N: 0    
#> ✓ NipponMap 0.2                          ── E: 0     | W: 0     | N: 0    
#> ✓ nlaR 0.4.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ nlgeocoder 0.1.3                       ── E: 0     | W: 0     | N: 0    
#> ✓ NLMR 0.4.2                             ── E: 0     | W: 0     | N: 0    
#> ✓ nlrx 0.4.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ nngeo 0.3.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ oceanis 1.0.5                          ── E: 0     | W: 0     | N: 0    
#> ✓ opendatatoronto 0.1.1                  ── E: 0     | W: 0     | N: 0    
#> ✓ openSTARS 1.1.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ Orcs 1.2.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ osmdata 0.1.2                          ── E: 0     | W: 0     | N: 0    
#> ✓ osrm 3.3.2                             ── E: 0     | W: 0     | N: 0    
#> ✓ ows4R 0.1-4                            ── E: 0     | W: 0     | N: 0    
#> ✓ parlitools 0.3.4                       ── E: 0     | W: 0     | N: 0    
#> ✓ pct 0.2.7                              ── E: 0     | W: 0     | N: 0    
#> ✓ pinochet 0.1.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ plotdap 0.0.4                          ── E: 0     | W: 0     | N: 0    
#> ✓ plotly 4.9.1                           ── E: 0     | W: 0     | N: 0    
#> ✓ protolite 2.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ PWFSLSmoke 1.2.100                     ── E: 0     | W: 0     | N: 0    
#> ✓ qualmap 0.1.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ quickmapr 0.3.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ raceland 1.0.3                         ── E: 0     | W: 0     | N: 0    
#> ✓ raster 3.0-7                           ── E: 0     | W: 0     | N: 0    
#> ✓ rasterVis 0.47                         ── E: 0     | W: 0     | N: 0    
#> ✓ rcartocolor 2.0.0                      ── E: 0     | W: 0     | N: 0    
#> ✓ RCzechia 1.4.3                         ── E: 0     | W: 0     | N: 0    
#> ✓ readwritesqlite 0.0.2                  ── E: 0     | W: 0     | N: 0    
#> ✓ reproducible 0.2.11                    ── E: 0     | W: 0     | N: 0    
#> ✓ rerddapXtracto 0.4.5                   ── E: 0     | W: 0     | N: 0    
#> ✓ rFIA 0.1.1                             ── E: 0     | W: 0     | N: 0    
#> ✓ rfishnet2 0.1.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ rgbif 1.4.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ rgeopat2 0.2.6                         ── E: 0     | W: 0     | N: 0    
#> ✓ rgrass7 0.2-1                          ── E: 0     | W: 0     | N: 0    
#> ✓ rmangal 2.0.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ rmapshaper 0.4.1                       ── E: 0     | W: 0     | N: 0    
#> ✓ rmapzen 0.4.2                          ── E: 0     | W: 0     | N: 0    
#> ✓ rnaturalearth 0.1.0                    ── E: 0     | W: 0     | N: 0    
#> ✓ rnoaa 0.9.5                            ── E: 0     | W: 0     | N: 0    
#> ✓ rpostgisLT 0.6.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ RPyGeo 1.0.0                           ── E: 0     | W: 0     | N: 0    
#> ✓ RQGIS 1.0.4                            ── E: 0     | W: 0     | N: 0    
#> ✓ Rsagacmd 0.0.2                         ── E: 0     | W: 0     | N: 0    
#> ✓ rSymbiota 1.0.0                        ── E: 0     | W: 0     | N: 0    
#> ✓ sabre 0.3.2                            ── E: 0     | W: 0     | N: 0    
#> ✓ sdcSpatial 0.1.1                       ── E: 0     | W: 0     | N: 0    
#> ✓ sen2r 1.2.1                            ── E: 0     | W: 0     | N: 0    
#> ✓ sfdct 0.0.6                            ── E: 0     | W: 0     | N: 0    
#> ✓ siland 1.4.5                           ── E: 0     | W: 0     | N: 0    
#> ✓ skimr 2.0.2                            ── E: 0     | W: 0     | N: 0    
#> ✓ slga 1.1.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ SMITIDstruct 0.0.5                     ── E: 0     | W: 0     | N: 0    
#> ✓ smoothr 0.1.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ sociome 1.3.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ SpaDES.core 0.2.7                      ── E: 0     | W: 0     | N: 0    
#> ✓ SpaDES.tools 0.3.4                     ── E: 0     | W: 0     | N: 0    
#> ✓ spatialEco 1.2-1                       ── E: 0     | W: 0     | N: 0    
#> ✓ SpatialKDE 0.5.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ SpatialPosition 2.0.0                  ── E: 0     | W: 0     | N: 0    
#> ✓ spatialreg 1.1-5                       ── E: 0     | W: 0     | N: 0    
#> ✓ spatialrisk 0.6.5                      ── E: 0     | W: 0     | N: 0    
#> ✓ spatialwidget 0.2                      ── E: 0     | W: 0     | N: 0    
#> ✓ spbabel 0.5.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ spData 0.3.2                           ── E: 0     | W: 0     | N: 0    
#> ✓ spdep 1.1-3                            ── E: 0     | W: 0     | N: 0    
#> ✓ spsurvey 4.1.1                         ── E: 0     | W: 0     | N: 0    
#> ✓ stars 0.4-0                            ── E: 0     | W: 0     | N: 0    
#> ✓ stats19 1.1.0                          ── E: 0     | W: 0     | N: 0    
#> ✓ stcos 0.2.1                            ── E: 0     | W: 0     | N: 0    
#> ✓ stlcsb 0.1.2                           ── E: 0     | W: 0     | N: 0    
#> ✓ stormwindmodel 0.1.1                   ── E: 0     | W: 0     | N: 0    
#> ✓ stplanr 0.4.1                          ── E: 0     | W: 0     | N: 0    
#> ✓ streamDepletr 0.1.0                    ── E: 0     | W: 0     | N: 0    
#> ✓ sugarbag 0.1.1                         ── E: 0     | W: 0     | N: 0    
#> ✓ swmmr 0.9.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ tabularaster 0.5.0                     ── E: 0     | W: 0     | N: 0    
#> ✓ tanaka 0.1.1                           ── E: 0     | W: 0     | N: 0    
#> ✓ TargomoR 0.2.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ tidycensus 0.9.2                       ── E: 0     | W: 0     | N: 0    
#> ✓ tidyRSS 1.2.11                         ── E: 0     | W: 0     | N: 0    
#> ✓ tidytransit 0.6.1                      ── E: 0     | W: 0     | N: 0    
#> ✓ tidyUSDA 0.2.4                         ── E: 0     | W: 0     | N: 0    
#> ✓ tigris 0.8.2                           ── E: 0     | W: 0     | N: 0    
#> ✓ tilegramsR 0.2.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ tmap 2.3-1                             ── E: 0     | W: 0     | N: 0    
#> ✓ tmaptools 2.0-2                        ── E: 0     | W: 0     | N: 0    
#> ✓ trackeRapp 1.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ transformr 0.1.1                       ── E: 0     | W: 0     | N: 0    
#> ✓ tricolore 1.2.1                        ── E: 0     | W: 0     | N: 0    
#> ✓ trigpoints 1.0.0                       ── E: 0     | W: 0     | N: 0    
#> ✓ uavRmp 0.5.4                           ── E: 0     | W: 0     | N: 0    
#> ✓ USAboundaries 0.3.1                    ── E: 0     | W: 0     | N: 0    
#> ✓ VancouvR 0.1.1                         ── E: 0     | W: 0     | N: 0    
#> ✓ vein 0.8.0                             ── E: 0     | W: 0     | N: 0    
#> ✓ velociraptr 1.1.0                      ── E: 0     | W: 0     | N: 0    
#> ✓ velox 0.2.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ WaveSampling 0.1.0                     ── E: 0     | W: 0     | N: 0    
#> ✓ wdpar 1.0.0                            ── E: 0     | W: 0     | N: 0    
#> ✓ weathercan 0.3.1                       ── E: 0     | W: 0     | N: 0    
#> ✓ webTRISr 0.2.0                         ── E: 0     | W: 0     | N: 0    
#> ✓ windAC 1.2.0                           ── E: 0     | W: 0     | N: 0    
#> ✓ windfarmGA 2.2.3                       ── E: 0     | W: 0     | N: 0
```

<sup>Created on 2019-12-19 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>