### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -95,7 +95,7 @@ Suggests:
     sp (>= 1.2-4),
     spatstat (>= 2.0-1),
     spatstat.geom, 
-    spatstat.core, 
+    spatstat.random, 
     spatstat.linnet, 
     spatstat.utils,
     stars (>= 0.2-0),

--- a/R/sample.R
+++ b/R/sample.R
@@ -20,7 +20,7 @@ st_sample = function(x, size, ...) UseMethod("st_sample")
 #' @param warn_if_not_integer logical; if \code{FALSE} then no warning is emitted if \code{size} is not an integer
 #' @param ... passed on to \link[base]{sample} for \code{multipoint} sampling, or to \code{spatstat} functions for spatstat sampling types (see details)
 #' @param type character; indicates the spatial sampling type; one of \code{random}, \code{hexagonal} (triangular really), \code{regular},
-#' or one of the \code{spatstat} methods such as \code{Thomas} for calling \code{spatstat.core::rThomas} (see Details).
+#' or one of the \code{spatstat} methods such as \code{Thomas} for calling \code{spatstat.random::rThomas} (see Details).
 #' @param exact logical; should the length of output be exactly
 #' @param by_polygon logical; for \code{MULTIPOLYGON} geometries, should the effort be split by \code{POLYGON}? See https://github.com/r-spatial/sf/issues/1480
 #' the same as specified by \code{size}? \code{TRUE} by default. Only applies to polygons, and
@@ -33,7 +33,7 @@ st_sample = function(x, size, ...) UseMethod("st_sample")
 #' As parameter called \code{offset} can be passed to control ("fix") regular or hexagonal sampling: for polygons a length 2 numeric vector (by default: a random point from \code{st_bbox(x)}); for lines use a number like \code{runif(1)}.
 #'
 #' Sampling methods from package \code{spatstat} are interfaced (see examples), and need their own parameters to be set. 
-#' For instance, to use \code{spatstat.core::rThomas()}, set \code{type = "Thomas"}.
+#' For instance, to use \code{spatstat.random::rThomas()}, set \code{type = "Thomas"}.
 #' @examples
 #' nc = st_read(system.file("shape/nc.shp", package="sf"))
 #' p1 = st_sample(nc[1:3, ], 6)
@@ -81,9 +81,9 @@ st_sample = function(x, size, ...) UseMethod("st_sample")
 #' st_sample(ls, 80)
 #' plot(st_sample(ls, 80))
 #' # spatstat example:
-#' if (require(spatstat.core)) {
+#' if (require(spatstat.random)) {
 #'  x <- sf::st_sfc(sf::st_polygon(list(rbind(c(0, 0), c(10, 0), c(10, 10), c(0, 0)))))
-#'  # for spatstat.core::rThomas(), set type = "Thomas":
+#'  # for spatstat.random::rThomas(), set type = "Thomas":
 #'  pts <- st_sample(x, kappa = 1, mu = 10, scale = 0.1, type = "Thomas") 
 #' }
 #' @export
