### PR TITLE
Fix empty `agr` attribute after subset

### DIFF
--- a/R/agr.R
+++ b/R/agr.R
@@ -52,7 +52,7 @@ st_agr.default = function(x = NA_character_, ...) {
 	stopifnot(is.character(value) || is.factor(value))
 	nv = setdiff(names(x), attr(x, "sf_column"))
 	if (length(value) == 0)
-		attr(x, "agr") = NA_agr_[0]
+		attr(x, "agr") = setNames(NA_agr_[0], character())
 	else if (! is.null(names(value)) && length(value) == 1) { 
 		# as in: st_agr(x) = c(Group.1 = "identity"): replace one particular named
 		if (!is.null(attr(x, "agr")))

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -91,3 +91,10 @@ test_that("transform work", {
   expect_identical(st_crs(x), st_crs(x))
   expect_identical(x$elev^2, x2$elev2)
 })
+
+test_that("empty agr attribute is named after subset", {
+	sf = st_sf(data.frame(x = st_sfc(st_point(1:2))))
+	out = sf[, "geometry"]
+	agr = attr(out, "agr")
+	expect_identical(names(agr), character())
+})


### PR DESCRIPTION
After subsetting an sf data frame with `[`, the `agr` attribute becomes unnamed:

```r
sf <- st_sf(data.frame(x = st_sfc(st_point(1:2))))
names(attr(sf, "agr"))
#> character(0)

names(attr(sf[, "geometry"], "agr"))
#> NULL
```

The first commit ensure it is named, to make it easier to compare sf data structures in unit tests.

The second commit finishes incomplete unit tests for `sample_n()` and `nest()` (the expectations depend on the agr fix).