### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Get gdal, proj and geos from the main repos and udunits from the AUR:
 
 ```
 pacman -S gdal proj geos
-pacaur/yaourt/whatever -S udunits
+yay/pacaur/yaourt/whatever -S udunits
 ```
 
 #### Other


### PR DESCRIPTION
yay today is the most used program in Arch Linux and derived distributions for installing community packages Arch. For example, yaourt has been discontinued.