### PR TITLE
Avoid 1: for possibly-empty input

### DIFF
--- a/R/break_antimeridian.R
+++ b/R/break_antimeridian.R
@@ -100,7 +100,7 @@ st_within_pm180 <- function(x, tol=0.0001) {
         xcrs = st_crs(x)
         xnames = names(x)
 	xnames = xnames[grep(attr(x, "sf_column"), xnames, invert=TRUE)]
-	x$st_within_pm180_ID = as.character(1:nrow(x))
+	x$st_within_pm180_ID = as.character(seq_len(nrow(x)))
         s2_status = sf_use_s2()
 	sf_use_s2(FALSE) # avoid s2 because we need a planar bounding box
 	bb0 = st_bbox(x)

--- a/R/sample.R
+++ b/R/sample.R
@@ -110,9 +110,9 @@ st_sample.sfc = function(x, size, ..., type = "random", exact = TRUE, warn_if_no
 		ret = if (progress) {
 				if (!requireNamespace("pbapply", quietly = TRUE))
 					stop("package pbapply required, please install it first")
-				pbapply::pblapply(1:length(x), function(i) st_sample(x[i], size[i], type = type, exact = exact, ...))
+				pbapply::pblapply(seq_along(x), function(i) st_sample(x[i], size[i], type = type, exact = exact, ...))
 			} else
-				lapply(1:length(x), function(i) st_sample(x[i], size[i], type = type, exact = exact, ...))
+				lapply(seq_along(x), function(i) st_sample(x[i], size[i], type = type, exact = exact, ...))
 		st_set_crs(do.call(c, ret), st_crs(x))
 	} else {
 		res = switch(max(st_dimension(x)) + 1,

--- a/R/sp.R
+++ b/R/sp.R
@@ -165,7 +165,7 @@ st_as_sfc.SpatialPolygons = function(x, ..., precision = 0.0, forceMulti = FALSE
 					cp0 <- st_contains(raw0[!holes], raw0[holes])
 					areas <- sapply(slot(pl, "Polygons"), slot, "area")
 					hole_assigned <- rep(FALSE, sum(holes))
-					names(cp0) <- 1:length(cp0)
+					names(cp0) <- seq_along(cp0)
                                         cp1 <- cp0[order(areas[!holes])]
 					for (i in seq_along(cp1)) {
                                           cp1i <- cp1[[i]]


### PR DESCRIPTION
Identified by `lintr::seq_linter()`.

I didn't see enough input validation to ensure that a length-0 input doesn't wind up running `1:0` accidentally in these cases, hence `seq_along()`/`seq_len()` should be preferred.