### PR TITLE
Add skip_if_not_installed

### DIFF
--- a/tests/testthat/test_geos.R
+++ b/tests/testthat/test_geos.R
@@ -1,5 +1,7 @@
 context("sf: geos tests")
 
+skip_if_not_installed("rgeos")
+
 test_that("st_relate works", {
   r1 = st_relate(st_sfc(st_point(c(0,0))), st_sfc(st_linestring(rbind(c(0,0),c(1,1)))))
   library(sp)

--- a/tests/testthat/test_postgis_RPostgres.R
+++ b/tests/testthat/test_postgis_RPostgres.R
@@ -10,6 +10,8 @@
 #'  docker start postgis
 skip_on_os("solaris")
 
+skip_if_not_installed("RPostgres")
+
 library(sf)
 library(DBI)
 library(RPostgres)


### PR DESCRIPTION
Hi,

Several tests fail in Debian due to some missing R packages that are not officially packaged for Debian. This patch prevents some errors.

https://salsa.debian.org/r-pkg-team/r-cran-sf/-/blob/master/debian/patches/Skip_tests.patch

Best,
Dylan