### PR TITLE
use anyDuplicated() over unique() equivalent

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -310,7 +310,7 @@ abbreviate_shapefile_names = function(x) {
 	if (length(wh. <- grep("\\.", fld_names) > 0))
 		fld_names[wh.] <- gsub("\\.", "_", fld_names[wh.])
 
-	if (length(fld_names) != length(unique(fld_names)))
+	if (anyDuplicated(fld_names))
 		stop("Non-unique field names") # nocov
 
 	names(x) = fld_names


### PR DESCRIPTION
Identified by `lintr::any_duplicated_linter()`.

Technically the output of `anyDuplicated()` is an integer, not logical, so some authors might prefer `anyDuplicated(fld_names) > 0L` (as e.g. suggested by the tidyverse style guide: https://style.tidyverse.org/syntax.html#implicit-type-coercion). Let me know & I can update.