### PR TITLE
Pass an `sfc` object to lapply() instead than `sfg`

### DIFF
--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -647,8 +647,9 @@ geos_op2_geom = function(op, x, y, s2_model = "semi-open", ...) {
 				sym_difference = s2::s2_sym_difference,
 				union = s2::s2_union, stop("invalid operator"))
 		# to be optimized -- this doesn't index on y:
-		lst = structure(unlist(lapply(x, fn, y, s2::s2_options(model = s2_model, ...)),
-			recursive = FALSE), class = "s2_geography")
+		lst = structure(unlist(lapply(seq_along(x), function(i) {
+			fn(x[i], y, s2::s2_options(model = s2_model, ...))
+		}), recursive = FALSE), class = "s2_geography")
 		e = s2::s2_is_empty(lst)
 		idx = cbind(rep(seq_along(x), length(y)), rep(seq_along(y), each = length(x)))
 		lst = st_as_sfc(lst, crs = st_crs(x))


### PR DESCRIPTION
Running the following code I am encountering the error reported below:
```r
library(s2)
library(sf)
packageVersion("sf")
# [1] ‘0.9.9’
packageVersion("s2")
# [1] ‘1.0.4.9000’
sf_use_s2(TRUE)

txt <- c("POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))",
         "POLYGON ((0.1 0.1, 0.1 0.5, 0.5 0.5, 0.5 0.1, 0.1 0.1))")
st_difference(st_as_sfc(as_s2_geography(txt[1])), st_as_sfc(as_s2_geography(txt[2])))
# Error in UseMethod("as_s2_geography") : 
#   no applicable method for 'as_s2_geography' applied to an object of class "c('XY', 'POLYGON', 'sfg')"
```

I see that the error occurs here: https://github.com/r-spatial/sf/blob/4911f5a888311384e5e2fb3c781836b0e4f981a0/R/geom-transformers.R#L650-L651
The proposed PR, although not elegant, allows passing a `sfc` geometry to `fn()` within `lapply()` instead than a `sfg` object.

Feel free to reject if it is not the most suitable solution.

Ps. the PR is toward branch `master`, but it should also affect `sf_1_0`... If it would be better to pull to `sf_1_0` before, you can make a PR from `ranghetti/sf:sf_1_0` which includes the commit.