### PR TITLE
Update URL field to put pkgdown URL first

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -47,7 +47,7 @@ Description: Support for simple features, a standardized way to
     data, to 'GEOS' for geometrical operations, and to 'PROJ' for
     projection conversions and datum transformations.
 License: GPL-2 | MIT + file LICENSE
-URL: https://github.com/r-spatial/sf/, https://r-spatial.github.io/sf/
+URL: https://r-spatial.github.io/sf/, https://github.com/r-spatial/sf/
 BugReports: https://github.com/r-spatial/sf/issues/
 Depends:
     methods,


### PR DESCRIPTION
For whatever reason, pkgdown uses the first URL in the DESCRIPTION to do its automagic linking. This tiny edit should fix that for sf!

(what current links to sf look like: https://r-spatial.github.io/stars/articles/stars1.html#cropping-a-rasters-extent ...the dplyr functions automagically link to the dplyr pkgdown site)