### PR TITLE
st_sample for unprojected polygons 

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -124,12 +124,10 @@ st_poly_sample = function(x, size, ..., type = "random",
 
 		pts = if (type == "hexagonal") {
 			if (isTRUE(st_is_longlat(x))){
-				bb=as.double(bb)
-				a0=as.double(bb[3]-bb[1])*(bb[4]-bb[2])
-				dx = sqrt(a0 / size / (sqrt(3)/2))
-			} else {
-				dx = sqrt(a0 / size / (sqrt(3)/2))
+				bb_longlat=as.double(bb)
+				a0=as.double(bb_longlat[3]-bb_longlat[1])*(bb_longlat[4]-bb_longlat[2])
 			}
+			dx = sqrt(a0 / size / (sqrt(3)/2))
 			hex_grid_points(x, pt = offset, dx = dx)
 		} else if (type == "regular") {
 			if (isTRUE(st_is_longlat(x))){

--- a/R/sample.R
+++ b/R/sample.R
@@ -123,7 +123,13 @@ st_poly_sample = function(x, size, ..., type = "random",
 		bb = st_bbox(x)
 
 		pts = if (type == "hexagonal") {
-			dx = sqrt(a0 / size / (sqrt(3)/2))
+			if (isTRUE(st_is_longlat(x))){
+				bb=as.double(bb)
+				a0=as.double(bb[3]-bb[1])*(bb[4]-bb[2])
+				dx = sqrt(a0 / size / (sqrt(3)/2))
+			} else {
+				dx = sqrt(a0 / size / (sqrt(3)/2))
+			}
 			hex_grid_points(x, pt = offset, dx = dx)
 		} else if (type == "regular") {
 			dx = as.numeric(sqrt(a0 / size))

--- a/R/sample.R
+++ b/R/sample.R
@@ -132,6 +132,10 @@ st_poly_sample = function(x, size, ..., type = "random",
 			}
 			hex_grid_points(x, pt = offset, dx = dx)
 		} else if (type == "regular") {
+			if (isTRUE(st_is_longlat(x))){
+				bb_longlat=as.double(bb)
+				a0=as.double(bb_longlat[3]-bb_longlat[1])*(bb_longlat[4]-bb_longlat[2])
+			}
 			dx = as.numeric(sqrt(a0 / size))
 			offset = c((offset[1] - bb["xmin"]) %% dx,
 				(offset[2] - bb["ymin"]) %% dx) + bb[c("xmin", "ymin")]


### PR DESCRIPTION
Small changes applied in order to make `st_sample` to work with unprojected shapes. `a0` parameter (area) is now computing as width*length of the bounding box when `st_is_longlat(x)==TRUE`.

Following #1220