### PR TITLE
apply filter to geometry types in area weighted interpolation

### DIFF
--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -130,6 +130,8 @@ st_interpolate_aw.sf = function(x, to, extensive, ..., keep_NA = FALSE) {
 	i[gc] = st_collection_extract(i[gc], "POLYGON")
 	two_d = which(st_dimension(i) == 2)
 	i[two_d] = st_cast(i[two_d], "MULTIPOLYGON")
+	
+	i <- Filter( \(x) st_geometry_type(x) %in% c("POLYGON", "MULTIPOLYGON"), i) # remove geometries of other types than (multi)polygons
 
 	x_st = st_set_geometry(x, NULL)[idx[,1],, drop=FALSE]   # create st table, remove geom
 	if (any(!sapply(x_st, is.numeric)))


### PR DESCRIPTION
I was able to reproduce the error mentioned in #2005, and avoid it's occurence by implementing a Filter on the intersection, removing geometry types other than polygon or multipolygon (I believe that the root cause of the #2005 issue was that the `i` object of intersection contained linestring and mutlilinestring geometries, which have no defined area and thus are unsuitable for area based interpolation).