### PR TITLE
Use scalar logical operators where appropriate

### DIFF
--- a/R/break_antimeridian.R
+++ b/R/break_antimeridian.R
@@ -31,7 +31,7 @@
 #' }
 st_break_antimeridian = function(x, lon_0=0, tol=0.0001, ...) {
 	ll = st_is_longlat(x)
-	if (!ll | is.na(ll))
+	if (!isTRUE(ll))
 		stop("'st_break_antimeridian' requires non-projected geographic coordinates",
 			 call. = FALSE)
 

--- a/R/db.R
+++ b/R/db.R
@@ -242,7 +242,7 @@ db_find_srid = function(conn, crs_local = st_crs(srid), srid = epsg(crs_local), 
     }
     crs_found <- st_crs(db_crs[["srtext"]])
     crs_found[["input"]] <- build_epsg(srid)
-    if(validate && crs_found != crs_local & !is.na(crs_local)) {
+    if(validate && crs_found != crs_local && !is.na(crs_local)) {
     	# TODO: pretty print db_spatial_ref
         warning("Local crs different from database crs. You can inspect the ",
                 "database crs using `dbReadtable(conn, \"spatial_ref_sys\")` ",

--- a/R/sample.R
+++ b/R/sample.R
@@ -119,7 +119,7 @@ st_sample.sfc = function(x, size, ..., type = "random", exact = TRUE, warn_if_no
 					 st_multipoints_sample(do.call(c, x), size = size, ..., type = type),
 					 st_ll_sample(st_cast(x, "LINESTRING"), size = size, ..., type = type),
 					 st_poly_sample(x, size = size, ..., type = type, by_polygon = by_polygon))
-		if (exact & type == "random" & all(st_geometry_type(res) == "POINT")) {
+		if (exact && type == "random" && all(st_geometry_type(res) == "POINT")) {
 			diff = size - length(res)
 			if (diff > 0) { # too few points
 				res_additional = st_sample_exact(x = x, size = diff, ..., 

--- a/R/sf.R
+++ b/R/sf.R
@@ -265,7 +265,7 @@ st_sf = function(..., agr = NA_agr_, row.names,
 			x
 		else if (length(x) == 1) # ONLY one sfc
 			data.frame(row.names = row.names)
-		else if (!sfc_last & inherits(x, "data.frame"))
+		else if (!sfc_last && inherits(x, "data.frame"))
 			x
 		else if (sfc_last && inherits(x, "data.frame"))
 			x[-all_sfc_columns]

--- a/R/shift_longitude.R
+++ b/R/shift_longitude.R
@@ -15,7 +15,7 @@
 #' @export
 st_shift_longitude = function(x) {
 	ll = st_is_longlat(x)
-	if (!ll | is.na(ll))
+	if (!isTRUE(ll))
 		stop("'st_shift_longitude' requires non-projected geographic coordinates",
 			 call. = FALSE)
 


### PR DESCRIPTION
As identified by `lintr::vector_logic_linter()`.

`&&` and `||` are appropriate inside `if()` / `while()` conditions, where passing a vector is incorrect (maybe an error, depending on the R version, and if not, has possibly misleading behavior).

`&&`/`||` also have early exit where `&`/`|` do not, c.f. `TRUE || stop('hi')` vs. `TRUE | stop('hi')`.