### PR TITLE
Fix st_as_grob issue when plotting mix of MULTI and base type

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,8 @@
 
 * allow to `st_cast` COMPOUNDCURVE, MULTISURFACE or CURVEPOLYGON to GEOMETRYCOLLECTION (and back); #1573
 
+* Fixed a bug in `st_as_grob()` when plotting a mix of MULTI and non-MULTI geometries of the same base type
+
 # version 0.9-7
 
 * n-ary `st_intersection` skips failing geometries, rather than returning an error; #1549

--- a/R/grid.R
+++ b/R/grid.R
@@ -209,7 +209,7 @@ st_as_grob.sfc_CIRCULARSTRING <- function(x, ...) {
 st_as_grob.sfc <- function(x, pch = 1, size = unit(1, "char"), arrow = NULL, gp = gpar(), ...) {
 	x <- st_cast_sfc_default(x)
 	if (class(x)[1] %in% c('sfc_MULTIPOINT', 'sfc_MULTILINESTRING', 'sfc_MULTIPOLYGON')) {
-		return(st_as_grob(x, gp = gp, ...))
+		return(st_as_grob(x, pch = pch, size = size, arrow = arrow, gp = gp, ...))
 	}
 	scalar_grobs(x, pch, size, arrow, gp, ...)
 }


### PR DESCRIPTION
This PR fixes an issue that surfaced in https://github.com/thomasp85/gganimate/issues/358

My initial implementation forgot to forward grab specific settings pertaining to `pointGrob` when forwarding calls