### PR TITLE
vignette sf7 (s2): minor fixes

### DIFF
--- a/vignettes/sf7.Rmd
+++ b/vignettes/sf7.Rmd
@@ -23,7 +23,7 @@ knitr::opts_chunk$set(collapse = TRUE)
 This vignette describes what spherical geometry implies, and how
 package `sf` uses the s2geometry library (https://s2geometry.io)
 for geometrical measures, predicates and transformations.
-The code in this vignette only run if `s2` has been installed, e.g. with
+The code in this vignette only runs if `s2` has been installed, e.g. with
 
 ```{r, eval=FALSE}
 install.packages("s2")
@@ -101,7 +101,7 @@ The `s2` package is really a wrapper around the C++
 [s2geometry](https://s2geometry.io) library which was written by
 Google, and which is used in many of its products (e.g. Google
 Maps, Google Earth Engine, Bigquery GIS) and has been translated
-in several programming other languages.
+in several other programming languages.
 
 # Fundamental differences
 
@@ -232,7 +232,7 @@ use GEOS or `sf`. First we will ask if `s2` is being used by default:
 ```{r eval=s2_available}
 sf_use_s2()
 ```
-then we can switch it of (and use GEOS) by
+then we can switch it off (and use GEOS) by
 ```{r eval=s2_available}
 sf_use_s2(FALSE)
 ```
@@ -296,7 +296,7 @@ st_intersects(nc[1:3,], nc[1:3,], s2_model = "semi-open") # only self-intersecti
 
 `st_intersection`, `st_union`, `st_difference` and
 `st_sym_difference` are available as `s2` equivalents. N-ary
-instersection and difference are not (yet) present; cascaded union
+intersection and difference are not (yet) present; cascaded union
 is present; unioning by feature does not work with `s2`.
 
 ## Buffers


### PR DESCRIPTION
Made a few typo and language fixes, while reading the vignette on S2 last week. A very nice vignette!

Some other notes:

- line 288: something is wrong with the last sentence
- line 310: `uk_sfc = st_as_sfc(uk)`
  - the result `uk_sfc` gets 'WGS 84' CRS by default. I presume that this is intended, but I couldn't find it documented somewhere (not for `st_as_sfc()`). Perhaps it is behaviour specific to `s2_geography` objects? Then my suggestion, not for the vignette but for the function docs, would be to document this case.