### PR TITLE
Fix vec_ptype(pt, pt)

### DIFF
--- a/R/tidyverse-vctrs.R
+++ b/R/tidyverse-vctrs.R
@@ -11,7 +11,10 @@ vec_restore.sfc = function(x, to, ...) {
 	# Ensure restoration of `n_empty` by `st_sfc()`
 	attr(x, "n_empty") = NULL
 
-	st_sfc(x, crs = st_crs(to), precision = st_precision(to))
+	# x can have length 0, reset class manually
+	out <- st_sfc(x, crs = st_crs(to), precision = st_precision(to))
+	class(out) <- class(to)
+	out
 }
 
 #' vctrs methods for sf objects


### PR DESCRIPTION
with dev vctrs. `vec_restore()` can be called with zero-length input.