### PR TITLE
Use anyNA() where possible

### DIFF
--- a/R/agr.R
+++ b/R/agr.R
@@ -92,5 +92,5 @@ summarize_agr = function(x) {
 
 all_constant = function(x) {
 	x = attr(x, "agr")
-	!(any(is.na(x)) || any(!(x %in% c("identity", "constant"))))
+	!anyNA(x) && all(x %in% c("identity", "constant"))
 }

--- a/R/db.R
+++ b/R/db.R
@@ -192,7 +192,7 @@ schema_table <- function(conn, table, public = "public") {
 	else if (length(table) > 2)
 		stop("table cannot be longer than 2 (schema, table)", call. = FALSE)
 
-	if (any(is.na(table)))
+	if (anyNA(table))
 		stop("table and schema cannot be NA", call. = FALSE)
 
 	return(table)

--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -85,7 +85,7 @@ st_buffer.sfg = function(x, dist, nQuadSegs = 30,
 	if (is.na(mitreLimit) || !mitreLimit > 0) stop("mitreLimit must be > 0")
 	if (is.na(ecs)) stop("endCapStyle must be 'ROUND', 'FLAT', or 'SQUARE'")
 	if (is.na(js))  stop("joinStyle must be 'ROUND', 'MITRE', or 'BEVEL'")
-	if (any(is.na(singleSide))) stop("singleSide should be TRUE or FALSE")
+	if (anyNA(singleSide)) stop("singleSide should be TRUE or FALSE")
 	styls$with_styles = TRUE
 	styls$endCapStyle = ecs
 	styls$joinStyle = js

--- a/R/grid.R
+++ b/R/grid.R
@@ -8,7 +8,7 @@ st_as_grob = function(x, ...) UseMethod("st_as_grob")
 
 #' @export
 st_as_grob.POINT = function(x, pch = 1, size = unit(1, "char"), default.units = "native", name = NULL, gp = gpar(), vp = NULL, ...) {
-	if (any(is.na(x)))
+	if (anyNA(x))
 		nullGrob()
 	else
 		pointsGrob(x[1], x[2], pch = pch, size = size, default.units = default.units, name = name, gp = gp, vp = vp)

--- a/R/plot.R
+++ b/R/plot.R
@@ -290,7 +290,7 @@ swap_axes_if_needed = function(x) {
 #' @export
 get_key_pos = function(x, ...) {
 	bb = st_bbox(x)
-	if (any(is.na(bb)) || (inherits(x, "sf") && ncol(x) > 2))
+	if (anyNA(bb) || (inherits(x, "sf") && ncol(x) > 2))
 		NULL
 	else {
 		pin = par("pin") # (width, height)
@@ -580,7 +580,7 @@ plot_sf = function(x, xlim = NULL, ylim = NULL, asp = NA, axes = FALSE, bgc = pa
 	if (is.na(asp))
 		asp <- ifelse(isTRUE(st_is_longlat(x)), 1/cos((mean(ylim) * pi)/180), 1.0)
 
-	if (any(is.na(bbox)))
+	if (anyNA(bbox))
 		stop("NA value(s) in bounding box. Trying to plot empty geometries?")
 
 	plot.new()

--- a/R/sf.R
+++ b/R/sf.R
@@ -45,7 +45,7 @@ st_as_sf.data.frame = function(x, ..., agr = NA_agr_, coords, wkt,
 			x$geometry = st_as_sfc(as.character(x[[wkt]]))
 	} else if (! missing(coords)) {
 		cc = as.data.frame(lapply(x[coords], as.numeric))
-		if (na.fail && any(is.na(cc)))
+		if (na.fail && anyNA(cc))
 			stop("missing values in coordinates not allowed")
 		# classdim = getClassDim(rep(0, length(coords)), length(coords), dim, "POINT")
 		x$geometry = structure( points_rcpp(as.matrix(cc), dim),

--- a/R/sfc.R
+++ b/R/sfc.R
@@ -98,12 +98,12 @@ st_sfc = function(..., crs = NA_crs_, precision = 0.0, check_ring_dir = FALSE, d
 
 	# compute bbox, if not set:
 	bb = attr(lst, "bbox")
-	if (is.null(bb) || any(is.na(bb)) || recompute_bbox)
+	if (is.null(bb) || anyNA(bb) || recompute_bbox)
 		attr(lst, "bbox") = compute_bbox(lst)
 
 	# compute z_range, if dims permit and not set
 	zr = attr(lst, "z_range")
-	if (is.null(zr) || any(is.na(zr))) {
+	if (is.null(zr) || anyNA(zr)) {
 		u <- dims_and_types[[1]]
 		if( "XYZM" %in% u ) {
 			attr(lst, "z_range") = compute_z_range(lst)

--- a/R/stars.R
+++ b/R/stars.R
@@ -110,7 +110,7 @@ xy_from_colrow = function(x, geotransform, inverse = FALSE) {
 # Yp = geotransform[3] + P*geotransform[4] + L*geotransform[5];
 	if (inverse) {
 		geotransform = gdal_inv_geotransform(geotransform) # nocov start
-		if (any(is.na(geotransform)))
+		if (anyNA(geotransform))
 			stop("geotransform not invertible") # nocov end
 	}
 	stopifnot(ncol(x) == 2)


### PR DESCRIPTION
Identified by `lintr::any_is_na_linter()`.

`any(is.na(x))` is equivalent to `anyNA()` in all but the most contrived examples, except that it runs faster and is usually easier to read.