### PR TITLE
add issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,22 @@
+---
+name: Bug report
+about: Standard bug report template
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+It is easier for developers to help if they can reproduce the problem.   
+Could you please provide a minimal reproducible example?
+
+**Additional context**
+Add any other context about the problem here.
+
+<details>
+Paste the output of your `sessionInfo()`
+</details>

--- a/.github/ISSUE_TEMPLATE/other_issue.md
+++ b/.github/ISSUE_TEMPLATE/other_issue.md
@@ -1,0 +1,8 @@
+---
+name: Other issue
+about: Blank template for other issue types
+title: ''
+labels: ''
+assignees: ''
+
+---


### PR DESCRIPTION
As discussed in #1814
Issue templates are just simple md files in the .github folder. They can be a lot more sophisticated but I don't think that's useful here. 
You can can try it on my fork to see what it looks like. 