### PR TITLE
further clarify st_read() of .zip files

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -77,7 +77,10 @@ set_utf8 = function(x) {
 #' In case of problems reading shapefiles from USB drives on OSX, please see
 #' \url{https://github.com/r-spatial/sf/issues/252}. Reading shapefiles (or other
 #' data sources) directly from zip files can be done by prepending the path 
-#' with \code{/vsizip/}, see also \url{https://github.com/r-spatial/sf/pull/1514}
+#' with \code{/vsizip/}. This is part of the GDAL Virtual File Systems interface
+#' that also supports .gz, curl, and other operations, including chaining; see
+#' \url{https://gdal.org/user/virtual_file_systems.html} for a complete
+#' description and examples.
 #'
 #' For \code{query} with a character \code{dsn} the query text is handed to
 #' 'ExecuteSQL' on the GDAL/OGR data set and will result in the creation of a

--- a/man/st_read.Rd
+++ b/man/st_read.Rd
@@ -140,7 +140,10 @@ lead to spurious errors that accompanying \code{*.shp} are missing.
 In case of problems reading shapefiles from USB drives on OSX, please see
 \url{https://github.com/r-spatial/sf/issues/252}. Reading shapefiles (or other
 data sources) directly from zip files can be done by prepending the path 
-with \code{/vsizip/}, see also \url{https://github.com/r-spatial/sf/pull/1514}
+with \code{/vsizip/}. This is part of the GDAL Virtual File Systems interface
+that also supports .gz, curl, and other operations, including chaining; see
+\url{https://gdal.org/user/virtual_file_systems.html} for a complete
+description and examples.
 
 For \code{query} with a character \code{dsn} the query text is handed to
 'ExecuteSQL' on the GDAL/OGR data set and will result in the creation of a


### PR DESCRIPTION
Follow-up to 3362108a005ab77ba83953430dbaa6edf4b26075 for #2179

I think this more completely fills out the documentation. It makes sense to mostly punt upstream to GDAL here, so sf doesn't need to keep updating this man page as the VSI interface evolves. zip/gz/curl pieces should be pretty stable, so safe to mention here.