### PR TITLE
add to details in st_coordinates() 

### DIFF
--- a/R/sfc.R
+++ b/R/sfc.R
@@ -472,6 +472,13 @@ typed_empty = function(cls, ncol = 2, dim = "XY") {
 #' @param x object of class sf, sfc or sfg
 #' @param ... ignored
 #' @return matrix with coordinates (X, Y, possibly Z and/or M) in rows, possibly followed by integer indicators \code{L1},...,\code{L3} that point out to which structure the coordinate belongs; for \code{POINT} this is absent (each coordinate is a feature), for \code{LINESTRING} \code{L1} refers to the feature, for \code{MULTILINESTRING} \code{L1} refers to the part and \code{L2} to the simple feature, for \code{POLYGON} \code{L1} refers to the main ring or holes and \code{L2} to the simple feature, for \code{MULTIPOLYGON} \code{L1} refers to the main ring or holes, \code{L2} to the ring id in the \code{MULTIPOLYGON}, and \code{L3} to the simple feature.
+#' 
+#' For \code{POLYGONS}, \code{L1} can be used to identify exterior rings and inner holes. 
+#' The exterior ring is when \code{L1} is equal to 1. Interior rings are identified 
+#' when \code{L1} is greater than 1. \code{L2} can be used to differentiate between the 
+#' feature. Whereas for \code{MULTIPOLYGON}, \code{L3} refers to the \code{MULTIPOLYGON}
+#' feature and \code{L2} refers to the component \code{POLYGON}.
+#' 
 #' @export
 st_coordinates = function(x, ...) UseMethod("st_coordinates")
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/r-spatial/sf/issues/1616. 

It adds a few sentences to `st_coordinates()` man page to clarify how one can identify exterior rings and interior holes. 

Note that I couldn't build the corresponding `.Rd` file because I don't have gdal configured locally 