@@ -184,11 +184,11 @@ st_poly_sample = function(x, size, ..., type = "random",
 			}
 		pts[x] # cut out x from bbox
 	} else { # try to go into spatstat
-		if (!requireNamespace("spatstat.core", quietly = TRUE))
-			stop("package spatstat.core required, please install it (or the full spatstat package) first")
-		spatstat_fun = try(get(paste0("r", type), asNamespace("spatstat.core")), silent = TRUE)
+		if (!requireNamespace("spatstat.random", quietly = TRUE))
+			stop("package spatstat.random required, please install it (or the full spatstat package) first")
+		spatstat_fun = try(get(paste0("r", type), asNamespace("spatstat.random")), silent = TRUE)
 		if (inherits(spatstat_fun, "try-error"))
-			stop(paste0("r", type), " is not an exported function from spatstat.core.")
+			stop(paste0("r", type), " is not an exported function from spatstat.random.")
 		pts = try(spatstat_fun(..., win = spatstat.geom::as.owin(x)), silent = TRUE)
 		if (inherits(pts, "try-error"))
 			stop("The spatstat function ", paste0("r", type),

--- a/man/st_sample.Rd
+++ b/man/st_sample.Rd
@@ -31,7 +31,7 @@ st_sample(x, size, ...)
 \item{...}{passed on to \link[base]{sample} for \code{multipoint} sampling, or to \code{spatstat} functions for spatstat sampling types (see details)}
 
 \item{type}{character; indicates the spatial sampling type; one of \code{random}, \code{hexagonal} (triangular really), \code{regular},
-or one of the \code{spatstat} methods such as \code{Thomas} for calling \code{spatstat.core::rThomas} (see Details).}
+or one of the \code{spatstat} methods such as \code{Thomas} for calling \code{spatstat.random::rThomas} (see Details).}
 
 \item{exact}{logical; should the length of output be exactly}
 
@@ -64,7 +64,7 @@ For \code{regular} or \code{hexagonal} sampling of polygons, the resulting size 
 As parameter called \code{offset} can be passed to control ("fix") regular or hexagonal sampling: for polygons a length 2 numeric vector (by default: a random point from \code{st_bbox(x)}); for lines use a number like \code{runif(1)}.
 
 Sampling methods from package \code{spatstat} are interfaced (see examples), and need their own parameters to be set. 
-For instance, to use \code{spatstat.core::rThomas()}, set \code{type = "Thomas"}.
+For instance, to use \code{spatstat.random::rThomas()}, set \code{type = "Thomas"}.
 }
 \examples{
 nc = st_read(system.file("shape/nc.shp", package="sf"))
@@ -113,9 +113,9 @@ ls = st_sfc(st_linestring(rbind(c(0,0),c(0,1))),
 st_sample(ls, 80)
 plot(st_sample(ls, 80))
 # spatstat example:
-if (require(spatstat.core)) {
+if (require(spatstat.random)) {
  x <- sf::st_sfc(sf::st_polygon(list(rbind(c(0, 0), c(10, 0), c(10, 10), c(0, 0)))))
- # for spatstat.core::rThomas(), set type = "Thomas":
+ # for spatstat.random::rThomas(), set type = "Thomas":
  pts <- st_sample(x, kappa = 1, mu = 10, scale = 0.1, type = "Thomas") 
 }
 }

--- a/tests/spatstat.R
+++ b/tests/spatstat.R
@@ -1,4 +1,4 @@
-suppressPackageStartupMessages(library(spatstat.core))
+suppressPackageStartupMessages(library(spatstat.random))
 suppressPackageStartupMessages(library(sf))
 
 data(chicago)

--- a/tests/spatstat.Rout.save
+++ b/tests/spatstat.Rout.save
@@ -15,7 +15,7 @@ Type 'demo()' for some demos, 'help()' for on-line help, or
 'help.start()' for an HTML browser interface to help.
 Type 'q()' to quit R.
 
-> suppressPackageStartupMessages(library(spatstat.core))
+> suppressPackageStartupMessages(library(spatstat.random))
 > suppressPackageStartupMessages(library(sf))
 > 
 > data(chicago)
@@ -108,7 +108,7 @@ First 10 features:
 > x <- sf::st_sfc(sf::st_polygon(list(rbind(c(0, 0), c(10, 0), c(10, 10), c(0, 0)))))
 > try(pts <- st_sample(x, type = "thomas"))
 Error in st_poly_sample(x, size = size, ..., type = type, by_polygon = by_polygon) : 
-  rthomas is not an exported function from spatstat.core.
+  rthomas is not an exported function from spatstat.random.
 > try(pts <- st_sample(x, kappa = 1, mu = 10, type = "Thomas"))
 Error in st_poly_sample(x, size = size, ..., type = type, by_polygon = by_polygon) : 
   The spatstat function rThomas did not return a valid result. Consult the help file.


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`.
The proposed changes should hopefully fix the upcoming problem for your package.