### PR TITLE
Fix minor typos in vignettes

### DIFF
--- a/vignettes/sf1.Rmd
+++ b/vignettes/sf1.Rmd
@@ -230,13 +230,13 @@ more general way uses `st_geometry`:
 ```
 
 Geometries are printed in abbreviated form, but we can
-can view a complete geometry by selecting it, e.g. the first one by
+view a complete geometry by selecting it, e.g. the first one by
 
 ```{r}
 nc_geom[[1]]
 ```
 
-The way this is printed is called _well-known text_, and is part of the standards. The word `MULTIPOLYGON` is followed by three parenthesis, because it can consist of multiple polygons, in the form of `MULTIPOLYGON(POL1,POL2)`, where `POL1` might consist of an exterior ring and zero or more interior rings, as of `(EXT1,HOLE1,HOLE2)`. Sets of coordinates are held together with parenthesis, so we get `((crds_ext)(crds_hole1)(crds_hole2))` where `crds_` is a comma-separated set of coordinates of a ring. This leads to the case above, where `MULTIPOLYGON(((crds_ext)))` refers to the exterior ring (1), without holes (2), of the first polygon (3) - hence three parentheses.
+The way this is printed is called _well-known text_, and is part of the standards. The word `MULTIPOLYGON` is followed by three parentheses, because it can consist of multiple polygons, in the form of `MULTIPOLYGON(POL1,POL2)`, where `POL1` might consist of an exterior ring and zero or more interior rings, as of `(EXT1,HOLE1,HOLE2)`. Sets of coordinates are held together with parentheses, so we get `((crds_ext)(crds_hole1)(crds_hole2))` where `crds_` is a comma-separated set of coordinates of a ring. This leads to the case above, where `MULTIPOLYGON(((crds_ext)))` refers to the exterior ring (1), without holes (2), of the first polygon (3) - hence three parentheses.
 
 We can see there is a single polygon with no rings:
 

--- a/vignettes/sf2.Rmd
+++ b/vignettes/sf2.Rmd
@@ -20,7 +20,7 @@ if (file.exists("nc1.shp"))
 	file.remove("nc1.shp", "nc1.dbf", "nc1.shx")
 ```
 
-This vignetted describes how simple features can be read in R
+This vignette describes how simple features can be read in R
 from files or databases, and how they can be converted to other
 formats (text, [sp](https://cran.r-project.org/package=sp))
 

--- a/vignettes/sf3.Rmd
+++ b/vignettes/sf3.Rmd
@@ -18,7 +18,7 @@ vignette: >
 knitr::opts_chunk$set(collapse = TRUE)
 ```
 
-This vignetted describes how simple feature geometries can be
+This vignette describes how simple feature geometries can be
 manipulated, where manipulations include
 
 * type transformations (e.g., `POLYGON` to `MULTIPOLYGON`)

--- a/vignettes/sf3.Rmd
+++ b/vignettes/sf3.Rmd
@@ -312,7 +312,7 @@ plot(st_intersection(st_union(x),st_union(y)), add = TRUE, col = 'red')
 ```
 Note that the function `st_intersects` returns a logical matrix indicating whether each geometry pair intersects (see the previous section in this vignette).
 
-To get _everything but_ the intersection, use `st_difference` or st_sym_difference`:
+To get _everything but_ the intersection, use `st_difference` or `st_sym_difference`:
 ```{r,fig=TRUE}
 par(mfrow=c(2,2), mar = c(0,0,1,0))
 plot(x, col = '#ff333388'); 

--- a/vignettes/sf4.Rmd
+++ b/vignettes/sf4.Rmd
@@ -17,7 +17,7 @@ vignette: >
 ```{r echo=FALSE, include=FALSE}
 knitr::opts_chunk$set(collapse = TRUE)
 ```
-This vignetted describes how simple features, i.e. records that come with a geometry, can be manipulated, for the case where these manipulations involve geometries. Manipulations include:
+This vignette describes how simple features, i.e. records that come with a geometry, can be manipulated, for the case where these manipulations involve geometries. Manipulations include:
 
 * aggregating feature sets
 * summarising feature sets

--- a/vignettes/sf6.Rmd
+++ b/vignettes/sf6.Rmd
@@ -86,7 +86,7 @@ library(sf)
 
 ## _although coordinates are longitude/latitude, xxx assumes that they are planar_
 
-Most (but not all) of the geometry calculating routines used by `sf` come from the [GEOS](https://trac.osgeo.org/geos/) library. This library considers coordinates in a two-dimensional, flat, Euclidian space. For longitude latitude data, this is not the case. A simple example is a polygon enclosing the North pole, which should include the pole:
+Most (but not all) of the geometry calculating routines used by `sf` come from the [GEOS](https://trac.osgeo.org/geos/) library. This library considers coordinates in a two-dimensional, flat, Euclidean space. For longitude latitude data, this is not the case. A simple example is a polygon enclosing the North pole, which should include the pole:
 ```{r}
 polygon = st_sfc(st_polygon(list(rbind(c(0,80), c(120,80), c(240,80), c(0,80)))), 
 		crs = 4326)

--- a/vignettes/sf7.Rmd
+++ b/vignettes/sf7.Rmd
@@ -84,6 +84,7 @@ problems. Doing this however leaves ambiguities, e.g. whether
 * passes through `POINT(180 0)`
 
 and whether it is
+
 * a straight line, cutting through the Earth's surface, or
 * a curved line following the Earth's surface
 


### PR DESCRIPTION
This PR fixes some minor typos and format matters found when reading the vignettes.

As always, many thanks for writing detailed documentation on how the functions work!