### PR TITLE
Clarify documentation #2199

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -298,7 +298,7 @@ st_sf = function(..., agr = NA_agr_, row.names,
 
 #' @name sf
 #' @param x object of class \code{sf}
-#' @param i record selection, see \link{[.data.frame}
+#' @param i record selection, see \link{[.data.frame}, or a \code{sf} object to work with the \code{op} argument
 #' @param j variable selection, see \link{[.data.frame}
 #' @param drop logical, default \code{FALSE}; if \code{TRUE} drop the geometry column and return a \code{data.frame}, else make the geometry sticky and return a \code{sf} object.
 #' @param op function; geometrical binary predicate function to apply when \code{i} is a simple feature object

--- a/man/sf.Rd
+++ b/man/sf.Rd
@@ -45,7 +45,7 @@ there is more than one and \code{sf_column_name} is \code{NULL}, the first one i
 
 \item{x}{object of class \code{sf}}
 
-\item{i}{record selection, see \link{[.data.frame}}
+\item{i}{record selection, see \link{[.data.frame}, or a \code{sf} object to work with the \code{op} argument}
 
 \item{j}{variable selection, see \link{[.data.frame}}
 


### PR DESCRIPTION
As I looked at the documentation but overlooked this option for `i` I thought it might be useful to improve the documentation
