### PR TITLE
Avoid SR-ORG code to be assigned to $epsg and interpreted as EPSG

### DIFF
--- a/src/gdal.cpp
+++ b/src/gdal.cpp
@@ -248,7 +248,7 @@ Rcpp::List CPL_crs_parameters(Rcpp::List crs) {
 	names(9) = "proj4string";
 
 	// epsg
-	if (srs->GetAuthorityCode(NULL) != NULL)
+	if (srs->GetAuthorityCode(NULL) != NULL && strcmp(srs->GetAuthorityName(NULL), "EPSG") == 0)
 		out(10) = Rcpp::IntegerVector::create(atoi(srs->GetAuthorityCode(NULL)));
 	else
 		out(10) = Rcpp::IntegerVector::create(NA_INTEGER);


### PR DESCRIPTION
I noticed that all Authority Codes are assigned to a `crs` object using `$epsg` method, regardless of their name. This could lead to unexpected behaviours, e.g.:
```r
download.file("https://spatialreference.org/ref/sr-org/6974/ogcwkt/", sinu_wkt <- tempfile())
readLines(sinu_wkt, warn = FALSE)
```
```
[1] "PROJCS[\"MODIS Sinusoidal\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378137,298.257223563,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0,AUTHORITY[\"EPSG\",\"8901\"]],UNIT[\"degree\",0.01745329251994328,AUTHORITY[\"EPSG\",\"9122\"]],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Sinusoidal\"],PARAMETER[\"false_easting\",0.0],PARAMETER[\"false_northing\",0.0],PARAMETER[\"central_meridian\",0.0],PARAMETER[\"semi_major\",6371007.181],PARAMETER[\"semi_minor\",6371007.181],UNIT[\"m\",1.0],AUTHORITY[\"SR-ORG\",\"6974\"]]"
```
```r
sinu_crs <- st_crs(sinu_wkt)
sinu_crs$epsg
```
```
[1] 6974
```
```r
st_crs(sinu_crs$epsg)
```
```
Coordinate Reference System: NA
Warning message:
In CPL_crs_from_input(x) :
  GDAL Error 1: PROJ: proj_create_from_database: crs not found
```

After this PR:
```r
sinu_crs$epsg
```
```
[1] NA
```
```r
st_crs(32632)$epsg
```
```
[1] 32632
```

Feel free to reject this PR if the current behaviour is actually the expected one.