### PR TITLE
Fixes to spelling, punctuation, capitalization in README & vignettes

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ A package that provides [simple features access](https://en.wikipedia.org/wiki/S
 ### Blogs, presentations, vignettes, sp-sf wiki
 
 * an open access [R Journal article](https://journal.r-project.org/archive/2018/RJ-2018-009/index.html) summarizes the package
-* package vignettes: [first](https://r-spatial.github.io/sf/articles/sf1.html), [second](https://r-spatial.github.io/sf/articles/sf2.html), [third](https://r-spatial.github.io/sf/articles/sf3.html), [forth](https://r-spatial.github.io/sf/articles/sf4.html), [fifth](https://r-spatial.github.io/sf/articles/sf5.html), [sixth](https://r-spatial.github.io/sf/articles/sf6.html)
+* package vignettes: [first](https://r-spatial.github.io/sf/articles/sf1.html), [second](https://r-spatial.github.io/sf/articles/sf2.html), [third](https://r-spatial.github.io/sf/articles/sf3.html), [fourth](https://r-spatial.github.io/sf/articles/sf4.html), [fifth](https://r-spatial.github.io/sf/articles/sf5.html), [sixth](https://r-spatial.github.io/sf/articles/sf6.html), [seventh](https://r-spatial.github.io/sf/articles/sf7.html)
 * blog posts: [first](http://r-spatial.org/r/2016/02/15/simple-features-for-r.html), [second](http://r-spatial.org/r/2016/07/18/sf2.html), [third](http://r-spatial.org/r/2016/11/02/sfcran.html), [fourth](http://r-spatial.org/r/2017/01/12/newssf.html)
 * the original R Consortium ISC [proposal](PROPOSAL.md), the R Consortium [blog post](https://www.r-consortium.org/blog/2017/01/03/simple-features-now-on-cran)
 * presentations: [rstudio::conf 2018](https://edzer.github.io/rstudio_conf/#1) ([video](https://www.rstudio.com/resources/videos/tidy-spatial-data-analysis/)), [UseR! 2016](http://pebesma.staff.ifgi.de/pebesma_sfr.pdf)
@@ -48,9 +48,9 @@ Install either from CRAN with:
 ```r
 install.packages("sf")
 ```
-this will install binary packages on Windows and MacOS, unless you configured R such that it tries to install source packages; in that case, see below.
+This will install binary packages on Windows and MacOS, unless you configured R such that it tries to install source packages; in that case, see below.
 
-Install development versions from github with
+Install development versions from GitHub with:
 ```r
 library(devtools)
 install_github("r-spatial/sf")
@@ -58,11 +58,11 @@ install_github("r-spatial/sf")
 
 ### Windows
 
-Installing sf from source works under windows when [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is installed. This downloads the system requirements from [rwinlib](https://github.com/rwinlib/). 
+Installing sf from source works under Windows when [Rtools](https://cran.r-project.org/bin/windows/Rtools/) is installed. This downloads the system requirements from [rwinlib](https://github.com/rwinlib/). 
 
 ### MacOS
 
-The easiest way to install `gdal` is using Homebrew. Recent versions of homebrew include a full-featured up-to-date [gdal formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gdal.rb), which installs `proj` and `gdal` at the same time:
+The easiest way to install `gdal` is using Homebrew. Recent versions of Homebrew include a full-featured up-to-date [gdal formula](https://github.com/Homebrew/homebrew-core/blob/master/Formula/gdal.rb), which installs `proj` and `gdal` at the same time:
 
 ```
 brew install pkg-config
@@ -82,15 +82,15 @@ library(devtools)
 install_github("r-spatial/sf", configure.args = "--with-proj-lib=/usr/local/lib/")
 ```
 
-If you are using `sf` and `rgdal` together it is necessary to install `rgdal` from source using this configuration:
+If you are using `sf` and `rgdal` together, it is necessary to install `rgdal` from source using this configuration:
 
 ```r
 install.packages("rgdal", configure.args = c("--with-proj-lib=/usr/local/lib/", "--with-proj-include=/usr/local/include/"))
 ```
 
-Alternatively [these instructions](https://stat.ethz.ch/pipermail/r-sig-mac/2017-June/012429.html) explain how to install gdal using kyngchaos frameworks.
+Alternatively, [these instructions](https://stat.ethz.ch/pipermail/r-sig-mac/2017-June/012429.html) explain how to install gdal using kyngchaos frameworks.
 
-For Mac OS 11 Big Sur source install instruction see [here](https://github.com/r-spatial/sf/issues/1536#issuecomment-727342736)
+For Mac OS 11 Big Sur source install instruction, see [here](https://github.com/r-spatial/sf/issues/1536#issuecomment-727342736)
 
 ### Linux
 
@@ -114,7 +114,7 @@ sudo apt-get install libudunits2-dev libgdal-dev libgeos-dev libproj-dev
 
 Adding this PPA is required for installing `sf` on older versions of Ubuntu (e.g. Xenial).
 
-Another option, for advanced users, is to install dependencies from source; see e.g. an older [travis](https://github.com/r-spatial/sf/blob/593ee48b34001fe3b383ea73ea57063ecf690732/.travis.yml) config file for hints.
+Another option, for advanced users, is to install dependencies from source; see e.g. an older [Travis](https://github.com/r-spatial/sf/blob/593ee48b34001fe3b383ea73ea57063ecf690732/.travis.yml) config file for hints.
 
 #### Fedora
 The following command installs all required dependencies:
@@ -124,7 +124,7 @@ sudo dnf install gdal-devel proj-devel proj-epsg proj-nad geos-devel sqlite-deve
 
 #### Arch
 
-Get gdal, proj and geos from the main repos and udunits from the AUR:
+Get gdal, proj and geos from the main repos, and udunits from the AUR:
 
 ```
 pacman -S gdal proj geos
@@ -136,7 +136,7 @@ To install on Debian, the [rocker geospatial](https://github.com/rocker-org/geos
 
 ### Multiple GDAL, GEOS and/or PROJ versions on your system
 
-In case you use dynamic linking (installation from source) and have multiple versions of these libraries installed (e.g. one from ubuntugis-unstable, another installed from source in `/usr/local/lib`) then this will in general not work, even when setting `LD_LIBRARY_PATH` manually. See [here](https://github.com/r-spatial/sf/issues/844) for the reason why. 
+If you use dynamic linking (installation from source) and have multiple versions of these libraries installed (e.g. one from ubuntugis-unstable, another installed from source in `/usr/local/lib`) then this will in general not work, even when setting `LD_LIBRARY_PATH` manually. See [here](https://github.com/r-spatial/sf/issues/844) for the reason why. 
 
 ### lwgeom
 

--- a/vignettes/sf3.Rmd
+++ b/vignettes/sf3.Rmd
@@ -39,7 +39,7 @@ For single geometries, `st_cast` will
 3. convert from MULTIXX to XX if MULTIXX does not have length one, but it will warn about the loss of information
 4. convert GEOMETRYCOLLECTION of length one to its component if 
 
-Examples of the first three types are
+Examples of the first three types are:
 ```{r}
 library(sf)
 suppressPackageStartupMessages(library(dplyr))
@@ -47,7 +47,7 @@ st_point(c(1,1)) %>% st_cast("MULTIPOINT")
 st_multipoint(rbind(c(1,1))) %>% st_cast("POINT")
 st_multipoint(rbind(c(1,1),c(2,2))) %>% st_cast("POINT")
 ```
-Examples of the fourth type are
+Examples of the fourth type are:
 ```{r}
 st_geometrycollection(list(st_point(c(1,1)))) %>% st_cast("POINT")
 ```
@@ -64,7 +64,7 @@ class(st_geometry(st_read(shp, quiet = TRUE, type = 1)))
 
 This option is handled by the GDAL library; in case of failure to convert to the target type, the original types are returned, which in this case is a mix of `POLYGON` and `MULTIPOLYGON` geometries, leading to a `GEOMETRY` as superclass. When we try to read multipolygons as polygons, all secondary rings of multipolygons get lost. 
 
-When functions return objects with mixed geometry type (`GEOMETRY`), downstream functions such as `st_write` may have difficulty handling them. For some of these cases, `st_cast` may help modifying their type.  For sets of geometry objects (`sfc`) and simple feature sets (`sf), `st_cast` can be used by specifying the target type, or without specifying it. 
+When functions return objects with mixed geometry type (`GEOMETRY`), downstream functions such as `st_write` may have difficulty handling them. For some of these cases, `st_cast` may help modify their type.  For sets of geometry objects (`sfc`) and simple feature sets (`sf), `st_cast` can be used by specifying the target type, or without specifying it. 
 
 ```{r}
 ls <- st_linestring(rbind(c(0,0),c(1,1),c(2,1)))
@@ -142,7 +142,7 @@ s2 = s
 st_crs(s2) <- "+proj=longlat +datum=WGS84"
 all.equal(s1, s2)
 ```
-an alternative, more pipe-friendly version of `st_crs<-` is 
+An alternative, more pipe-friendly version of `st_crs<-` is 
 ```{r}
 s1 %>% st_set_crs(4326)
 ```
@@ -150,7 +150,7 @@ s1 %>% st_set_crs(4326)
 ### Coordinate reference system transformations
 
 If we change the coordinate reference system from one non-missing
-value into another non-missing value, the crs is is changed without
+value into another non-missing value, the CRS is is changed without
 modifying any coordinates, but a warning is issued that this
 did not reproject values:
 ```{r}
@@ -158,7 +158,7 @@ s3 <- s1 %>% st_set_crs(4326) %>% st_set_crs(3857)
 ```
 A cleaner way to do this that better expresses intention and does
 not generate this warning is to first wipe the CRS by assigning it 
-a missing value, and then setting it to the intended value.
+a missing value, and then set it to the intended value.
 ```{r}
 s3 <- s1  %>% st_set_crs(NA) %>% st_set_crs(3857)
 ```
@@ -173,8 +173,8 @@ for which we see that coordinates are actually modified (projected).
 ## Geometrical operations
 
 All geometrical operations `st_op(x)` or `st_op2(x,y)` work
-both for `sf` objects as well as `sfc` objects `x` and `y`; since
-the operations work on the geometries, the non-geometries parts of
+both for `sf` objects and for `sfc` objects `x` and `y`; since
+the operations work on the geometries, the non-geometry parts of
 an `sf` object are simply discarded. Also, all binary operations
 `st_op2(x,y)` called with a single argument, as `st_op2(x)`, are
 handled as `st_op2(x,x)`.
@@ -310,6 +310,7 @@ plot(x)
 plot(y, add = TRUE)
 plot(st_intersection(st_union(x),st_union(y)), add = TRUE, col = 'red')
 ```
+
 Note that the function `st_intersects` returns a logical matrix indicating whether each geometry pair intersects (see the previous section in this vignette).
 
 To get _everything but_ the intersection, use `st_difference` or `st_sym_difference`:
@@ -346,7 +347,7 @@ plot(pol.seg, col = 'grey')
 points(pol.seg[[1]])
 ```
 
-Function `st_polygonize` polygonizes a multilinestring, as far as the points form a closed polygon:
+Function `st_polygonize` polygonizes a multilinestring, as long as the points form a closed polygon:
 ```{r,fig=TRUE}
 par(mfrow=c(1,2),mar=c(0,0,1,0))
 mls = st_multilinestring(list(matrix(c(0,0,0,1,1,1,0,0),,2,byrow=TRUE)))

--- a/vignettes/sf4.Rmd
+++ b/vignettes/sf4.Rmd
@@ -23,7 +23,7 @@ This vignette describes how simple features, i.e. records that come with a geome
 * summarising feature sets
 * joining two feature sets based on feature geometry
 
-Features are represented by records in an `sf` object, and have feature attributes (all non-geometry fields) and feature geometry. Since `sf` objects are a subclass of `data.frame` or `tbl_df`, operations on feature attributes work identical to how they work on `data.frame`s, e.g.
+Features are represented by records in an `sf` object, and have feature attributes (all non-geometry fields) and feature geometry. Since `sf` objects are a subclass of `data.frame` or `tbl_df`, operations on feature attributes work identically to how they work on `data.frame`s, e.g.
 
 ```{r}
 library(sf)
@@ -33,7 +33,7 @@ nc[1,]
 ``` 
 prints the first record.
 
-Many of the tidyverse/dplyr verbs have methods for `sf` objects. This means that given that both `sf` and `dplyr` are loaded, manipulations such as selecting a single attribute will return an `sf` object:
+Many of the tidyverse/dplyr verbs have methods for `sf` objects. This means that if both `sf` and `dplyr` are loaded, manipulations such as selecting a single attribute will return an `sf` object:
 ```{r}
 library(dplyr)
 nc %>% select(NWBIR74) %>% head(2)
@@ -60,19 +60,19 @@ Ashe = nc[nc$NAME == "Ashe",]
 class(Ashe)
 nc[Ashe,]
 ```
-we see that in the result set `Ashe` is included, as the default value for argument `op` in `[.sf` is `st_intersects`, and `Ashe` intersects with itself. We could exclude self-intersection by using predicate `st_touches` (overlapping features don't touch):
+We see that in the result set `Ashe` is included, as the default value for argument `op` in `[.sf` is `st_intersects`, and `Ashe` intersects with itself. We could exclude self-intersection by using predicate `st_touches` (overlapping features don't touch):
 ```{r}
 Ashe = nc[nc$NAME == "Ashe",]
 nc[Ashe, op = st_touches]
 ```
-using `dplyr`, we can do the same by calling the predicate directly:
+Using `dplyr`, we can do the same by calling the predicate directly:
 ```{r}
 nc %>% filter(lengths(st_touches(., Ashe)) > 0)
 ```
 
 ## Aggregating or summarizing feature sets
 
-Suppose we want to compare the 1974 fraction of SID (sudden infant death) of the counties that intersect with `Ashe` to the remaining ones. We can do this by
+Suppose we want to compare the 1974 fraction of SID (sudden infant death) of the counties that intersect with `Ashe` to the remaining ones. We can do this by:
 ```{r}
 a <- aggregate(nc[, c("SID74", "BIR74")], list(Ashe_nb = lengths(st_intersects(nc, Ashe)) > 0), sum)
 (a <- a %>% mutate(frac74 = SID74 / BIR74) %>% select(frac74))
@@ -82,7 +82,7 @@ plot(st_geometry(Ashe), border = '#ff8888', add = TRUE, lwd = 2)
 
 ## Joining two feature sets based on attributes
 
-The usual join verbs base R (`merge`) and of dplyr (`left_join`, etc) work for `sf` objects as well; the joining takes place on attributes (ignoring geometries). In case of no matching geometry, an empty geometry is substituted. The second argument should be a `data.frame` (or similar), not an `sf` object:
+The usual join verbs of base R (`merge`) and of dplyr (`left_join`, etc) work for `sf` objects as well; the joining takes place on attributes (ignoring geometries). In case of no matching geometry, an empty geometry is substituted. The second argument should be a `data.frame` (or similar), not an `sf` object:
 
 ```{r}
 x = st_sf(a = 1:2, geom = st_sfc(st_point(c(0,0)), st_point(c(1,1))))
@@ -114,7 +114,7 @@ st_join(y, x)
 
 and the geometry retained is that of the first argument.
 
-The spatial join predicate can be controlled with any function compatible to `st_intersects` (the default), e.g.
+The spatial join predicate can be controlled with any function compatible with `st_intersects` (the default), e.g.
 
 ```{r}
 st_join(x, y, join = st_covers) # no matching y records: points don't cover circles

--- a/vignettes/sf5.Rmd
+++ b/vignettes/sf5.Rmd
@@ -86,13 +86,13 @@ plot(nc["f"], axes = TRUE, key.pos = 4, pal = sf.colors(10), key.width = lcm(4.5
 
 # Class intervals
 
-color breaks (class intervals) can be controlled by plot arguments `breaks` and `nbreaks`. `nbreaks` specifies the number of breaks; `breaks` is either a vector with break values:
+Color breaks (class intervals) can be controlled by plot arguments `breaks` and `nbreaks`. `nbreaks` specifies the number of breaks; `breaks` is either a vector with break values:
 
 ```{r}
 plot(nc["AREA"], breaks = c(0,.05,.1,.15,.2,.25))
 ```
 
-or `breaks` is used to indicate a breaks finding method that is passed as the `style` argument to `classInt::classIntervals`. Its default value, `pretty`, results in rounded class breaks, and has as a side effect that `nbreaks` may be honoured only approximately. Other methods include `"equal"` to define the data range into `"nbreaks"` equal classes, `"quantile"` to use quantiles as class breaks, and `"jenks"`, used in other software.
+or `breaks` is used to indicate a breaks-finding method that is passed as the `style` argument to `classInt::classIntervals`. Its default value, `pretty`, results in rounded class breaks, and has as a side effect that `nbreaks` may be honoured only approximately. Other methods include `"equal"` to break the data range into `"nbreaks"` equal classes, `"quantile"` to use quantiles as class breaks, and `"jenks"`, used in other software.
 
 ```{r}
 plot(nc["AREA"], breaks = "jenks")
@@ -159,14 +159,14 @@ which convert simple simple feature objects into `grob` ("graphics objects") obj
 
 ## ggplot2
 
-contains a geom specially for simple feature objects, with support for graticule white lines in the background using `sf::st_graticule`. Support is currently good for polygons; for lines or points your milage may vary.
+contains a geom specially for simple feature objects, with support for graticule white lines in the background using `sf::st_graticule`. Support is currently good for polygons; for lines or points, your mileage may vary.
 
 ```{r}
 library(ggplot2)
 ggplot() + geom_sf(data = usa)
 ```
 
-polygons can be colored using `aes`:
+Polygons can be colored using `aes`:
 ```{r}
 ggplot() + 
   geom_sf(data = nc, aes(fill = BIR74)) + 
@@ -186,7 +186,7 @@ ggplot() +
 
 ## mapview
 
-Package `mapview` creates interactive maps in html pages, using package `leaflet` as a work horse. Extensive examples are found [here](https://r-spatial.github.io/mapview/).
+Package `mapview` creates interactive maps in html pages, using package `leaflet` as a workhorse. Extensive examples are found [here](https://r-spatial.github.io/mapview/).
 
 ```{r, eval = FALSE}
 library(mapview)
@@ -211,7 +211,7 @@ tmap_mode("view")
 tm_shape(nc) + tm_fill("BIR74", palette = sf.colors(5))
 ```
 
-replotting the last map in non-interactive mode is as simple as:
+Replotting the last map in non-interactive mode is as simple as:
 ```{r}
 ttm()
 tmap_last()


### PR DESCRIPTION
This commit also adds a link in the README to vignette 7 (on spherical
geometry).