### PR TITLE
Use startsWith() over substr()

### DIFF
--- a/R/proj.R
+++ b/R/proj.R
@@ -150,7 +150,7 @@ sf_proj_pipelines = function(source_crs, target_crs, authority = character(0), A
 		as.numeric(desired_accuracy), as.logical(strict_containment), 
 		as.logical(axis_order_authority_compliant))
 	if (nrow(ret)) {
-		if (substr(ret$definition[1], 1, 1) != "+") # paste + to every word
+		if (!startsWith(ret$definition[1], "+")) # paste + to every word
 			ret$definition = 
 				sapply(strsplit(ret$definition, " "), 
 					function(x) paste0(paste0("+", x), collapse=" "))

--- a/R/wkb.R
+++ b/R/wkb.R
@@ -6,7 +6,7 @@
 #
 hex_to_raw = function(y) {
 	stopifnot((nchar(y) %% 2) == 0)
-	if (substr(y, 1, 2) == "0x")
+	if (startsWith(y, "0x"))
 		y = substr(y, 3, nchar(y))
 	as.raw(as.numeric(paste0("0x", vapply(seq_len(nchar(y)/2),
 		function(x) substr(y, (x-1)*2+1, x*2), "")))) # SLOW, hence the Rcpp implementation
@@ -15,7 +15,7 @@ hex_to_raw = function(y) {
 skip0x = function(x) {
 	if (is.na(x))
 		"010700000000000000" # empty GeometryCollection, st_as_binary(st_geometrycollection())
-	else if (substr(x, 1, 2) == "0x")
+	else if (startsWith(x, "0x"))
 		substr(x, 3, nchar(x))
 	else
 		x


### PR DESCRIPTION
This should be faster and more readable.

There is one more usage:

https://github.com/r-spatial/sf/blob/ff5104869a78d15efa41acbb073ae2bcdd6135d6/R/crs.R#L338

But `grepl()` has some difference with respect to `NA_character_` input, so the technical equivalent would be `!is.na(x[["input"]]) && startsWith(x[["input"]], "EPSG:")`, not quite as clean (though it may be preferable to expose the NA checking explicitly.