### PR TITLE
Use bootstrap 5 in `pkgdown`

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,2 @@
+template:
+  bootstrap: 5


### PR DESCRIPTION
Hello, thank you for all your work on this package!

One feature that I miss in the website is the ability to search for specific terms across vignettes, functions reference, etc. 

`pkgdown` now provides a Bootstrap 5 theme that comes with a search bar. It also modifies a bit the default style, so the website would look like this:

![image](https://user-images.githubusercontent.com/52219252/229068403-f44d862c-9822-454a-8da0-db1d920a4736.png)

If you want to reproduce locally to explore a bit more (also see the [`pkgdown` vignette](https://pkgdown.r-lib.org/articles/search.html#bootstrap-5-built-in-search)):

* create `_pkgdown.yml` as in this PR
* `pkgdown::build_site()`
* `servr::httw("docs")`
