### PR TITLE
Add class declaration for sfc_GEOMETRYCOLLECTION

### DIFF
--- a/R/init.R
+++ b/R/init.R
@@ -24,6 +24,7 @@ setOldClass(c("sfc_MULTILINESTRING", "sfc"))
 setOldClass(c("sfc_POLYGON", "sfc"))
 setOldClass(c("sfc_MULTIPOLYGON", "sfc"))
 setOldClass(c("sfc_GEOMETRY", "sfc"))
+setOldClass(c("sfc_GEOMETRYCOLLECTION", "sfc"))
 setOldClass("sfg")
 setOldClass("crs")
 


### PR DESCRIPTION
This avoids a warning in packages that declare methods for this class.