### PR TITLE
Vignette sf7 (spherical): stress condition of GEOGCRS for s2

### DIFF
--- a/vignettes/sf7.Rmd
+++ b/vignettes/sf7.Rmd
@@ -96,7 +96,8 @@ and whether it is
 * a straight line, cutting through the Earth's surface, or
 * a curved line following the Earth's surface
 
-Starting with `sf` version 1.0, `sf` uses the new package `s2`
+Starting with `sf` version 1.0, if you provide a spatial object in a
+geographical coordinate reference system, `sf` uses the new package `s2`
 (Dunnington, Pebesma, Rubak 2020) for spherical geometry, which
 has functions for computing pretty much all measures, predicates
 and transformations _on the sphere_. This means:

--- a/vignettes/sf7.Rmd
+++ b/vignettes/sf7.Rmd
@@ -112,6 +112,8 @@ Google, and which is used in many of its products (e.g. Google
 Maps, Google Earth Engine, Bigquery GIS) and has been translated
 in several other programming languages.
 
+With projected coordinates `sf` continues to work in $R^2$ as before.
+
 # Fundamental differences
 
 Compared to geometry on $R^2$, and DE9-IM, the `s2` package brings a


### PR DESCRIPTION
In the vignette introduction, it is said once already, but IMHO rather inconspicuously (boldface added here):

> Most `sf` functions automatically use `s2` functions **when working with ellipsoidal coordinates**; [...]

I suggest to stress this aspect again where the vignette says:

> Starting with `sf` version 1.0, sf uses the new package `s2` (Dunnington, Pebesma, Rubak 2020) for spherical geometry [...]

For some readers it may be not clear enough that `s2` is not going to be used for projected coordinates. It may seem as if `s2` is always going to be used, which isn't the case, so I suggest to make that more visible.