### PR TITLE
add aliases to ?sfc for sfc_MULTIPOLYGON, etc

### DIFF
--- a/R/sfc.R
+++ b/R/sfc.R
@@ -18,6 +18,13 @@ format.sfc = function(x, ..., width = 30) {
 #' Create simple feature geometry list column, set class, and add coordinate reference system and precision
 #'
 #' @name sfc
+#' @alias sfc_POINT
+#' @alias sfc_LINESTRING
+#' @alias sfc_POLYGON
+#' @alias sfc_MULTIPOINT
+#' @alias sfc_MULTILINESTRING
+#' @alias sfc_MULTIPOLYGON
+#' @alias sfc_GEOMETRYCOLLECTION
 #' @param ... zero or more simple feature geometries (objects of class \code{sfg}), or a single list of such objects; \code{NULL} values will get replaced by empty geometries.
 #' @param crs coordinate reference system: integer with the EPSG code, or character with proj4string
 #' @param precision numeric; see \link{st_as_binary}


### PR DESCRIPTION
Was trying to find the man page and tried `?sfc_MULTIPOLYGON`, it would be nice to land on `?sfc` from this (to me) natural attempt