### PR TITLE
Remove unclass call from [.sfc

### DIFF
--- a/R/sfc.R
+++ b/R/sfc.R
@@ -145,7 +145,7 @@ sfg_is_empty = function(x) {
 "[.sfc" = function(x, i, j, ..., op = st_intersects) {
 	if (!missing(i) && (inherits(i, "sf") || inherits(i, "sfc") || inherits(i, "sfg")))
 		i = lengths(op(x, i, ...)) != 0
-	st_sfc(unclass(x)[i], crs = st_crs(x), precision = st_precision(x), 
+	st_sfc(NextMethod(), crs = st_crs(x), precision = st_precision(x),
 		dim = if(length(x)) class(x[[1]])[1] else "XY")
 }
 


### PR DESCRIPTION
References #1666. This does not replace the solution in 4911f5a888311384e5e2fb3c781836b0e4f981a0 but greatly improves runtime in other cases where you need to index into an `sfc`. There appear to be other cases that could could benefit from the same technique.