### PR TITLE
Add is_coverage argument to st_union

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -173,8 +173,8 @@ CPL_geos_normalize <- function(sfc) {
     .Call('_sf_CPL_geos_normalize', PACKAGE = 'sf', sfc)
 }
 
-CPL_geos_union <- function(sfc, by_feature = FALSE) {
-    .Call('_sf_CPL_geos_union', PACKAGE = 'sf', sfc, by_feature)
+CPL_geos_union <- function(sfc, by_feature = FALSE, is_coverage = FALSE) {
+    .Call('_sf_CPL_geos_union', PACKAGE = 'sf', sfc, by_feature, is_coverage)
 }
 
 CPL_geos_snap <- function(sfc0, sfc1, tolerance) {

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -13,7 +13,7 @@
 #' @param endCapStyle character; style of line ends, one of 'ROUND', 'FLAT', 'SQUARE'
 #' @param joinStyle character; style of line joins, one of 'ROUND', 'MITRE', 'BEVEL'
 #' @param mitreLimit numeric; limit of extension for a join if \code{joinStyle} 'MITRE' is used (default 1.0, minimum 0.0)
-#' @param singleSide logical; if \code{TRUE}, single-sided buffers are returned for linear geometries, 
+#' @param singleSide logical; if \code{TRUE}, single-sided buffers are returned for linear geometries,
 #' in which case negative \code{dist} values give buffers on the right-hand side, positive on the left.
 #' @param ... passed on to \code{s2_buffer_cells}
 #' @return an object of the same class of \code{x}, with manipulated geometry.
@@ -67,7 +67,7 @@ st_buffer = function(x, dist, nQuadSegs = 30,
 #' @export
 st_buffer.sfg = function(x, dist, nQuadSegs = 30,
 						 endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0, singleSide = FALSE, ...)
-	get_first_sfg(st_buffer(st_sfc(x), dist, nQuadSegs = nQuadSegs, endCapStyle = endCapStyle, 
+	get_first_sfg(st_buffer(st_sfc(x), dist, nQuadSegs = nQuadSegs, endCapStyle = endCapStyle,
 		joinStyle = joinStyle, mitreLimit = mitreLimit, singleSide = singleSide, ...))
 
 .process_style_opts = function(endCapStyle, joinStyle, mitreLimit, singleSide) {
@@ -89,7 +89,7 @@ st_buffer.sfg = function(x, dist, nQuadSegs = 30,
 }
 #' @export
 st_buffer.sfc = function(x, dist, nQuadSegs = 30,
-						 endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0, 
+						 endCapStyle = "ROUND", joinStyle = "ROUND", mitreLimit = 1.0,
 						 singleSide = FALSE, ...) {
 	longlat = isTRUE(st_is_longlat(x))
 	if (longlat && sf_use_s2()) {
@@ -132,7 +132,7 @@ st_buffer.sfc = function(x, dist, nQuadSegs = 30,
 				stop("Flat capstyle is incompatible with POINT/MULTIPOINT geometries") # nocov
 			if (any(dist < 0) && any(st_dimension(x) < 1))
 				stop("Negative dist values may only be used with 1-D or 2-D geometries") # nocov
-	
+
 			st_sfc(CPL_geos_op("buffer_with_style", x, dist, nQ, numeric(0), logical(0),
 				endCapStyle = endCapStyle, joinStyle = joinStyle, mitreLimit = mitreLimit,
 				singleside = singleSide))
@@ -587,7 +587,7 @@ geos_op2_geom = function(op, x, y, s2_model = "closed", ...) {
 	if (longlat && sf_use_s2() && s2_model >= 0) {
 		if (! requireNamespace("s2", quietly = TRUE))
 			stop("package s2 required, please install it first")
-		fn = switch(op, intersection = s2::s2_intersection, 
+		fn = switch(op, intersection = s2::s2_intersection,
 				difference = s2::s2_difference,
 				sym_difference = s2::s2_sym_difference,
 				union = s2::s2_union, stop("invalid operator"))
@@ -753,7 +753,7 @@ st_sym_difference.sf = function(x, y, ...)
 #' @name geos_binary_ops
 #' @param tolerance tolerance values used for \code{st_snap}; numeric value or object of class \code{units}; may have tolerance values for each feature in \code{x}
 #' @details \code{st_snap} snaps the vertices and segments of a geometry to another geometry's vertices. If \code{y} contains more than one geometry, its geometries are merged into a collection before snapping to that collection.
-#' 
+#'
 #' (from the GEOS docs:) "A snap distance tolerance is used to control where snapping is performed. Snapping one geometry to another can improve robustness for overlay operations by eliminating nearly-coincident edges (which cause problems during noding and intersection calculation). Too much snapping can result in invalid topology being created, so the number and location of snapped vertices is decided using heuristics to determine when it is safe to snap. This can result in some potential snaps being omitted, however."
 #' @example
 #' poly = st_polygon(list(cbind(c(0, 0, 1, 1, 0), c(0, 1, 1, 0, 0))))
@@ -790,6 +790,7 @@ st_snap.sf = function(x, y, tolerance)
 #' @name geos_combine
 #' @export
 #' @param by_feature logical; if TRUE, union each feature, if FALSE return a single feature that is the geometric union of the set of features
+#' @param is_coverage logical; if TRUE, use an optimized algorithm for features that form a polygonal coverage (have no overlaps)
 #' @param y object of class \code{sf}, \code{sfc} or \code{sfg} (optional)
 #' @param ... ignored
 #' @seealso \link{st_intersection}, \link{st_difference}, \link{st_sym_difference}
@@ -803,26 +804,26 @@ st_snap.sf = function(x, y, tolerance)
 st_union = function(x, y, ..., by_feature = FALSE) UseMethod("st_union")
 
 #' @export
-st_union.sfg = function(x, y, ..., by_feature = FALSE) {
+st_union.sfg = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	out = if (missing(y)) # unary union, possibly by_feature:
-		st_sfc(CPL_geos_union(st_geometry(x), by_feature))
+		st_sfc(CPL_geos_union(st_geometry(x), by_feature, is_coverage))
 	else
 		st_union(st_geometry(x), st_geometry(y))
 	get_first_sfg(out)
 }
 
 #' @export
-st_union.sfc = function(x, y, ..., by_feature = FALSE) {
+st_union.sfc = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	if (missing(y)) # unary union, possibly by_feature:
-		st_sfc(CPL_geos_union(st_geometry(x), by_feature))
+		st_sfc(CPL_geos_union(st_geometry(x), by_feature, is_coverage))
 	else
 		geos_op2_geom("union", x, y)
 }
 
 #' @export
-st_union.sf = function(x, y, ..., by_feature = FALSE) {
+st_union.sf = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	if (missing(y)) { # unary union, possibly by_feature:
-		geom = st_sfc(CPL_geos_union(st_geometry(x), by_feature))
+		geom = st_sfc(CPL_geos_union(st_geometry(x), by_feature, is_coverage))
 		if (by_feature)
 			st_set_geometry(x, geom)
 		else

--- a/man/geos_combine.Rd
+++ b/man/geos_combine.Rd
@@ -18,6 +18,8 @@ st_union(x, y, ..., by_feature = FALSE)
 \item{...}{ignored}
 
 \item{by_feature}{logical; if TRUE, union each feature, if FALSE return a single feature that is the geometric union of the set of features}
+
+\item{is_coverage}{logical; if TRUE, use an optimized algorithm for features that form a polygonal coverage (have no overlaps)}
 }
 \value{
 \code{st_combine} returns a single, combined geometry, with no resolved boundaries; returned geometries may well be invalid.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -558,14 +558,15 @@ BEGIN_RCPP
 END_RCPP
 }
 // CPL_geos_union
-Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature);
-RcppExport SEXP _sf_CPL_geos_union(SEXP sfcSEXP, SEXP by_featureSEXP) {
+Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature, bool is_coverage);
+RcppExport SEXP _sf_CPL_geos_union(SEXP sfcSEXP, SEXP by_featureSEXP, SEXP is_coverageSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type sfc(sfcSEXP);
     Rcpp::traits::input_parameter< bool >::type by_feature(by_featureSEXP);
-    rcpp_result_gen = Rcpp::wrap(CPL_geos_union(sfc, by_feature));
+    Rcpp::traits::input_parameter< bool >::type is_coverage(is_coverageSEXP);
+    rcpp_result_gen = Rcpp::wrap(CPL_geos_union(sfc, by_feature, is_coverage));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -1183,7 +1184,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_sf_CPL_geos_is_simple", (DL_FUNC) &_sf_CPL_geos_is_simple, 1},
     {"_sf_CPL_geos_is_empty", (DL_FUNC) &_sf_CPL_geos_is_empty, 1},
     {"_sf_CPL_geos_normalize", (DL_FUNC) &_sf_CPL_geos_normalize, 1},
-    {"_sf_CPL_geos_union", (DL_FUNC) &_sf_CPL_geos_union, 2},
+    {"_sf_CPL_geos_union", (DL_FUNC) &_sf_CPL_geos_union, 3},
     {"_sf_CPL_geos_snap", (DL_FUNC) &_sf_CPL_geos_snap, 3},
     {"_sf_CPL_geos_op", (DL_FUNC) &_sf_CPL_geos_op, 11},
     {"_sf_CPL_geos_voronoi", (DL_FUNC) &_sf_CPL_geos_voronoi, 4},

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -589,6 +589,13 @@ Rcpp::List CPL_geos_normalize(Rcpp::List sfc) { // #nocov start
 // [[Rcpp::export]]
 Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false, bool is_coverage = false) {
 
+#ifndef HAVE380
+	if (is_coverage) {
+		Rcpp::warning("ignoring 'is_coverage = TRUE' which requires GEOS version 3.8 or greater");
+		is_coverage = false;
+	}
+#endif
+
 	if (sfc.size() == 0)
 		return sfc; // #nocov
 

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -587,7 +587,7 @@ Rcpp::List CPL_geos_normalize(Rcpp::List sfc) { // #nocov start
 } // #nocov end
 
 // [[Rcpp::export]]
-Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) {
+Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false, bool is_coverage = false) {
 
 	if (sfc.size() == 0)
 		return sfc; // #nocov
@@ -616,6 +616,12 @@ Rcpp::List CPL_geos_union(Rcpp::List sfc, bool by_feature = false) {
 			gmv_out[0] = std::move(gmv[0]);
 		} else {
 			GeomPtr gc = geos_ptr(GEOSGeom_createCollection_r(hGEOSCtxt, GEOS_GEOMETRYCOLLECTION, to_raw(gmv).data(), gmv.size()), hGEOSCtxt);
+
+#ifdef HAVE380
+			if (is_coverage)
+				gmv_out[0] = geos_ptr(GEOSCoverageUnion_r(hGEOSCtxt, gc.get()), hGEOSCtxt);
+			else
+#endif
 			gmv_out[0] = geos_ptr(GEOSUnaryUnion_r(hGEOSCtxt, gc.get()), hGEOSCtxt);
 		}
 	}


### PR DESCRIPTION
This provides a large performance boost when unioning polygons that do not overlap.

```
nc <- st_read(system.file("shape/nc.shp", package="sf"))

microbenchmark(
	st_union(nc),
	st_union(nc, is_coverage=TRUE))

# Unit: milliseconds
#                             expr       min        lq      mean    median       uq       max neval
#                      st_union(nc) 26.993417 29.620176 31.715862 30.732768 33.24951 41.823208   100
#  st_union(nc, is_coverage = TRUE)  2.381553  2.660049  3.068268  2.866013  3.27515  4.872649   100
```
A more substantial example is TIGER counties (USA)

```
counties <- st_read('/home/dan/data/tl_2019_us_county.shp')

system.time(a <- st_union(counties))
#   user  system elapsed 
# 108.517   0.175 108.709 

system.time(b <- st_union(counties, is_coverage=TRUE))
#   user  system elapsed 
#  6.451   0.044   6.505 

st_area(a)
# 9.84098e+12 [m^2]

st_area(b)
# 9.84098e+12 [m^2]
```

If the polygons do overlap, an error is thrown:

```
# st_union(st_buffer(nc, 0.2), is_coverage=TRUE)
# Error in CPL_geos_union(st_geometry(x), by_feature, is_coverage) : 
#  Evaluation error: TopologyException: CoverageUnion cannot process incorrectly noded inputs.. 
```
