### PR TITLE
Add as_tibble argument to st_as_af() and st_sf()

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -34,6 +34,9 @@ st_as_sf = function(x, ...) UseMethod("st_as_sf")
 #' meuse_sf = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant")
 #' meuse_sf[1:3,]
 #' summary(meuse_sf)
+#' # Use as_tibble = TRUE to return a tibble instead of a data.frame
+#' muse_tib = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant", as_tibble = TRUE)
+#' muse_tib[1:3,]
 #' @export
 st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 		dim = "XYZ", remove = TRUE, na.fail = TRUE, sf_column_name = NULL, as_tibble = FALSE) {

--- a/R/sf.R
+++ b/R/sf.R
@@ -35,8 +35,8 @@ st_as_sf = function(x, ...) UseMethod("st_as_sf")
 #' meuse_sf[1:3,]
 #' summary(meuse_sf)
 #' # Use as_tibble = TRUE to return a tibble instead of a data.frame
-#' muse_tib = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant", as_tibble = TRUE)
-#' muse_tib[1:3,]
+#' meuse_tib = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant", as_tibble = TRUE)
+#' meuse_tib[1:3,]
 #' @export
 st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 		dim = "XYZ", remove = TRUE, na.fail = TRUE, sf_column_name = NULL, as_tibble = FALSE) {

--- a/man/sf.Rd
+++ b/man/sf.Rd
@@ -16,7 +16,8 @@ st_sf(
   precision,
   sf_column_name = NULL,
   check_ring_dir = FALSE,
-  sfc_last = TRUE
+  sfc_last = TRUE,
+  as_tibble = FALSE
 )
 
 \method{[}{sf}(x, i, j, ..., drop = FALSE, op = st_intersects)
@@ -42,6 +43,8 @@ there is more than one and \code{sf_column_name} is \code{NULL}, the first one i
 \item{check_ring_dir}{see \link{st_read}}
 
 \item{sfc_last}{logical; if \code{TRUE}, \code{sfc} columns are always put last, otherwise column order is left unmodified.}
+
+\item{as_tibble}{logical; should the returned table be of class tibble or data.frame?}
 
 \item{x}{object of class \code{sf}}
 

--- a/man/st_as_sf.Rd
+++ b/man/st_as_sf.Rd
@@ -88,6 +88,9 @@ data(meuse, package = "sp")
 meuse_sf = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant")
 meuse_sf[1:3,]
 summary(meuse_sf)
+# Use as_tibble = TRUE to return a tibble instead of a data.frame
+muse_tib = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, agr = "constant", as_tibble = TRUE)
+muse_tib[1:3,]
 library(sp)
 x = rbind(c(-1,-1), c(1,-1), c(1,1), c(-1,1), c(-1,-1))
 x1 = 0.1 * x + 0.1

--- a/man/st_as_sf.Rd
+++ b/man/st_as_sf.Rd
@@ -23,7 +23,8 @@ st_as_sf(x, ...)
   dim = "XYZ",
   remove = TRUE,
   na.fail = TRUE,
-  sf_column_name = NULL
+  sf_column_name = NULL,
+  as_tibble = FALSE
 )
 
 \method{st_as_sf}{sf}(x, ...)
@@ -59,6 +60,8 @@ st_as_sf(x, ...)
 
 \item{sf_column_name}{character; name of the active list-column with simple feature geometries; in case
 there is more than one and \code{sf_column_name} is \code{NULL}, the first one is taken.}
+
+\item{as_tibble}{logical; should the returned table be of class tibble or data.frame?}
 
 \item{fill}{logical; the value for \code{fill} that was used in the call to \link[maps]{map}.}
 

--- a/tests/testthat/test_sf.R
+++ b/tests/testthat/test_sf.R
@@ -27,6 +27,13 @@ test_that("we can create points sf from data.frame", {
   expect_identical(class(meuse_sf), c("sf", "data.frame"))
 })
 
+test_that("st_as_sf responds to as_tibble = TRUE", {
+	data(meuse, package = "sp") # load data.frame from sp
+	meuse_sf = st_as_sf(meuse, coords = c("x", "y"), crs = 28992, as_tibble = TRUE)
+	expect_identical(class(meuse_sf), c("sf", "tbl_df", "tbl", "data.frame"))
+})
+
+
 test_that("st_zm works", {
   pt = st_point(1:2)
   ptz = st_point(1:3, "XYZ")


### PR DESCRIPTION
The `as_tibble` argument of `read_sf()` is a great feature, but this functionality is not currently provided in `st_as_sf()` or `st_sf()`. This is particularly desirable when converting `{sp}` objects to `{sf}` objects.

By default `as_tibble = FALSE` for both functions to prevent unexpected code changes for end-users.

I feel it is useful for the package to provide a nice way to add the "tbl_df" class to an `{sf}` object, similarly to how `st_drop_geometry()` was added for throwing away the geometry column. But this approach might not fit with the package owner's goals.