### PR TITLE
add quiet param to sf_use_s2

### DIFF
--- a/R/s2.R
+++ b/R/s2.R
@@ -6,16 +6,17 @@
 #' @param ... passed on
 #' @param use_s2 logical; if \code{TRUE}, use the s2 spherical geometry package
 #' for geographical coordinate operations
+#' @param quiet logical; suppress message if \code{TRUE}
 #' @name s2
 #' @return \code{sf_use_s2} returns the value of this variable before (re)setting it,
 #' invisibly if \code{use_s2} is not missing.
-sf_use_s2 = function(use_s2) {
+sf_use_s2 = function(use_s2, quiet = FALSE) {
 	ret_val = get(".sf.use_s2", envir = .sf_cache)
 	if (! missing(use_s2)) {
 		stopifnot(is.logical(use_s2), length(use_s2)==1, !is.na(use_s2))
 		if (use_s2 && !requireNamespace("s2", quietly = TRUE))
 			stop("package s2 not available: install it first?")
-		if (ret_val != use_s2)
+		if (ret_val != use_s2 & !quiet)
 			cat(paste0("Spherical geometry (s2) switched ", ifelse(use_s2, "on", "off"), "\n"))
 		assign(".sf.use_s2", use_s2, envir = .sf_cache)
 		invisible(ret_val)

--- a/man/s2.Rd
+++ b/man/s2.Rd
@@ -8,7 +8,7 @@
 \alias{st_as_s2.sfc}
 \title{functions for spherical geometry, using s2 package}
 \usage{
-sf_use_s2(use_s2)
+sf_use_s2(use_s2, quiet = FALSE)
 
 st_as_s2(x, ...)
 
@@ -19,6 +19,8 @@ st_as_s2(x, ...)
 \arguments{
 \item{use_s2}{logical; if \code{TRUE}, use the s2 spherical geometry package
 for geographical coordinate operations}
+
+\item{quiet}{logical; suppress message if \code{TRUE}}
 
 \item{x}{object of class \code{sf}, \code{sfc} or \code{sfg}}
 


### PR DESCRIPTION
There is currently no way to suppress the message, `Spherical geometry (s2) switched on/off`. This PR adds a `quiet` option to suppress if changed from default `FALSE` to `TRUE`.