### PR TITLE
Remove redundant attributes(x) argument

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -171,7 +171,7 @@ process_cpl_read_ogr = function(x, quiet = FALSE, ..., check_ring_dir = FALSE,
 		x <- as.data.frame(set_utf8(x[-c(lc.other, which.geom)]), stringsAsFactors = stringsAsFactors)
 		if (as_tibble) {
 			# "sf" class is added later by `st_as_sf` (and sets all the attributes)
-			x <- tibble::new_tibble(x, attributes(x), nrow = nrow(x))
+			x <- tibble::new_tibble(x, nrow = nrow(x))
 		}
 	}
 


### PR DESCRIPTION
to `new_tibble()`.

This breaks in tibble 3.0.0, and never had an effect to begin with. The `...` expects named arguments, an unnamed list is ignored. On the up side, all arguments in `x` are retained.