### PR TITLE
improved crs conversion from terra w.r.t. NA

### DIFF
--- a/R/terra.R
+++ b/R/terra.R
@@ -14,12 +14,14 @@ st_as_sf.SpatVector = function(x, ..., hex = TRUE) {
 st_crs.SpatRaster = function(x, ...) {
 	if (!requireNamespace("terra", quietly = TRUE))
 		stop("package terra required, please install it first") # nocov
-	st_crs(terra::crs(x))
+	string = terra::crs(x)
+	if (string == "") st_crs(NA) else st_crs(string)
 }
 
 #' @export
 st_crs.SpatVector = function(x, ...) {
 	if (!requireNamespace("terra", quietly = TRUE))
 		stop("package terra required, please install it first") # nocov
-	st_crs(terra::crs(x))
+	string = terra::crs(x)
+	if (string == "") st_crs(NA) else st_crs(string)
 }


### PR DESCRIPTION
``` r
library(sf)
#> Linking to GEOS 3.8.0, GDAL 3.0.4, PROJ 6.3.1
library(terra)
#> terra version 1.3.4
    
x = rast(nrows=108, ncols=21, xmin=0, xmax=1000)
terra::crs(x)
#> [1] ""
```

Before this fix

```r
sf::st_crs(x)
Error in st_crs.character(terra::crs(x)) : invalid crs: 
```

After:
```r
sf::st_crs(x)
#> Coordinate Reference System: NA
```