### PR TITLE
Fix tests

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -155,7 +155,9 @@ rename.sf <- function(.data, ...) {
 #' @examples
 #' nc %>% slice(1:2)
 slice.sf <- function(.data, ..., .dots) {
-	st_as_sf(NextMethod(), sf_column_name = attr(.data, "sf_column"))
+	class(.data) <- setdiff(class(.data), "sf")
+	sf_column <- attr(.data, "sf_column")
+	st_as_sf(NextMethod(), sf_column_name = sf_column)
 }
 
 #' @name tidyverse

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -60,11 +60,15 @@ test_that("sample_n etc work", {
 	tbl = tibble(a = c(1,1,2,2), g = st_sfc(st_point(0:1), st_point(1:2), st_point(2:3), st_point(3:4)))
 	d = st_sf(tbl)
 
-	set.seed(1)
-	expect_identical(sample_n(d, 2), d[c(1, 3), ])
+	expect_sampled <- function(x) {
+		expect_true(inherits(x, c("sf", "tbl_df")))
+		expect_named(x, c("a", "g"))
+		expect_equal(nrow(x), 2)
+		expect_true(inherits(x$g, "sfc_POINT"))
+	}
 
-	set.seed(1)
-	expect_identical(sample_frac(d, .5), d[c(1, 3), ])
+	expect_sampled(sample_n(d, 2))
+	expect_sampled(sample_frac(d, .5))
 })
 
 test_that("nest() works", {

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -109,6 +109,7 @@ test_that("unnest works", {
 
 test_that("bind_rows() returns type of first input", {
 	skip_if_not_installed("dplyr", "0.8.99")
+	skip_if_not_installed("vctrs", "0.3.0.9000")
 
 	sf1 = st_sf(x = 1, y = st_sfc(st_point(0:1)))
 	sf2 = st_sf(z = st_sfc(st_point(2:3)), x = 2)

--- a/tests/testthat/test_vctrs.R
+++ b/tests/testthat/test_vctrs.R
@@ -44,17 +44,14 @@ test_that("`precision` and `crs` attributes of `sfc` vectors are combined", {
 	expect_identical(st_precision(x), st_precision(out))
 	expect_identical(st_crs(x), st_crs(out))
 
+	# Used to fail because of incompatible precisions and crs when
+	# vctrs was using the ptype2 methods for `sfc`. It now uses
+	# `c.sfc()` instead.
+	skip_if_not_installed("vctrs", "0.3.0.9000")
+
 	y = st_sfc(st_point(c(0, 0)), precision = 1e-2, crs = 3857)
-	expect_error(vctrs::vec_c(x, y), "precisions not equal")
+	expect_identical(vctrs::vec_c(x, y), c(x, y))
 
 	y = st_sfc(st_point(c(0, 0)), precision = 1e-4, crs = 4326)
-	expect_error(vctrs::vec_c(x, y), "coordinate reference systems not equal")
-})
-
-test_that("`sfc` vectors have a common type", {
-	pt = st_sfc(st_point())
-	ln = st_sfc(st_linestring())
-	expect_identical(class(vctrs::vec_ptype2(pt, pt)), c("sfc_POINT", "sfc"))
-	expect_identical(class(vctrs::vec_ptype2(ln, ln)), c("sfc_LINESTRING", "sfc"))
-	expect_identical(class(vctrs::vec_ptype2(pt, ln)), c("sfc_GEOMETRY", "sfc"))
+	expect_identical(vctrs::vec_c(x, y), c(x, y))
 })


### PR DESCRIPTION
Follow-up to https://github.com/r-spatial/sf/pull/1405#issuecomment-634603739

`test_tidy.R` and `test_vctrs.R` now succeed with combinations of CRAN and dev dplyr, and CRAN and dev vctrs.