### PR TITLE
Update `pivot_longer()` signature

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -101,7 +101,7 @@ Suggests:
     terra,
     testthat,
     tibble (>= 1.4.1),
-    tidyr (>= 1.0-0),
+    tidyr (>= 1.2.0),
     tidyselect (>= 1.0.0),
     tmap (>= 2.0),
     vctrs,

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -330,10 +330,10 @@ gather.sf <- function(data, key, value, ..., na.rm = FALSE, convert = FALSE, fac
 }
 
 pivot_longer.sf <- function (data, cols, names_to = "name", names_prefix = NULL,
-		names_sep = NULL, names_pattern = NULL, names_ptypes = list(),
-		names_transform = list(), names_repair = "check_unique",
-		values_to = "value", values_drop_na = FALSE, values_ptypes = list(),
-		values_transform = list(), ...) {
+		names_sep = NULL, names_pattern = NULL, names_ptypes = NULL,
+		names_transform = NULL, names_repair = "check_unique",
+		values_to = "value", values_drop_na = FALSE, values_ptypes = NULL,
+		values_transform = NULL, ...) {
 
   sf_column_name = attr(data, "sf_column")
   data = as.data.frame(data)
@@ -345,19 +345,19 @@ pivot_longer.sf <- function (data, cols, names_to = "name", names_prefix = NULL,
   if (!requireNamespace("tidyr", quietly = TRUE))
     stop("tidyr required: install first?")
   out <- tidyr::pivot_longer(
-    data = data, 
+    data = data,
     cols = {{ cols }},
-    names_to = names_to, 
+    names_to = names_to,
     names_prefix = names_prefix,
-    names_sep = names_sep, 
-    names_pattern = names_pattern, 
+    names_sep = names_sep,
+    names_pattern = names_pattern,
     names_ptypes = names_ptypes,
-    names_transform = names_transform, 
+    names_transform = names_transform,
     names_repair = names_repair,
-    values_to = values_to, 
-    values_drop_na = values_drop_na, 
+    values_to = values_to,
+    values_drop_na = values_drop_na,
     values_ptypes = values_ptypes,
-    values_transform = values_transform, 
+    values_transform = values_transform,
     ...
   )
   st_as_sf(out, sf_column_name = sf_column_name)


### PR DESCRIPTION
In tidyr 1.2.0 we updated `pivot_longer()`'s `names_transform`, `values_transform`, `names_ptypes` and `values_ptypes` arguments to allow a _single_ function or ptype which will be applied to all columns, rather than requiring a named list. See https://github.com/tidyverse/tidyr/blob/main/NEWS.md#pivoting

This required us to change the default argument from `list()` to `NULL`. In particular, for `names/values_ptypes`, this was important because `list()` should now be interpreted as "use a list ptype for all columns".

For backwards compatibility with sf and a few other packages that extend `pivot_longer()`, we have temporarily forced `list()` to be interpreted as `NULL`, but we would like to remove this behavior. See https://github.com/tidyverse/tidyr/issues/1296.

This PR is a step towards that by updating the signature used in sf to use `NULL` rather than `list()`. We would appreciate if you could merge this in and get it on CRAN at your earliest convenience!