### PR TITLE
remove tic badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 <!-- badges: start -->
 [![rcmdcheck](https://github.com/r-spatial/sf/actions/workflows/rcmdcheck.yml/badge.svg?branch=main)](https://github.com/r-spatial/sf/actions/workflows/rcmdcheck.yml)
-[![tic](https://github.com/r-spatial/sf/workflows/tic/badge.svg?branch=main)](https://github.com/r-spatial/sf/actions)
 [![tic-db](https://github.com/r-spatial/sf/workflows/tic-db/badge.svg?branch=main)](https://github.com/r-spatial/sf/actions)
 [![Coverage Status](https://img.shields.io/codecov/c/github/r-spatial/sf/main.svg)](https://app.codecov.io/gh/r-spatial/sf)
 [![License](http://img.shields.io/badge/license-GPL%20%28%3E=%202%29-brightgreen.svg?style=flat)](http://www.gnu.org/licenses/gpl-2.0.html)


### PR DESCRIPTION
We don't use tic workflow anymore (but tic-db is still in use), so we can delete tic badge in README. Related to https://github.com/r-spatial/sf/pull/2135.