### PR TITLE
Update DESCRIPTION for sqlite3 in SystemRequirements

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -104,7 +104,7 @@ VignetteBuilder:
 Encoding: UTF-8
 RoxygenNote: 7.1.1
 SystemRequirements: C++11, GDAL (>= 2.0.1), GEOS (>= 3.4.0),
-    PROJ (>= 4.8.0)
+    PROJ (>= 4.8.0), sqlite3
 Collate: 
     'RcppExports.R'
     'init.R'


### PR DESCRIPTION
Without sqlite3(-devel) the configure script fails, therefore it should be added to SystemRequirements: 
See: 
[   11s] checking PROJ: checking whether PROJ and sqlite3 are available for linking:... no
[   11s] configure: error: libproj or sqlite3 not found in standard or given locations.