### PR TITLE
drop the rownames in `st_coordinates()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # version 1.0-10
 
+* drop the rownames in `st_coordinates()` reducing the output size
+
 # version 1.0-9
 
 * adjust for changes how R-devel handles `POSIXlt`; #2028

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -488,7 +488,7 @@ st_coordinates.sfc = function(x, ...) {
 
 	ret = switch(class(x)[1],
 		sfc_POINT = matrix(unlist(x, use.names = FALSE), nrow = length(x), byrow = TRUE,
-		     dimnames = list(seq_along(x))),
+		     dimnames = NULL),
 		sfc_MULTIPOINT = ,
 		sfc_LINESTRING = coord_2(x),
 		sfc_MULTILINESTRING = ,


### PR DESCRIPTION
This will improve https://github.com/r-spatial/sf/issues/2008#issuecomment-1309530848 and https://github.com/r-spatial/sf/issues/1879#issuecomment-1009185571. I ran the local and GHA tests and nothing seems to break. With this PR, I see a reduced output size of ~9 times in `st_distance(by_element = TRUE, which = "Euclidean")` and ~5 times in `st_coordinates()`.

```r
n = 10000
df1 = st_as_sf(data.frame(x = runif(n), y = runif(n)), coords = 1:2, crs = 3857)
df2 = st_as_sf(data.frame(x = runif(n), y = runif(n)), coords = 1:2, crs = 3857)
dist = st_distance(df1, df2, by_element = TRUE, which = "Euclidean")
format(object.size(x), units = "auto")
format(object.size(st_coordinates(df1)), units = "auto")
```

| **Function**      | **Before [Kb]** | **After [kB]** |
|-------------------|-----------------|----------------|
| `st_distance`    | 704.4           | 79.2           |
| `st_coordinates` | 781.9           | 156.8          |