### PR TITLE
Handle sfc_POINT with Z dimension

### DIFF
--- a/R/grid.R
+++ b/R/grid.R
@@ -139,7 +139,7 @@ st_viewport = function(x, ..., bbox = st_bbox(x), asp) {
 
 #' @export
 st_as_grob.sfc_POINT <- function(x, pch = 1, size = unit(1, "char"), default.units = "native", name = NULL, gp = gpar(), vp = NULL, ...) {
-	x <- matrix(unlist(x), nrow = 2)
+	x <- matrix(unlist(x, use.names = FALSE), ncol = length(x))
 	pointsGrob(x[1, ], x[2, ], pch = pch, size = size, default.units = default.units, name = name, gp = gp, vp = vp)
 }
 #' @export


### PR DESCRIPTION
Fix https://github.com/tidyverse/ggplot2/pull/3681.

Currently, `st_as_grob.sfc_POINT()` assumes the dimension of data is always 2, which results in this incorrect result:

``` r
library(sf)
#> Linking to GEOS 3.8.0, GDAL 3.0.2, PROJ 6.2.1
library(ggplot2)

obj_z <- list(st_point(c(1, 1, 1)))
sfc_z <- st_sfc(obj_z)

g <- st_as_grob(sfc_z)
#> Warning in matrix(unlist(x), nrow = 2): data length [3] is not a sub-multiple or
#> multiple of the number of rows [2]

# should be one point
g$x
#> [1] 1native 1native
g$y
#> [1] 1native 1native
```

<sup>Created on 2019-12-20 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>

This should be handled in the same way as how `plot.sfc_POINT()` does using `length()` of the data.

https://github.com/r-spatial/sf/blob/a71f43f069baf006a859b00db3f15ce0b2ab30b9/R/plot.R#L296