### PR TITLE
Fix issue with key in plot.R

### DIFF
--- a/R/plot.R
+++ b/R/plot.R
@@ -117,7 +117,7 @@ plot.sf <- function(x, y, ..., main, pal = NULL, nbreaks = 10, breaks = "pretty"
 				values = as.factor(values)
 			if (logz)
 				values = log10(values)
-			if (is.character(breaks) && is.numeric(values))) { # compute breaks from values:
+			if (is.character(breaks) && is.numeric(values)) { # compute breaks from values:
 				v0 = values[!is.na(values)]
 				n.unq = length(unique(v0))
 				breaks = if (! all(is.na(values)) && n.unq > 1)

--- a/R/plot.R
+++ b/R/plot.R
@@ -113,9 +113,11 @@ plot.sf <- function(x, y, ..., main, pal = NULL, nbreaks = 10, breaks = "pretty"
 
 		if (!is.null(key.pos)) {
 			values = do.call(c, as.data.frame(x)[cols])
+			if (is.character(values))
+				values = as.factor(values)
 			if (logz)
 				values = log10(values)
-			if (is.character(breaks)) { # compute breaks from values:
+			if (is.character(breaks) && is.numeric(values))) { # compute breaks from values:
 				v0 = values[!is.na(values)]
 				n.unq = length(unique(v0))
 				breaks = if (! all(is.na(values)) && n.unq > 1)


### PR DESCRIPTION
When plotting multiple character/factor-valued columns of an `sf` object, an error occurs when requesting a key because a portion of the code intended for numeric `values` gets executed (`classInt::classIntervals()`). I added lines to convert character `values` to a factor, and to check for numeric `values` before using `classIntervals()`. The changes solve the issue for me.