### PR TITLE
Update Makevars for Windows

### DIFF
--- a/src/Makevars.ucrt
+++ b/src/Makevars.ucrt
@@ -9,8 +9,8 @@ PKG_LIBS =  \
 all: clean winlibs
 
 winlibs:
-	cp -r $(R_TOOLS_SOFT)/share/gdal ../inst/
-	cp -r $(R_TOOLS_SOFT)/share/proj ../inst/
+	cp -r "$(R_TOOLS_SOFT)/share/gdal" ../inst/
+	cp -r "$(R_TOOLS_SOFT)/share/proj" ../inst/
 
 CXX_STD = CXX11
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -25,8 +25,8 @@ CXX_STD = CXX11
 winlibs:
 	mkdir -p ../inst
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" --vanilla "../tools/winlibs.R" $(VERSION)
-	cp -r $(RWINLIB)/share/gdal ../inst/
-	cp -r $(RWINLIB)/share/proj ../inst/
+	cp -r "$(RWINLIB)/share/gdal" ../inst/
+	cp -r "$(RWINLIB)/share/proj" ../inst/
 
 clean:
 	rm -f $(SHLIB) $(OBJECTS)


### PR DESCRIPTION
When attempting to build sf from source on my work (Windows) computer I get the following error.

```
cp -r C:/Program Files/rtools42/x86_64-w64-mingw32.static.posix/share/gdal ../inst/
cp: cannot stat 'C:/Program': No such file or directory
cp: cannot stat 'Files/rtools42/x86_64-w64-mingw32.static.posix/share/gdal': No such file or directory
make: *** [Makevars.ucrt:12: winlibs] Error 1
ERROR: compilation failed for package 'sf'
```

This appears to be because my rtools42 directory is inside "Program Files" which has a space in the name.

I do not have control over where Rtools is installed.

Adding quotes around the `cp` command paths in Makevars.ucrt resolves the error for me.

I also made an analogous change to Makevars.win.

@kadyb suggested I propose these changes here after making similar ones in {terra}.