### PR TITLE
don't negate Y-res in default geotransform

### DIFF
--- a/src/stars.cpp
+++ b/src/stars.cpp
@@ -309,13 +309,15 @@ List CPL_read_gdal(CharacterVector fname, CharacterVector options, CharacterVect
 	// geotransform:
 	double adfGeoTransform[6];
 	CPLErr err = poDataset->GetGeoTransform( adfGeoTransform );
+	// return the default geotransform as per the
+	// GetGeoTransform() doc in classGDALDataset
 	NumericVector geotransform = NumericVector::create(
 		err == CE_None ? adfGeoTransform[0] : 0,
 		err == CE_None ? adfGeoTransform[1] : 1,
 		err == CE_None ? adfGeoTransform[2] : 0,
 		err == CE_None ? adfGeoTransform[3] : 0,
 		err == CE_None ? adfGeoTransform[4] : 0,
-		err == CE_None ? adfGeoTransform[5] : -1); // so non-geo is y-up
+		err == CE_None ? adfGeoTransform[5] : 1);
 	int default_geotransform = 0;
 	if (err != CE_None) {
 		default_geotransform = 1;


### PR DESCRIPTION
I think this should return as per the GDAL documentation - with Y-res = 1. 

Cf https://github.com/r-spatial/sf/pull/1306

This way, the `gdal_read()` function does as GDAL says, and other tools can apply the Y-flip and shift to put a non-geo raster into natural orientation, and with [0, nrow, 0, ncol]. 

I had more to follow up with stars but that's stalled for now