### PR TITLE
Use fixed=TRUE for fixed strings

### DIFF
--- a/R/break_antimeridian.R
+++ b/R/break_antimeridian.R
@@ -43,7 +43,7 @@ st_break_antimeridian = function(x, lon_0=0, tol=0.0001, ...) {
 st_break_antimeridian.sf = function(x, lon_0=0, tol=0.0001, ...) {
 	type = st_geometry_type(x)
         if (all(grepl("CURVE", grep("LINESTRING|POLYGON", type, value=TRUE),
-            fixed=TRUE, invert=TRUE))) stop("'st_break_antimeridian' requires linestring or polygon objects", call. = FALSE)
+            fixed=TRUE))) stop("'st_break_antimeridian' requires linestring or polygon objects", call. = FALSE)
 	bb0 = st_bbox(x)
         low = bb0[1] < -(180+tol)
 	high = bb0[3] > (180+tol)

--- a/R/break_antimeridian.R
+++ b/R/break_antimeridian.R
@@ -42,8 +42,8 @@ st_break_antimeridian = function(x, lon_0=0, tol=0.0001, ...) {
 #' @name st_break_antimeridian
 st_break_antimeridian.sf = function(x, lon_0=0, tol=0.0001, ...) {
 	type = st_geometry_type(x)
-        if (length(grep("CURVE", type[grep("LINESTRING|POLYGON", type)],
-            invert=TRUE)) == 0L) stop("'st_break_antimeridian' requires linestring or polygon objects", call. = FALSE)
+        if (all(grepl("CURVE", grep("LINESTRING|POLYGON", type, value=TRUE),
+            fixed=TRUE, invert=TRUE))) stop("'st_break_antimeridian' requires linestring or polygon objects", call. = FALSE)
 	bb0 = st_bbox(x)
         low = bb0[1] < -(180+tol)
 	high = bb0[3] > (180+tol)

--- a/R/read.R
+++ b/R/read.R
@@ -304,8 +304,8 @@ abbreviate_shapefile_names = function(x) {
 			fld_names <- abbreviate(fld_names, minlength = 5) # nocov
 	}
 # fix for dots in DBF field names 121124
-	if (length(wh. <- grep("\\.", fld_names) > 0))
-		fld_names[wh.] <- gsub("\\.", "_", fld_names[wh.])
+	if (any(wh. <- grepl(".", fld_names, fixed = TRUE)))
+		fld_names[wh.] <- gsub(".", "_", fld_names[wh.], fixed = TRUE)
 
 	if (length(fld_names) != length(unique(fld_names)))
 		stop("Non-unique field names") # nocov

--- a/R/sp.R
+++ b/R/sp.R
@@ -172,7 +172,7 @@ st_as_sfc.SpatialPolygons = function(x, ..., precision = 0.0, forceMulti = FALSE
 					  tgt <- as.integer(names(cp1[i]))
                                           if (length(cp1i) > 0L) {
                                             for (j in cp1i) {
-					      wkts[[tgt]] <- paste(sub("))", "),", wkts[[tgt]]), sub("POLYGON \\(", "", st_as_text(raw0[holes][j])))
+					      wkts[[tgt]] <- paste(sub("))", "),", wkts[[tgt]], fixed = TRUE), sub("POLYGON (", "", st_as_text(raw0[holes][j]), fixed = TRUE))
 					      hole_assigned[j] <- TRUE
 					    }
                                           }


### PR DESCRIPTION
Uncovered by `lintr::fixed_regex_linter()`. Actually there were many more hits uncovered, but I balanced in favor of a smaller PR by focusing on call sites that look likelier to have larger inputs (and hence a more meaningful impact).

Here's the full list of hits in case we'd rather use `fixed=TRUE` universally:

```
filename               line     line
R/break_antimeridian.R   45         if (length(grep("CURVE", type[grep("LINESTRING|POLYGON", type)],       
R/crs.R                 192 			x = strsplit(x, " ")[[1]]                                                
R/crs.R                 422 			p4s = strsplit(p$proj4string, " ")[[1]]                                  
R/crs.R                 423 			p4s2 = strsplit(p4s, "=")                                                
R/db.R                  384                 if(grepl("permission denied", err)) {  # nocov start           
R/geom-transformers.R  1087 	lst = strsplit(msg, " at ")[[1]]                                             
R/init.R                 50 	m = paste0("Linking to GEOS ", strsplit(CPL_geos_version(TRUE), "-")[[1]][1],
R/maps.R                 69 			vapply(strsplit(x$names, ":"), function(y) y[1], "")                     
R/plot.R                801 		kl = as.numeric(gsub(" cm", "", key.length))                               
R/plot.R                873 	ksz = as.numeric(gsub(" cm", "", key.width)) * 2                             
R/plot.R                876 		kl = as.numeric(gsub(" cm", "", key.length))                               
R/proj.R                 35 		res$description <- sapply(strsplit(as.character(res$description), "\n"),  
R/proj.R                155 				sapply(strsplit(ret$definition, " "),                                  
R/read.R                307 	if (length(wh. <- grep("\\.", fld_names) > 0))                             
R/read.R                308 		fld_names[wh.] <- gsub("\\.", "_", fld_names[wh.])                       
R/read.R                458 	if (length(dsn) == 1 && length(grep("~", dsn)) == 1) # resolve ~             
R/read.R                635 		drv = prefix_map[tolower(strsplit(dsn, ":")[[1]][1])]                      
R/read.R                647 	any(grep(":", gsub(":[/\\]", "/", dsn)))                                   
R/tidyverse-vctrs.R      80 	st_cast(x, gsub("sfc_", "", class(to)[1])) # nocov
```