### PR TITLE
Added sgbp multiplication

### DIFF
--- a/R/sgbp.R
+++ b/R/sgbp.R
@@ -64,6 +64,25 @@ dim.sgbp = function(x) {
 	c(length(x), attr(x, "ncol"))
 }
 
+#' @name sgbp
+#' @export
+`%*%` <- function(x, y) UseMethod("%*%")
+
+#' @name sgbp
+#' @export
+`%*%.sgbp` <- function(sgbp, mat) {
+	ret = lapply(sgbp, function(x) mat[x, ])
+	
+	if(dim(mat)[2] == 1){
+		ret = lapply(ret, function(x) sum(x))
+	} else {
+		ret = lapply(ret, function(x) colSums(x))	
+	}
+	
+	ret = do.call(rbind, ret)
+	return(ret)
+}
+
 #' @export
 Ops.sgbp = function(e1, e2) {
 	if (.Generic != "!")


### PR DESCRIPTION
From issue #1492. This allows sgbp %*% matrix to work. See below for example. I don't think we need `%*%` <- function(x, y) UseMethod("%*%") in the pull request, but in my local version, I couldn't get it to work without including it. Let me know if there is anything you would like to me add.


    library("sf")
    #> Linking to GEOS 3.7.2, GDAL 2.4.2, PROJ 5.2.0

    `%*%` <- function(x, y) UseMethod("%*%")

    `%*%.sgbp` <- function(sgbp, mat) {
        # mat[x, ] selects only the rows with sgbp = TRUE
        ret = lapply(sgbp, function(x) mat[x, ])
        # colSums is multiplying the non-sparse 1,0 matrix
        if(dim(mat)[2] == 1){
            ret = lapply(ret, function(x) sum(x))
        }else {
            ret = lapply(ret, function(x) colSums(x))   
        }
        
        ret = do.call(rbind, ret)
        
        return(ret)
    }

    nc <- sf::st_read(system.file("shape/nc.shp", package="sf"))
    #> Reading layer `nc' from data source `/Library/Frameworks/R.framework/Versions/4.0/Resources/library/sf/shape/nc.shp' using driver `ESRI Shapefile'
    #> Simple feature collection with 100 features and 14 fields
    #> geometry type:  MULTIPOLYGON
    #> dimension:      XY
    #> bbox:           xmin: -84.32385 ymin: 33.88199 xmax: -75.45698 ymax: 36.58965
    #> CRS:            4267

    births_79 <- nc[["BIR79"]] %>% as.matrix()
    births <- nc[, c("BIR74", "BIR79")] %>% st_drop_geometry() %>% as.matrix()

    intersect <- sf::st_intersects(nc, nc)
    #> although coordinates are longitude/latitude, st_intersects assumes that they are planar

    intersect %*% births_79
    #>         [,1]
    #>   [1,]  7406
    #>   [2,]  9247
    #>   [3,] 27193
    #>   [4,]  2239
    #>   [5,] 10713
    #>   [6,]  5654
    #>   [7,]  4049
    #>   [8,]  6632
    #>   [9,] 17064
    #>  [10,] 47287
    #>  [11,] 18674
    #>  [12,] 50691
    #>  [13,] 39769
    #>  [14,] 20027
    #>  [15,]  7880
    #>  [16,] 22135
    #>  [17,]  3895
    #>  [18,] 23922
    #>  [19,] 12090
    #>  [20,]  4444
    #>  [21,]  2169
    #>  [22,] 14449
    #>  [23,] 31451
    #>  [24,] 43169
    #>  [25,] 57436
    #>  [26,] 62292
    #>  [27,] 45536
    #>  [28,] 12513
    #>  [29,] 26118
    #>  [30,] 42029
    #>  [31,] 47407
    #>  [32,]  4980
    #>  [33,] 27201
    #>  [34,] 23606
    #>  [35,] 14885
    #>  [36,] 22972
    #>  [37,] 52382
    #>  [38,] 14214
    #>  [39,] 66367
    #>  [40,] 37680
    #>  [41,] 21940
    #>  [42,] 61603
    #>  [43,] 30524
    #>  [44,]  8261
    #>  [45,]  1887
    #>  [46,] 22793
    #>  [47,] 46694
    #>  [48,] 60915
    #>  [49,] 35074
    #>  [50,] 30714
    #>  [51,] 33456
    #>  [52,] 30872
    #>  [53,] 25052
    #>  [54,] 53858
    #>  [55,] 20812
    #>  [56,]  2316
    #>  [57,] 21187
    #>  [58,]  6495
    #>  [59,] 24971
    #>  [60,] 13670
    #>  [61,] 29906
    #>  [62,] 29340
    #>  [63,] 69124
    #>  [64,] 34538
    #>  [65,] 67152
    #>  [66,]  7408
    #>  [67,] 54780
    #>  [68,] 61371
    #>  [69,] 56565
    #>  [70,] 32435
    #>  [71,] 31024
    #>  [72,] 21715
    #>  [73,]  3701
    #>  [74,] 31287
    #>  [75,] 19003
    #>  [76,] 50555
    #>  [77,]  7895
    #>  [78,]  5624
    #>  [79,] 54044
    #>  [80,] 11135
    #>  [81,]  3237
    #>  [82,] 50985
    #>  [83,] 33241
    #>  [84,] 46613
    #>  [85,] 14893
    #>  [86,] 46422
    #>  [87,]  5855
    #>  [88,] 35583
    #>  [89,] 14438
    #>  [90,]  2749
    #>  [91,] 25984
    #>  [92,] 20052
    #>  [93,] 23023
    #>  [94,] 45976
    #>  [95,] 26239
    #>  [96,] 46702
    #>  [97,] 38249
    #>  [98,] 19540
    #>  [99,] 11174
    #> [100,] 15318
    intersect %*% births
    #>        BIR74 BIR79
    #>   [1,]  6047  7406
    #>   [2,]  7912  9247
    #>   [3,] 21560 27193
    #>   [4,]  1315  2239
    #>   [5,]  8773 10713
    #>   [6,]  4617  5654
    #>   [7,]  2852  4049
    #>   [8,]  5031  6632
    #>   [9,] 13597 17064
    #>  [10,] 37291 47287
    #>  [11,] 14876 18674
    #>  [12,] 39810 50691
    #>  [13,] 29260 39769
    #>  [14,] 15396 20027
    #>  [15,]  6218  7880
    #>  [16,] 17947 22135
    #>  [17,]  2828  3895
    #>  [18,] 19585 23922
    #>  [19,]  9950 12090
    #>  [20,]  3293  4444
    #>  [21,]  1655  2169
    #>  [22,] 11903 14449
    #>  [23,] 24807 31451
    #>  [24,] 32330 43169
    #>  [25,] 45276 57436
    #>  [26,] 48740 62292
    #>  [27,] 35606 45536
    #>  [28,] 10344 12513
    #>  [29,] 20043 26118
    #>  [30,] 30491 42029
    #>  [31,] 35838 47407
    #>  [32,]  4168  4980
    #>  [33,] 21631 27201
    #>  [34,] 19519 23606
    #>  [35,] 11667 14885
    #>  [36,] 18914 22972
    #>  [37,] 38966 52382
    #>  [38,] 11160 14214
    #>  [39,] 49357 66367
    #>  [40,] 28588 37680
    #>  [41,] 17981 21940
    #>  [42,] 47434 61603
    #>  [43,] 25737 30524
    #>  [44,]  7141  8261
    #>  [45,]  1576  1887
    #>  [46,] 18248 22793
    #>  [47,] 36373 46694
    #>  [48,] 45068 60915
    #>  [49,] 27981 35074
    #>  [50,] 23174 30714
    #>  [51,] 27021 33456
    #>  [52,] 25490 30872
    #>  [53,] 19845 25052
    #>  [54,] 41044 53858
    #>  [55,] 15955 20812
    #>  [56,]  1367  2316
    #>  [57,] 17073 21187
    #>  [58,]  5140  6495
    #>  [59,] 19893 24971
    #>  [60,] 10322 13670
    #>  [61,] 23999 29906
    #>  [62,] 24306 29340
    #>  [63,] 52196 69124
    #>  [64,] 28415 34538
    #>  [65,] 51150 67152
    #>  [66,]  5898  7408
    #>  [67,] 42907 54780
    #>  [68,] 44971 61371
    #>  [69,] 40703 56565
    #>  [70,] 25159 32435
    #>  [71,] 23313 31024
    #>  [72,] 16897 21715
    #>  [73,]  2914  3701
    #>  [74,] 25120 31287
    #>  [75,] 14515 19003
    #>  [76,] 37684 50555
    #>  [77,]  6099  7895
    #>  [78,]  4341  5624
    #>  [79,] 43297 54044
    #>  [80,]  9102 11135
    #>  [81,]  2523  3237
    #>  [82,] 40980 50985
    #>  [83,] 26090 33241
    #>  [84,] 33528 46613
    #>  [85,] 11855 14893
    #>  [86,] 37408 46422
    #>  [87,]  4789  5855
    #>  [88,] 28699 35583
    #>  [89,] 11981 14438
    #>  [90,]  2108  2749
    #>  [91,] 20777 25984
    #>  [92,] 17042 20052
    #>  [93,] 17861 23023
    #>  [94,] 37136 45976
    #>  [95,] 20018 26239
    #>  [96,] 37640 46702
    #>  [97,] 30733 38249
    #>  [98,] 16430 19540
    #>  [99,]  8935 11174
    #> [100,] 12285 15318

<sup>Created on 2020-09-24 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>