### PR TITLE
Prefer .empty() method over comparing .size()

### DIFF
--- a/src/gdal.cpp
+++ b/src/gdal.cpp
@@ -590,7 +590,7 @@ Rcpp::List CPL_transform(Rcpp::List sfc, Rcpp::List crs,
 
 	// transform geometries:
 	std::vector<OGRGeometry *> g = ogr_from_sfc(sfc, NULL);
-	if (g.size() == 0)
+	if (g.empty())
 		return sfc_from_ogr(g, true); // destroys g
 
 	OGRSpatialReference *dest = NULL;


### PR DESCRIPTION
See https://releases.llvm.org/5.0.1/tools/clang/tools/extra/docs/clang-tidy/checks/readability-container-size-empty.html