### PR TITLE
Ignores the `.keep` of `group_split.sf()` for rowwise_df

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -25,7 +25,11 @@ dplyr_reconstruct.sf = function(data, template) {
 
 group_split.sf <- function(.tbl, ..., .keep = TRUE) {
 	 class(.tbl) = setdiff(class(.tbl), "sf")
-     lapply(dplyr::group_split(.tbl, ..., .keep = .keep), st_as_sf)
+	 if (inherits(.tbl, "rowwise_df")) {
+	 	lapply(dplyr::group_split(.tbl, ...), st_as_sf)
+	 } else {
+	 	lapply(dplyr::group_split(.tbl, ..., .keep = .keep), st_as_sf)	
+	 }
 }
 
 #' Tidyverse methods for sf objects (remove .sf suffix!)

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -276,3 +276,8 @@ test_that("rowwise_df class is retained on filtered rows", {
 	skip_if_not_installed("dplyr")
 	expect_true(nc %>% rowwise() %>% filter(AREA > .1) %>% inherits("rowwise_df"))
 })
+
+test_that("`group_split.sf()` ignores `.keep` for rowwise_df class", {
+	skip_if_not_installed("dplyr")
+	expect_no_warning(nc %>% rowwise() %>% group_split())
+})

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -281,3 +281,18 @@ test_that("`group_split.sf()` ignores `.keep` for rowwise_df class", {
 	skip_if_not_installed("dplyr")
 	expect_no_warning(nc %>% rowwise() %>% group_split())
 })
+
+test_that("group_split.sf()` does not ignore `.keep` for grouped_df class", {
+	skip_if_not_installed("dplyr")
+	
+	nc_kept <- nc %>%
+		group_by(CNTY_ID) %>%
+		group_split(.keep = TRUE)
+	
+	nc_notkept <- nc %>%
+		group_by(CNTY_ID) %>%
+		group_split(.keep = FALSE)
+	
+	expect_identical(names(nc_kept[[1]]), names(nc))
+	expect_identical(names(nc_notkept[[1]]), setdiff(names(nc), "CNTY_ID"))
+})


### PR DESCRIPTION
`group_split.sf()` for rowwise_df warns that `.keep` is ignored as follows, 
so I modified the behavior of `group_split.sf()` for rowwise_df.

``` r
suppressMessages(require(sf, quietly = TRUE))
suppressMessages(require(dplyr, quietly = TRUE))

nc <- st_read(system.file("shape/nc.shp", package="sf"), quiet = TRUE)

out <- nc %>%
  rowwise() %>%
  group_split()
#> Warning: .keep is ignored in group_split(<rowwise_df>)
```

<sup>Created on 2022-11-24 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
