### PR TITLE
Test build GDAL3 stack on Windows

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,22 +1,24 @@
-VERSION = 2.2.3
-COMPILED_BY ?= gcc-4.6.3
-RWINLIB = ../windows/gdal2-$(VERSION)
+VERSION = 3.0.4
+RWINLIB = ../windows/gdal3-$(VERSION)
 TARGET = lib$(subst gcc,,$(COMPILED_BY))$(R_ARCH)
 
 PKG_CPPFLAGS =\
-	-I$(RWINLIB)/include/gdal \
-	-I$(RWINLIB)/include/geos \
-	-I$(RWINLIB)/include/proj
+	-I$(RWINLIB)/include/gdal-3.0.4 \
+	-I$(RWINLIB)/include/geos-3.8.0 \
+	-I$(RWINLIB)/include/proj-6.3.1 \
+	-DHAVE_PROJ_H
 
 PKG_LIBS = \
 	-L$(RWINLIB)/$(TARGET) \
 	-L$(RWINLIB)/lib$(R_ARCH) \
 	-lgdal -lsqlite3 -lspatialite -lproj -lgeos_c -lgeos  \
-	-ljson-c -lnetcdf -lmariadbclient -lpq -lintl -lwebp -lcurl -lssh2 -lssl -lcrypto \
-	-lkea -lhdf5_cpp -lhdf5_hl -lhdf5 -lexpat -lfreexl -lcfitsio \
-	-lmfhdf -ldf -lxdr \
-	-lopenjp2 -ljasper -lpng16 -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lszip -lz \
-	-lodbc32 -lodbccp32 -liconv -lpsapi -lws2_32 -lcrypt32 -lwldap32 -lsecur32 -lgdi32
+	-ljson-c -lnetcdf -lmariadbclient -lpq -lpgport -lpgcommon \
+	-lwebp -lcurl -lssh2 -lssl \
+	-lhdf5_hl -lhdf5 -lexpat -lfreexl -lcfitsio \
+	-lmfhdf -lhdf -lxdr -lpcre \
+	-lopenjp2 -ljasper -lpng -ljpeg -ltiff -lgeotiff -lgif -lxml2 -llzma -lz \
+	-lodbc32 -lodbccp32 -liconv -lpsapi -lwldap32 -lsecur32 -lgdi32 -lnormaliz \
+	-lcrypto -lcrypt32 -lws2_32
 
 all: clean winlibs
 

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -2,11 +2,11 @@ if(getRversion() < "3.3.0") {
   stop("Your version of R is too old. This package requires R-3.3.0 or newer on Windows.")
 }
 
-# For details see: https://github.com/rwinlib/gdal2
+# For details see: https://github.com/rwinlib/gdal3
 VERSION <- commandArgs(TRUE)
-if(!file.exists(sprintf("../windows/gdal2-%s/include/gdal/gdal.h", VERSION))){
+if(!file.exists(sprintf("../windows/gdal3-%s/include/gdal/gdal.h", VERSION))){
   if(getRversion() < "3.3.0") setInternet2()
-  download.file(sprintf("https://github.com/rwinlib/gdal2/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
+  download.file(sprintf("https://github.com/rwinlib/gdal3/archive/v%s.zip", VERSION), "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")
   unlink("lib.zip")


### PR DESCRIPTION
This is a test run with the [rwinlib/gdal3](https://github.com/rwinlib/gdal3) stack to be able to see if there are unexpected issues in either `sf` or the windows builds. The stack may change, is not ready to be merged.

I think we should wait for R 4.0 before shipping these changes to CRAN because it may cause temporary disruption with the gdal/proj data files and environment variables as some R packages are still using gdal2 and others gdal3.