### PR TITLE
Change st_simplify

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -113,7 +113,7 @@ LinkingTo:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 SystemRequirements: C++11, GDAL (>= 2.0.1), GEOS (>= 3.4.0),
     PROJ (>= 4.8.0), sqlite3
 Collate: 

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -194,23 +194,49 @@ st_convex_hull.sf = function(x) {
 #' @name geos_unary
 #' @export
 #' @details \code{st_simplify} simplifies lines by removing vertices
-#' @param preserveTopology logical; carry out topology preserving simplification? May be specified for each, or for all feature geometries. Note that topology is preserved only for single feature geometries, not for sets of them.
-#' @param dTolerance numeric; tolerance parameter, specified for all or for each feature geometry.
-st_simplify = function(x, preserveTopology = FALSE, dTolerance = 0.0)
+#' @param preserveTopology logical; carry out topology preserving
+#'   simplification? May be specified for each, or for all feature geometries.
+#'   Note that topology is preserved only for single feature geometries, not for
+#'   sets of them. Ignored when the input data is specified with long-lat
+#'   coordinates and \code{sf_use_s2()} returns \code{TRUE} since, in that case,
+#'   \code{st_simplify} implicitly calls \code{s2::s2_simplify} which always
+#'   preserve topology (per single feature).
+#' @param dTolerance numeric; tolerance parameter, specified for all or for each
+#'   feature geometry. If you run \code{st_simplify}, the input data is
+#'   specified with long-lat coordinates and \code{sf_use_s2()} returns
+#'   \code{TRUE}, then the value of \code{dTolerance} must be specified in
+#'   meters.
+#' @examples
+#'
+#' # st_simplify examples:
+#' op = par(mfrow = c(2, 3), mar = rep(0, 4))
+#' plot(nc_g[1])
+#' plot(st_simplify(nc_g[1], dTolerance = 1e3)) # 1000m
+#' plot(st_simplify(nc_g[1], dTolerance = 5e3)) # 5000m
+#' nc_g_planar = st_transform(nc_g, 2264) # planar coordinates, US foot
+#' plot(nc_g_planar[1])
+#' plot(st_simplify(nc_g_planar[1], dTolerance = 1e3)) # 1000 foot
+#' plot(st_simplify(nc_g_planar[1], dTolerance = 5e3)) # 5000 foot
+#' par(op)
+#'
+st_simplify = function(x, preserveTopology, dTolerance = 0.0)
 	UseMethod("st_simplify")
 
 #' @export
-st_simplify.sfg = function(x, preserveTopology = FALSE, dTolerance = 0.0)
+st_simplify.sfg = function(x, preserveTopology, dTolerance = 0.0)
 	get_first_sfg(st_simplify(st_sfc(x), preserveTopology, dTolerance = dTolerance))
 
 #' @export
-st_simplify.sfc = function(x, preserveTopology = FALSE, dTolerance = 0.0) {
+st_simplify.sfc = function(x, preserveTopology, dTolerance = 0.0) {
 	ll = isTRUE(st_is_longlat(x))
 	if (ll && sf_use_s2()) {
 		if (!missing(preserveTopology))
 			warning("argument preserveTopology is ignored")
 		st_as_sfc(s2::s2_simplify(x, dTolerance), crs = st_crs(x))
 	} else {
+		if (missing(preserveTopology)) {
+			preserveTopology = FALSE
+		}
 		stopifnot(mode(preserveTopology) == 'logical')
 		if (ll)
 			warning("st_simplify does not correctly simplify longitude/latitude data, dTolerance needs to be in decimal degrees")
@@ -222,7 +248,7 @@ st_simplify.sfc = function(x, preserveTopology = FALSE, dTolerance = 0.0) {
 }
 
 #' @export
-st_simplify.sf = function(x, preserveTopology = FALSE, dTolerance = 0.0) {
+st_simplify.sf = function(x, preserveTopology, dTolerance = 0.0) {
 	st_set_geometry(x, st_simplify(st_geometry(x), preserveTopology, dTolerance))
 }
 
@@ -256,7 +282,7 @@ st_triangulate.sf = function(x, dTolerance = 0.0, bOnlyEdges = FALSE) {
 
 #' @name geos_unary
 #' @export
-#' @details \code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries. 
+#' @details \code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries.
 #' For \code{st_inscribed_circle}, if \code{nQuadSegs} is 0 a 2-point LINESTRING is returned with the
 #' center point and a boundary point of every circle, otherwise a circle (buffer) is returned where
 #' \code{nQuadSegs} controls the number of points per quadrant to approximate the circle.
@@ -289,7 +315,7 @@ st_inscribed_circle.sfc = function(x, dTolerance = sqrt(st_area(st_set_crs(x, NA
 			pts = st_cast(ret, "POINT")
 			idx = seq(1, length(pts) * 2, by = 2)
 			ret = st_buffer(pts[idx], st_length(st_set_crs(ret, NA_crs_)), nQuadSegs = nQuadSegs)
-		} 
+		}
 		ret
 	} else
 		stop("for st_inscribed_circle, GEOS version 3.9.0 or higher is required")
@@ -439,7 +465,7 @@ st_centroid.sfc = function(x, ..., of_largest_polygon = FALSE) {
 	longlat = isTRUE(st_is_longlat(x))
 	if (longlat && sf_use_s2())
 		st_as_sfc(s2::s2_centroid(x), crs = st_crs(x))
-	else { 
+	else {
 		if (longlat)
 			warning("st_centroid does not give correct centroids for longitude/latitude data")
 		st_sfc(CPL_geos_op("centroid", x, numeric(0), integer(0), numeric(0), logical(0)))
@@ -855,14 +881,14 @@ st_union.sfg = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 st_union.sfc = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	ll = isTRUE(st_is_longlat(x))
 	if (missing(y)) { # unary union, possibly by_feature:
-		if (ll && sf_use_s2()) { 
+		if (ll && sf_use_s2()) {
 			if (! by_feature) { # see https://github.com/r-spatial/s2/issues/97 :
 				if (is_coverage)
 					st_as_sfc(s2::s2_coverage_union_agg(x, ...), crs = st_crs(x))
 				else
-					st_as_sfc(s2::s2_union_agg(x, ...), crs = st_crs(x)) 
+					st_as_sfc(s2::s2_union_agg(x, ...), crs = st_crs(x))
 			} else
-				st_as_sfc(s2::s2_union(x, ...), crs = st_crs(x)) 
+				st_as_sfc(s2::s2_union(x, ...), crs = st_crs(x))
 		} else {
 			if (ll)
 				message_longlat("st_union")
@@ -871,7 +897,7 @@ st_union.sfc = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	} else {
 		stopifnot(st_crs(x) == st_crs(y))
 		if (ll && sf_use_s2())
-			st_as_sfc(s2::s2_union(x, y, ...), crs = st_crs(x)) 
+			st_as_sfc(s2::s2_union(x, y, ...), crs = st_crs(x))
 		else {
 			if (ll)
 				message_longlat("st_union")

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -282,7 +282,7 @@ st_triangulate.sf = function(x, dTolerance = 0.0, bOnlyEdges = FALSE) {
 
 #' @name geos_unary
 #' @export
-#' @details \code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries.
+#' @details \code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries. 
 #' For \code{st_inscribed_circle}, if \code{nQuadSegs} is 0 a 2-point LINESTRING is returned with the
 #' center point and a boundary point of every circle, otherwise a circle (buffer) is returned where
 #' \code{nQuadSegs} controls the number of points per quadrant to approximate the circle.
@@ -315,7 +315,7 @@ st_inscribed_circle.sfc = function(x, dTolerance = sqrt(st_area(st_set_crs(x, NA
 			pts = st_cast(ret, "POINT")
 			idx = seq(1, length(pts) * 2, by = 2)
 			ret = st_buffer(pts[idx], st_length(st_set_crs(ret, NA_crs_)), nQuadSegs = nQuadSegs)
-		}
+		} 
 		ret
 	} else
 		stop("for st_inscribed_circle, GEOS version 3.9.0 or higher is required")
@@ -465,7 +465,7 @@ st_centroid.sfc = function(x, ..., of_largest_polygon = FALSE) {
 	longlat = isTRUE(st_is_longlat(x))
 	if (longlat && sf_use_s2())
 		st_as_sfc(s2::s2_centroid(x), crs = st_crs(x))
-	else {
+	else { 
 		if (longlat)
 			warning("st_centroid does not give correct centroids for longitude/latitude data")
 		st_sfc(CPL_geos_op("centroid", x, numeric(0), integer(0), numeric(0), logical(0)))
@@ -881,14 +881,14 @@ st_union.sfg = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 st_union.sfc = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	ll = isTRUE(st_is_longlat(x))
 	if (missing(y)) { # unary union, possibly by_feature:
-		if (ll && sf_use_s2()) {
+		if (ll && sf_use_s2()) { 
 			if (! by_feature) { # see https://github.com/r-spatial/s2/issues/97 :
 				if (is_coverage)
 					st_as_sfc(s2::s2_coverage_union_agg(x, ...), crs = st_crs(x))
 				else
-					st_as_sfc(s2::s2_union_agg(x, ...), crs = st_crs(x))
+					st_as_sfc(s2::s2_union_agg(x, ...), crs = st_crs(x)) 
 			} else
-				st_as_sfc(s2::s2_union(x, ...), crs = st_crs(x))
+				st_as_sfc(s2::s2_union(x, ...), crs = st_crs(x)) 
 		} else {
 			if (ll)
 				message_longlat("st_union")
@@ -897,7 +897,7 @@ st_union.sfc = function(x, y, ..., by_feature = FALSE, is_coverage = FALSE) {
 	} else {
 		stopifnot(st_crs(x) == st_crs(y))
 		if (ll && sf_use_s2())
-			st_as_sfc(s2::s2_union(x, y, ...), crs = st_crs(x))
+			st_as_sfc(s2::s2_union(x, y, ...), crs = st_crs(x)) 
 		else {
 			if (ll)
 				message_longlat("st_union")

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -233,7 +233,7 @@ st_simplify.sfc = function(x, preserveTopology, dTolerance = 0.0) {
 	ll = isTRUE(st_is_longlat(x))
 	if (ll && sf_use_s2()) {
 		if (!missing(preserveTopology) && isFALSE(preserveTopology))
-			warning("argument preserveTopology is ignored")
+			warning("argument preserveTopology cannot be set to FALSE when working with ellipsoidal coordinates since the algorithm behind st_simplify always preserves topological relationships")
 		st_as_sfc(s2::s2_simplify(x, dTolerance), crs = st_crs(x))
 	} else {
 		if (missing(preserveTopology)) {

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -193,14 +193,16 @@ st_convex_hull.sf = function(x) {
 
 #' @name geos_unary
 #' @export
-#' @details \code{st_simplify} simplifies lines by removing vertices
+#' @details \code{st_simplify} simplifies lines by removing vertices. 
 #' @param preserveTopology logical; carry out topology preserving
 #'   simplification? May be specified for each, or for all feature geometries.
 #'   Note that topology is preserved only for single feature geometries, not for
-#'   sets of them. Ignored when the input data is specified with long-lat
-#'   coordinates and \code{sf_use_s2()} returns \code{TRUE} since, in that case,
-#'   \code{st_simplify} implicitly calls \code{s2::s2_simplify} which always
-#'   preserve topology (per single feature).
+#'   sets of them. If not specified (i.e. the default), then it is internally
+#'   set equal to \code{FALSE} when the input data is specified with projected
+#'   coordinates or \code{sf_use_s2()} returns \code{FALSE}. Ignored in all the
+#'   other cases (with a warning when set equal to \code{FALSE}) since the
+#'   function implicitly calls \code{s2::s2_simplify} which always preserve
+#'   topological relationships (per single feature).
 #' @param dTolerance numeric; tolerance parameter, specified for all or for each
 #'   feature geometry. If you run \code{st_simplify}, the input data is
 #'   specified with long-lat coordinates and \code{sf_use_s2()} returns

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -230,7 +230,7 @@ st_simplify.sfg = function(x, preserveTopology, dTolerance = 0.0)
 st_simplify.sfc = function(x, preserveTopology, dTolerance = 0.0) {
 	ll = isTRUE(st_is_longlat(x))
 	if (ll && sf_use_s2()) {
-		if (!missing(preserveTopology))
+		if (!missing(preserveTopology) && isFALSE(preserveTopology))
 			warning("argument preserveTopology is ignored")
 		st_as_sfc(s2::s2_simplify(x, dTolerance), crs = st_crs(x))
 	} else {

--- a/man/geos_unary.Rd
+++ b/man/geos_unary.Rd
@@ -33,7 +33,7 @@ st_boundary(x)
 
 st_convex_hull(x)
 
-st_simplify(x, preserveTopology = FALSE, dTolerance = 0)
+st_simplify(x, preserveTopology, dTolerance = 0)
 
 st_triangulate(x, dTolerance = 0, bOnlyEdges = FALSE)
 
@@ -75,9 +75,19 @@ in which case negative \code{dist} values give buffers on the right-hand side, p
 
 \item{...}{ignored}
 
-\item{preserveTopology}{logical; carry out topology preserving simplification? May be specified for each, or for all feature geometries. Note that topology is preserved only for single feature geometries, not for sets of them.}
+\item{preserveTopology}{logical; carry out topology preserving
+simplification? May be specified for each, or for all feature geometries.
+Note that topology is preserved only for single feature geometries, not for
+sets of them. Ignored when the input data is specified with long-lat
+coordinates and \code{sf_use_s2()} returns \code{TRUE} since, in that case,
+\code{st_simplify} implicitly calls \code{s2::s2_simplify} which always
+preserve topology (per single feature).}
 
-\item{dTolerance}{numeric; tolerance parameter, specified for all or for each feature geometry.}
+\item{dTolerance}{numeric; tolerance parameter, specified for all or for each
+feature geometry. If you run \code{st_simplify}, the input data is
+specified with long-lat coordinates and \code{sf_use_s2()} returns
+\code{TRUE}, then the value of \code{dTolerance} must be specified in
+meters.}
 
 \item{bOnlyEdges}{logical; if TRUE, return lines, else return polygons}
 
@@ -107,7 +117,7 @@ See \href{https://postgis.net/docs/ST_Buffer.html}{postgis.net/docs/ST_Buffer.ht
 
 \code{st_triangulate} triangulates set of points (not constrained). \code{st_triangulate} requires GEOS version 3.4 or above
 
-\code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries. 
+\code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries.
 For \code{st_inscribed_circle}, if \code{nQuadSegs} is 0 a 2-point LINESTRING is returned with the
 center point and a boundary point of every circle, otherwise a circle (buffer) is returned where
 \code{nQuadSegs} controls the number of points per quadrant to approximate the circle.
@@ -171,6 +181,18 @@ nc = st_read(system.file("shape/nc.shp", package="sf"))
 nc_g = st_geometry(nc)
 plot(st_convex_hull(nc_g))
 plot(nc_g, border = grey(.5), add = TRUE)
+
+# st_simplify examples:
+op = par(mfrow = c(2, 3), mar = rep(0, 4))
+plot(nc_g[1])
+plot(st_simplify(nc_g[1], dTolerance = 1e3)) # 1000m
+plot(st_simplify(nc_g[1], dTolerance = 5e3)) # 5000m
+nc_g_planar = st_transform(nc_g, 2264) # planar coordinates, US foot
+plot(nc_g_planar[1])
+plot(st_simplify(nc_g_planar[1], dTolerance = 1e3)) # 1000 foot
+plot(st_simplify(nc_g_planar[1], dTolerance = 5e3)) # 5000 foot
+par(op)
+
 if (compareVersion(sf_extSoftVersion()[["GEOS"]], "3.9.0") > -1) {
   nc_t = st_transform(nc, 'EPSG:2264')
   x = st_inscribed_circle(st_geometry(nc_t))

--- a/man/geos_unary.Rd
+++ b/man/geos_unary.Rd
@@ -78,10 +78,12 @@ in which case negative \code{dist} values give buffers on the right-hand side, p
 \item{preserveTopology}{logical; carry out topology preserving
 simplification? May be specified for each, or for all feature geometries.
 Note that topology is preserved only for single feature geometries, not for
-sets of them. Ignored when the input data is specified with long-lat
-coordinates and \code{sf_use_s2()} returns \code{TRUE} since, in that case,
-\code{st_simplify} implicitly calls \code{s2::s2_simplify} which always
-preserve topology (per single feature).}
+sets of them. If not specified (i.e. the default), then it is internally
+set equal to \code{FALSE} when the input data is specified with projected
+coordinates or \code{sf_use_s2()} returns \code{FALSE}. Ignored in all the
+other cases (with a warning when set equal to \code{FALSE}) since the
+function implicitly calls \code{s2::s2_simplify} which always preserve
+topological relationships (per single feature).}
 
 \item{dTolerance}{numeric; tolerance parameter, specified for all or for each
 feature geometry. If you run \code{st_simplify}, the input data is
@@ -113,11 +115,11 @@ See \href{https://postgis.net/docs/ST_Buffer.html}{postgis.net/docs/ST_Buffer.ht
 
 \code{st_convex_hull} creates the convex hull of a set of points
 
-\code{st_simplify} simplifies lines by removing vertices
+\code{st_simplify} simplifies lines by removing vertices.
 
 \code{st_triangulate} triangulates set of points (not constrained). \code{st_triangulate} requires GEOS version 3.4 or above
 
-\code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries.
+\code{st_inscribed_circle} returns the maximum inscribed circle for polygon geometries. 
 For \code{st_inscribed_circle}, if \code{nQuadSegs} is 0 a 2-point LINESTRING is returned with the
 center point and a boundary point of every circle, otherwise a circle (buffer) is returned where
 \code{nQuadSegs} controls the number of points per quadrant to approximate the circle.


### PR DESCRIPTION
The current implementation of `st_simplify` always returns a warning message when the input object is specified with lat-long coordinates and `sf_use_s2` returns `TRUE` since the argument `preserveTopology` is never evaluated as missing: 

``` r
remotes::install_github("r-spatial/sf", quiet = TRUE)
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.2.1, PROJ 7.2.1
nc = st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)
nc = st_simplify(nc)
#> Warning in st_simplify.sfc(st_geometry(x), preserveTopology, dTolerance):
#> argument preserveTopology is ignored
```

<sup>Created on 2021-09-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

I created this PR to propose a solution that (I think) preserves the original behaviour and removes that warning message when is not needed. I also added some examples and wrote more details in the docs. This is the figure created in the examples: 

``` r
library(sf)
#> Linking to GEOS 3.9.1, GDAL 3.2.1, PROJ 7.2.1
nc = st_read(system.file("shape/nc.shp", package="sf"))
nc_g = st_geometry(nc)
op = par(mfrow = c(2, 3), mar = rep(0, 4))
plot(nc_g[1])
plot(st_simplify(nc_g[1], dTolerance = 1e3)) # 1000m
plot(st_simplify(nc_g[1], dTolerance = 5e3)) # 5000m
nc_g_planar = st_transform(nc_g, 2264) # planar coordinates, US foot
plot(nc_g_planar[1])
plot(st_simplify(nc_g_planar[1], dTolerance = 1e3)) # 1000 foot
plot(st_simplify(nc_g_planar[1], dTolerance = 5e3)) # 5000 foot
```

![](https://i.imgur.com/aqbkNvo.png)

<sup>Created on 2021-09-22 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>