### PR TITLE
Use stored value of missing(nbreaks)

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -126,7 +126,7 @@ plot.sf <- function(x, y, ..., main, pal = NULL, nbreaks = 10, breaks = "pretty"
 				nbreaks = length(breaks) - 1
 			}
 		}
-		if (missing(nbreaks) && is.numeric(breaks))
+		if (nbreaks.missing && is.numeric(breaks))
 			nbreaks = length(breaks) - 1
 
 		# loop over each map to plot:


### PR DESCRIPTION
`lintr::object_usage_linter()` points out that `nbreaks.missing` is unused; my guess it was intended to be used as here:

https://github.com/r-spatial/sf/blob/3362108a005ab77ba83953430dbaa6edf4b26075/R/plot.R#L80