### PR TITLE
Don't strip whitespaces in RStudio project

### DIFF
--- a/sf.Rproj
+++ b/sf.Rproj
@@ -13,7 +13,7 @@ RnwWeave: knitr
 LaTeX: XeLaTeX
 
 AutoAppendNewline: Yes
-StripTrailingWhitespace: Yes
+StripTrailingWhitespace: No
 
 BuildType: Package
 PackageUseDevtools: Yes


### PR DESCRIPTION
If we edit project code in RStudio, the option to strip trailing whitespace is enabled by default. Currently, this generates large code differences. Disabling this option will make it easier to track changes in the code.