### PR TITLE
Coerce comments

### DIFF
--- a/R/sp.R
+++ b/R/sp.R
@@ -159,7 +159,7 @@ st_as_sfc.SpatialPolygons = function(x, ..., precision = 0.0, forceMulti = FALSE
 					for (i in seq_along(wkts)) {
 						wkts[[i]] <- st_as_text(raw0[!holes][i])
 					}
-					cp0 <- st_contains_properly(raw0[!holes], raw0[holes])
+					cp0 <- st_contains(raw0[!holes], raw0[holes])
 					areas <- sapply(slot(pl, "Polygons"), slot, "area")
 					hole_assigned <- rep(FALSE, sum(holes))
 					names(cp0) <- 1:length(cp0)
@@ -181,8 +181,11 @@ st_as_sfc.SpatialPolygons = function(x, ..., precision = 0.0, forceMulti = FALSE
 					}
 					if (any(!hole_assigned))
 					  warning("orphaned hole, cannot find containing polygon")
-					raw <- st_as_sfc(wkts)
-					val <- st_union(st_make_valid(raw))
+					raw0 <- st_as_sfc(wkts)
+                                        raw1 <- st_make_valid(raw0)
+                                        if (any(st_is(raw1, "GEOMETRYCOLLECTION"))) 
+                                          raw1 <- st_collection_extract(raw1, "POLYGON")
+					val <- st_union(raw1)
 				}
 				if (inherits(val, "sfc_GEOMETRYCOLLECTION"))
 					val = st_collection_extract(val, "POLYGON")


### PR DESCRIPTION
This should work with older GEOS; not checked for `lwgeom` for #2069 . Looks like  

> CAPI: GEOSMakeValidWithParams new validity enforcement approach from https://github.com/locationtech/jts/pull/704, uses GeometryFixer (Paul Ramsey, Martin Davis)

https://github.com/libgeos/geos/blob/3.11.1/NEWS.md in 3.10.0.