### PR TITLE
for #2063; reproducing rgeos workflow for assigning interior to exterior rings

### DIFF
--- a/R/sp.R
+++ b/R/sp.R
@@ -159,7 +159,7 @@ st_as_sfc.SpatialPolygons = function(x, ..., precision = 0.0, forceMulti = FALSE
 					for (i in seq_along(wkts)) {
 						wkts[[i]] <- st_as_text(raw0[!holes][i])
 					}
-					cp0 <- st_contains_properly(raw0[!holes], raw0[holes])
+					cp0 <- st_contains(raw0[!holes], raw0[holes])
 					areas <- sapply(slot(pl, "Polygons"), slot, "area")
 					hole_assigned <- rep(FALSE, sum(holes))
 					names(cp0) <- 1:length(cp0)

--- a/tests/testthat/test_sp.R
+++ b/tests/testthat/test_sp.R
@@ -24,6 +24,34 @@ test_that("we can convert points & lines to and from sp objects", {
   expect_identical(class(st_geometry(l2)), c("sfc_MULTILINESTRING", "sfc")) #-> name differences
 })
 
+test_that("we can convert SpatialPolygons objects without SF comments to sfc and back", {
+  skip_if_not_installed("sp")
+  library(sp)
+# nested holes https://github.com/r-spatial/evolution/issues/9
+  p1 <- Polygon(cbind(x=c(0, 0, 10, 10, 0), y=c(0, 10, 10, 0, 0)), hole=FALSE) # I
+  p2 <- Polygon(cbind(x=c(3, 3, 7, 7, 3), y=c(3, 7, 7, 3, 3)), hole=TRUE) # H
+  p8 <- Polygon(cbind(x=c(1, 1, 2, 2, 1), y=c(1, 2, 2, 1, 1)), hole=TRUE) # H
+  p9 <- Polygon(cbind(x=c(1, 1, 2, 2, 1), y=c(5, 6, 6, 5, 5)), hole=TRUE) # H
+  p3 <- Polygon(cbind(x=c(20, 20, 30, 30, 20), y=c(20, 30, 30, 20, 20)), hole=FALSE) # I
+  p4 <- Polygon(cbind(x=c(21, 21, 29, 29, 21), y=c(21, 29, 29, 21, 21)), hole=TRUE) # H
+  p5 <- Polygon(cbind(x=c(22, 22, 28, 28, 22), y=c(22, 28, 28, 22, 22)), hole=FALSE) # I
+  p6 <- Polygon(cbind(x=c(23, 23, 27, 27, 23), y=c(23, 27, 27, 23, 23)), hole=TRUE) # H
+  p7 <- Polygon(cbind(x=c(13, 13, 17, 17, 13), y=c(13, 17, 17, 13, 13)), hole=FALSE) # I
+  p10 <- Polygon(cbind(x=c(24, 24, 26, 26, 24), y=c(24, 26, 26, 24, 24)), hole=FALSE) # I
+  p11 <- Polygon(cbind(x=c(24.25, 24.25, 25.75, 25.75, 24.25), y=c(24.25, 25.75, 25.75, 24.25, 24.25)), hole=TRUE) # H
+  p12 <- Polygon(cbind(x=c(24.5, 24.5, 25.5, 25.5, 24.5), y=c(24.5, 25.5, 25.5, 24.5, 24.5)), hole=FALSE) # I
+  p13 <- Polygon(cbind(x=c(24.75, 24.75, 25.25, 25.25, 24.75), y=c(24.75, 25.25, 25.25, 24.75, 24.75)), hole=TRUE) # H
+  lp <- list(p1, p2, p13, p7, p6, p5, p4, p3, p8, p11, p12, p9, p10)
+  spls <- SpatialPolygons(list(Polygons(lp, ID="1")))
+  expect_equal(comment(spls), "FALSE")
+  expect_true(is.null(comment(slot(spls, "polygons")[[1]])))
+  spls_sfc <- sf::st_as_sfc(spls)
+# rsbivand fork coerce_comments 2022-12-21
+  spls_rt <- as(spls_sfc, "Spatial")
+  expect_equal(comment(spls_rt), "TRUE")
+  expect_equal(comment(slot(spls_rt, "polygons")[[1]]), "0 1 1 1 0 0 6 0 8 0 10 0 12")
+})
+
 test_that("as() can convert GEOMETRY to Spatial (#131)", {
   skip_if_not_installed("sp")
   single <- list(rbind(c(0,0), c(1,0), c(1, 1), c(0,1), c(0,0))) %>% st_polygon()

--- a/tests/testthat/test_sp.R
+++ b/tests/testthat/test_sp.R
@@ -41,7 +41,9 @@ test_that("we can convert SpatialPolygons objects without SF comments to sfc and
   p11 <- Polygon(cbind(x=c(24.25, 24.25, 25.75, 25.75, 24.25), y=c(24.25, 25.75, 25.75, 24.25, 24.25)), hole=TRUE) # H
   p12 <- Polygon(cbind(x=c(24.5, 24.5, 25.5, 25.5, 24.5), y=c(24.5, 25.5, 25.5, 24.5, 24.5)), hole=FALSE) # I
   p13 <- Polygon(cbind(x=c(24.75, 24.75, 25.25, 25.25, 24.75), y=c(24.75, 25.25, 25.25, 24.75, 24.75)), hole=TRUE) # H
-  lp <- list(p1, p2, p13, p7, p6, p5, p4, p3, p8, p11, p12, p9, p10)
+  p9a <- Polygon(cbind(x=c(1, 1, 2, 2, 1), y=c(6, 7, 7, 6, 6)), hole=TRUE) # H
+  p7a <- Polygon(cbind(x=c(14, 14, 15, 15, 14), y=c(13, 14, 14, 13, 13)), hole=TRUE) # H
+  lp <- list(p1, p2, p13, p7, p7a, p6, p5, p4, p3, p8, p11, p12, p9, p9a, p10)
   spls <- SpatialPolygons(list(Polygons(lp, ID="1")))
   expect_equal(comment(spls), "FALSE")
   expect_true(is.null(comment(slot(spls, "polygons")[[1]])))


### PR DESCRIPTION
https://github.com/r-spatial/evolution/issues/9, https://github.com/rstudio/leaflet/issues/833

This is not optimized at all, but since it is unlikely to be entered unless someone has canned, stale **sp** polygon objects in their workflows, speed doesn't matter. Here the workhorse is: `st_contains_properly(raw0[!holes], raw0[holes])`, where `holes` are got from the input object. If no holes were assigned initially, the flow of control reverts effectively to the previous code. `st_contains_properly()` may fail if a quasi-hole shares a border segment with its containing exterior ring. Holes are assigned as interior rings to  exterior rings in order of exterior ring area from smallest to largest (the nested island/holes case), and assigned holes the dropped from the larger exterior rings.