### PR TITLE
Update `update-tic.yml`

### DIFF
--- a/.github/workflows/update-tic.yml
+++ b/.github/workflows/update-tic.yml
@@ -23,7 +23,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
         with:
           persist-credentials: false
 
@@ -43,7 +43,7 @@ jobs:
             Rscript -e "tic::update_yml()"
 
       - name: "[Stage] Create Pull Request"
-        uses: peter-evans/create-pull-request@master
+        uses: peter-evans/create-pull-request@v3
         with:
           author: github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>
           token: ${{ secrets.TIC_UPDATE }}


### PR DESCRIPTION
Required for future executions of the WF as the `@master` ref will stop working after June 30th for the `peter-evans/create-pull-request` action.