### PR TITLE
another shot at #2005 - asking s2 to ignore line & point intersections

### DIFF
--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -122,7 +122,7 @@ st_interpolate_aw.sf = function(x, to, extensive, ..., keep_NA = FALSE) {
 
 	if (! all_constant(x))
 		warning("st_interpolate_aw assumes attributes are constant or uniform over areas of x")
-	i = st_intersection(st_geometry(x), st_geometry(to))
+	i = st_intersection(st_geometry(x), st_geometry(to), dimensions = "polygon")
 	idx = attr(i, "idx")
 
 	# https://stackoverflow.com/questions/57767022/how-do-you-use-st-interpolate-aw-with-polygon-layers-that-legitimately-include-p


### PR DESCRIPTION
I believe this pull request resolves the underlying issue behind #2005  better than (now closed) #2006 

If we ask S2 to return only polygon intersections - which is possible, I just did not realise it when composing the previous pull - it will not be necessary to do any filtering.

In case of planar intersection the `dimensions = "polygon"` part of the intersection call would be safely ignored. 