### PR TITLE
Issue1332

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -325,11 +325,11 @@ CPL_write_wkb <- function(sfc, EWKB = FALSE) {
     .Call('_sf_CPL_write_wkb', PACKAGE = 'sf', sfc, EWKB)
 }
 
-CPL_get_z_range <- function(sf, depth = 0L) {
+CPL_get_z_range <- function(sf, depth) {
     .Call('_sf_CPL_get_z_range', PACKAGE = 'sf', sf, depth)
 }
 
-CPL_get_m_range <- function(sf, depth = 0L) {
+CPL_get_m_range <- function(sf, depth) {
     .Call('_sf_CPL_get_m_range', PACKAGE = 'sf', sf, depth)
 }
 

--- a/R/m_range.R
+++ b/R/m_range.R
@@ -2,7 +2,7 @@
 #' @name st_m_range
 #' @param x object of class \code{m_range}
 #' @export
-is.na.m_range = function(x) identical(x, NA_m_range_) # nocov
+is.na.m_range = function(x) identical(x, NA_m_range_)
 
 mb_wrap = function(mb) {
 	stopifnot(is.numeric(mb) && length(mb) == 2)

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -97,7 +97,7 @@ st_sfc = function(..., crs = NA_crs_, precision = 0.0, check_ring_dir = FALSE) {
 		} else if ( "XYZ" %in% u ) {
 			attr(lst, "z_range") = compute_z_range(lst)
 		} else if ("XYM" %in% u ) {
-			attr(lst, "m_range") = compute_z_range(lst) ## because it's the 3rd element
+			attr(lst, "m_range") = compute_m_range(lst)
 		}
 	}
 
@@ -276,9 +276,9 @@ st_geometry.sfc = function(obj, ...) obj
 #'
 #' Return geometry type of an object, as a factor
 #' @param x object of class \link{sf} or \link{sfc}
-#' @param by_geometry logical; if \code{TRUE}, return geometry type of each geometry, 
+#' @param by_geometry logical; if \code{TRUE}, return geometry type of each geometry,
 #' else return geometry type of the set
-#' @return a factor with the geometry type of each simple feature geometry 
+#' @return a factor with the geometry type of each simple feature geometry
 #' in \code{x}, or that of the whole set
 #' @export
 st_geometry_type = function(x, by_geometry = TRUE) {

--- a/src/zm_range.cpp
+++ b/src/zm_range.cpp
@@ -2,8 +2,38 @@
 
 #include "zm_range.h"
 
+int get_m_position(Rcpp::NumericVector& pt) {
+	if( pt.size() < 3 ) {
+		Rcpp::stop("m error - expecting at least three coordinates");
+	}
+	int pos = pt.size() == 3 ? 2 : 3;
+	return pos;
+}
 
-Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int pos, int depth) {
+int get_m_position(Rcpp::NumericMatrix& nm) {
+	if( nm.ncol() < 3 ) {
+		Rcpp::stop("m error - expecting at least three columns");
+	}
+	int pos = nm.ncol() == 3 ? 2 : 3;
+	return pos;
+}
+
+int get_z_position(Rcpp::NumericVector& pt) {
+	if( pt.size() < 3 ) {
+		Rcpp::stop("z error - expecting three coordinates");
+	}
+	return 2;
+}
+
+int get_z_position(Rcpp::NumericMatrix& nm) {
+	if( nm.ncol() < 3 ) {
+		Rcpp::stop("z error - expecting three columns;");
+	}
+	return 2;
+}
+
+// [[Rcpp::export]]
+Rcpp::NumericVector CPL_get_z_range(Rcpp::List sf, int depth) {
 
 	Rcpp::NumericVector bb(2);
 	bb[0] = bb[1] = NA_REAL;
@@ -13,6 +43,7 @@ Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int pos, int depth) {
 	case 0: // points:
 		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericVector pt = sf[i];
+			int pos = get_z_position(pt);
 			if (i == 0) {
 				bb[0] = pt[pos];
 				bb[1] = pt[pos];
@@ -26,6 +57,7 @@ Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int pos, int depth) {
 	case 1: // list of matrices:
 		for (decltype(n) i = 0; i < n; i++) {
 			Rcpp::NumericMatrix m = sf[i];
+			int pos = get_z_position(m);
 			auto rows = m.nrow();
 
 			if (i == 0) { // initialize:
@@ -44,7 +76,7 @@ Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int pos, int depth) {
 
 	default: // recursive list
 		for (decltype(n) i = 0; i < n; i++) {
-			Rcpp::NumericVector bbi = CPL_get_zm_range(sf[i], pos, depth - 1); // recurse
+			Rcpp::NumericVector bbi = CPL_get_z_range(sf[i], depth - 1); // recurse
 			if (! Rcpp::NumericVector::is_na(bbi[0])) {
 				if (i == 0) {
 					bb[0] = bbi[0];
@@ -61,11 +93,62 @@ Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int pos, int depth) {
 }
 
 // [[Rcpp::export]]
-Rcpp::NumericVector CPL_get_z_range(Rcpp::List sf, int depth = 0) {
-	return( CPL_get_zm_range(sf, 2, depth ));
+Rcpp::NumericVector CPL_get_m_range(Rcpp::List sf, int depth) {
+
+	Rcpp::NumericVector bb(2);
+	bb[0] = bb[1] = NA_REAL;
+	auto n = sf.size();
+
+	switch(depth) {
+	case 0: // points:
+		for (decltype(n) i = 0; i < n; i++) {
+			Rcpp::NumericVector pt = sf[i];
+			int pos = get_m_position(pt);
+			if (i == 0) {
+				bb[0] = pt[pos];
+				bb[1] = pt[pos];
+			} else {
+				bb[0] = std::min(pt[pos],bb[0]);
+				bb[1] = std::max(pt[pos],bb[1]);
+			}
+		}
+		break;
+
+	case 1: // list of matrices:
+		for (decltype(n) i = 0; i < n; i++) {
+			Rcpp::NumericMatrix m = sf[i];
+			int pos = get_m_position(m);
+			auto rows = m.nrow();
+
+			if (i == 0) { // initialize:
+				if (rows == 0)
+					return bb; // #nocov
+				// Rcpp::stop("CPL_get_zbox: invalid geometry");
+				bb[0] = m(0,pos);
+				bb[1] = m(0,pos);
+			}
+			for (decltype(rows) j = 0; j < rows; j++) {
+				bb[0] = std::min(m(j,pos),bb[0]);
+				bb[1] = std::max(m(j,pos),bb[1]);
+			}
+		}
+		break;
+
+	default: // recursive list
+		for (decltype(n) i = 0; i < n; i++) {
+			Rcpp::NumericVector bbi = CPL_get_m_range(sf[i], depth - 1); // recurse
+			if (! Rcpp::NumericVector::is_na(bbi[0])) {
+				if (i == 0) {
+					bb[0] = bbi[0];
+					bb[1] = bbi[1];
+				} else {
+					bb[0] = std::min(bbi[0],bb[0]);
+					bb[1] = std::max(bbi[1],bb[1]);
+				}
+			}
+		}
+		break;
+	}
+	return bb;
 }
 
-// [[Rcpp::export]]
-Rcpp::NumericVector CPL_get_m_range(Rcpp::List sf, int depth = 0) {
-	return( CPL_get_zm_range(sf, 3, depth ));
-}

--- a/src/zm_range.h
+++ b/src/zm_range.h
@@ -1,4 +1,12 @@
-Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int depth);
+//Rcpp::NumericVector CPL_get_zm_range(Rcpp::List sf, int depth);
+
+int get_m_position(Rcpp::NumericVector& pt);
+
+int get_m_position(Rcpp::NumericMatrix& nm);
+
+int get_z_position(Rcpp::NumericVector& pt);
+
+int get_z_position(Rcpp::NumericMatrix& nm);
 
 Rcpp::NumericVector CPL_get_z_range(Rcpp::List sf, int depth);
 


### PR DESCRIPTION
I've added [these](https://github.com/r-spatial/sf/compare/master...dcooley:issue1332?expand=1#diff-b14e8733b035cbed978d319881866251R5) `get_m_position()` and `get_z_postiion()` functions to check the objects are the correct size before they are subset.

This should solve the valgrind warnings, and I believe the reported crashes.


However, I have an outstanding question where the `m_range` is being printed as (0,0), where it logically should be `NA_m_range_` as it doesn't exist (the dimension is `XYZ`)

```r
# example taken from issue 1332
read_sf("~/Desktop/Fisheries/FisheriesRecreation.gdb/", "bathymetry")
# Simple feature collection with 4887 features and 5 fields
# geometry type:  MULTILINESTRING
# dimension:      XYZ
# bbox:           xmin: 218674 ymin: 4494114 xmax: 713612.8 ymax: 4818581
# z_range:        zmin: 0 zmax: 0
# m_range:        mmin: 0 mmax: 0
# projected CRS:  NAD83 / UTM zone 15N
```

I would expect it to behave the same as these two examples, where only the relevant z or m range is printed, given the dimension of the object.

```r
sf_z <- sf::st_read(system.file("/shape/storms_xyz.shp", package = "sf"), quiet = TRUE)
sf_m <- sf::st_read(system.file("/shape/storms_xyzm.shp", package = "sf"), quiet = TRUE)

sf_z
# Simple feature collection with 71 features and 0 fields
# geometry type:  LINESTRING
# dimension:      XYZ
# bbox:           xmin: -102.2 ymin: 8.3 xmax: 0 ymax: 59.5
# z_range:        zmin: 924 zmax: 1017
# CRS:            NA
# First 10 features:
# 	geometry

sf_m
# Simple feature collection with 71 features and 0 fields
# geometry type:  LINESTRING
# dimension:      XYM
# bbox:           xmin: -102.2 ymin: 8.3 xmax: 0 ymax: 59.5
# m_range:        mmin: 924 mmax: 1017
# CRS:            NA
# First 10 features:
# 	geometry

```