### PR TITLE
Avoid && in stopifnot() conditions

### DIFF
--- a/R/bbox.R
+++ b/R/bbox.R
@@ -5,7 +5,7 @@
 is.na.bbox = function(x) identical(x, NA_bbox_)
 
 bb_wrap = function(bb) {
-	stopifnot(is.numeric(bb) && length(bb) == 4)
+	stopifnot(is.numeric(bb), length(bb) == 4)
 	structure(as.double(bb), names = c("xmin", "ymin", "xmax", "ymax"), class = "bbox")
 }
 

--- a/R/geom-predicates.R
+++ b/R/geom-predicates.R
@@ -101,7 +101,7 @@ st_geos_binop = function(op, x, y, par = 0.0, pattern = NA_character_,
 #' st_queen <- function(a, b = a) st_relate(a, b, pattern = "F***T****")
 st_relate	= function(x, y, pattern = NA_character_, sparse = !is.na(pattern)) {
 	if (!is.na(pattern)) {
-		stopifnot(is.character(pattern) && length(pattern) == 1 && nchar(pattern) == 9)
+		stopifnot(is.character(pattern), length(pattern) == 1, nchar(pattern) == 9)
 		st_geos_binop("relate_pattern", x, y, pattern = pattern, sparse = sparse)
 	} else
 		st_geos_binop("relate", x, y, sparse = FALSE)

--- a/R/graticule.R
+++ b/R/graticule.R
@@ -90,7 +90,7 @@ st_graticule = function(x = c(-180,-90,180,90), crs = st_crs(x),
 		st_bbox(x)
 	else
 		x
-	stopifnot(is.numeric(bb) && length(bb) == 4)
+	stopifnot(is.numeric(bb), length(bb) == 4)
 
 	if (isTRUE(st_is_longlat(crs)))
 		bb = trim_bb(bb, margin)
@@ -206,7 +206,7 @@ graticule_attributes = function(df) {
 }
 
 trim_bb = function(bb = c(-180, -90, 180, 90), margin, wrap=c(-180,180)) {
-	stopifnot(margin > 0 && margin <= 1.0)
+	stopifnot(margin > 0, margin <= 1.0)
 	fr = 1.0 - margin
 	if (min(bb[c(1,3)]) >= -15. && max(bb[c(1,3)]) > 195.) { # 0-360 span:
 		wrap=c(0., 360.)

--- a/R/m_range.R
+++ b/R/m_range.R
@@ -5,7 +5,7 @@
 is.na.m_range = function(x) identical(x, NA_m_range_)
 
 mb_wrap = function(mb) {
-	stopifnot(is.numeric(mb) && length(mb) == 2)
+	stopifnot(is.numeric(mb), length(mb) == 2)
 	structure(mb, names = c("mmin", "mmax"), class = "m_range")
 }
 

--- a/R/sfg.R
+++ b/R/sfg.R
@@ -38,7 +38,7 @@ MtrxSet = function(x, dim = "XYZ", type, needClosed = FALSE) {
 
 # creates object of class c(dim, type, "sfg") from list x, d, possibly checking rings are closed
 MtrxSetSet = function(x, dim = "XYZ", type, needClosed = FALSE) {
-	stopifnot(is.list(x) && all(vapply(x, is.list, TRUE)))
+	stopifnot(is.list(x), vapply(x, is.list, TRUE))
 	if (length(x)) {
 		nc = unique(unlist(lapply(x, function(y) vapply(y, ncol, 0L))))
 		if (length(nc) != 1)

--- a/R/transform.R
+++ b/R/transform.R
@@ -183,7 +183,7 @@ st_wrap_dateline.sfc = function(x, options = "WRAPDATELINE=YES", quiet = TRUE) {
 	else
 		stopifnot(st_is_longlat(x))
 	stopifnot(is.character(options))
-	stopifnot(is.logical(quiet) && length(quiet) == 1)
+	stopifnot(is.logical(quiet), length(quiet) == 1)
 	st_sfc(CPL_wrap_dateline(x, options, quiet), crs = st_crs(x))
 }
 

--- a/R/wkb.R
+++ b/R/wkb.R
@@ -43,7 +43,7 @@ st_as_sfc.WKB = function(x, ..., EWKB = FALSE, spatialite = FALSE, pureR = FALSE
 			else
 				structure(CPL_hex_to_raw(vapply(x, skip0x, USE.NAMES = FALSE, "")), class = "WKB")
 	} else # direct call with raw:
-		stopifnot(inherits(x, "WKB") && all(vapply(x, is.raw, TRUE))) # WKB as raw
+		stopifnot(inherits(x, "WKB"), vapply(x, is.raw, TRUE)) # WKB as raw
 	if (any(lengths(x) == 0))
 		stop("cannot read WKB object from zero-length raw vector")
 	ret = if (pureR)

--- a/R/z_range.R
+++ b/R/z_range.R
@@ -5,7 +5,7 @@
 is.na.z_range = function(x) identical(x, NA_z_range_)
 
 zb_wrap = function(zb) {
-	stopifnot(is.numeric(zb) && length(zb) == 2)
+	stopifnot(is.numeric(zb), length(zb) == 2)
 	structure(zb, names = c("zmin", "zmax"), class = "z_range")
 }
 

--- a/demo/bm_wkb.R
+++ b/demo/bm_wkb.R
@@ -1,6 +1,6 @@
 # benchmark, comparing reading of largish simple feature objects from WKB
 WKB_LINESTRING = function(m = 1, n) {
-	stopifnot(m > 0 && n > 1)
+	stopifnot(m > 0, n > 1)
 	l = lapply(seq_len(m), function(x) {
 		con = rawConnection(raw(0), "w")
 		writeBin(as.raw(1), con) # "little"


### PR DESCRIPTION
Identified by `lintr::conjunct_test_linter()`.

Compare:

```r
x = TRUE
y = FALSE
# Error: x && y is not TRUE
stopifnot(x, y)
# Error: y is not TRUE
```

The latter gives a much friendlier failure message.

Alternatively, we could use the R>=4 feature (happy to make the change):

```r
stopifnot("Both x and y must be TRUE" = x && y)
# Error: Both x and y must be TRUE
```

Note that the code works on R<4, just that it gives the earlier, less-friendly failure message.