### PR TITLE
Improve reading with `use_stream = TRUE`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -107,7 +107,7 @@ Suggests:
     tidyselect (>= 1.0.0),
     tmap (>= 2.0),
     vctrs,
-    wk
+    wk (>= 0.9.0)
 LinkingTo: 
     Rcpp
 VignetteBuilder: 

--- a/R/read.R
+++ b/R/read.R
@@ -239,7 +239,8 @@ process_cpl_read_ogr_stream = function(x, default_crs, num_features, fid_column_
 		st_set_crs(x, crs)	
 	})
 
-	# Prefer "geometry" as the geometry column name instead of "wkb_geometry"
+	# Prefer "geometry" as the geometry column name instead of "wkb_geometry",
+	# which is what happens when the geometry column doesn't have a name
 	if (any(is_geometry_column) && !("geometry" %in% names(df))) {
 		geometry_column_name <- names(df)[which(is_geometry_column)[1]]
 		if (identical(geometry_column_name, "wkb_geometry")) {

--- a/R/read.R
+++ b/R/read.R
@@ -258,9 +258,9 @@ process_cpl_read_ogr_stream = function(x, geom_column_info, num_features, fid_co
 		names(df)[names(df) == "OGC_FID"] = fid_column_name
 	}
 	
-	gc1 = which(is_geometry_column)[1]
-	df = df[c(setdiff(seq_along(df), gc1), gc1)]
-
+	# All geometry columns to the end
+	df = df[c(setdiff(seq_along(df), geom_column_info$index), geom_column_info$index)]
+	
 	process_cpl_read_ogr(df, ...)
 }
 

--- a/R/read.R
+++ b/R/read.R
@@ -218,46 +218,46 @@ default_st_read_use_stream = function() {
 	)
 }
 
-process_cpl_read_ogr_stream = function(x, default_crs, num_features, fid_column_name,
+process_cpl_read_ogr_stream = function(x, geom_column_info, num_features, fid_column_name,
                                        crs = NULL, promote_to_multi = TRUE, ...) {
-    is_geometry_column = vapply(
+	is_geometry_column = vapply(
 		x$get_schema()$children,
 		function(s) identical(s$metadata[["ARROW:extension:name"]], "ogc.wkb"),
 		logical(1)
 	)
-
-    crs = if (is.null(crs)) st_crs(default_crs) else st_crs(crs)
-	if (num_features == -1) {
+    
+    geom_column_info$index = which(is_geometry_column)
+    
+    if (num_features == -1) {
 		num_features = NULL
 	}
+    
+    # Suppress warnings about extension type conversion (since we want the
+    # default behaviour of converting the storage type)
 	df = suppressWarnings(nanoarrow::convert_array_stream(x, size = num_features))
-
-	df[is_geometry_column] = lapply(df[is_geometry_column], function(x) {
-		attributes(x) <- NULL
+	
+	for (i in seq_len(nrow(geom_column_info))) {
+		crs = if (is.null(crs)) st_crs(geom_column_info$crs[[i]]) else st_crs(crs)
+		name = geom_column_info$name[[i]]
+		index = geom_column_info$index[[i]]
 		
-		x <- wk::wk_handle(wk::new_wk_wkb(x), wk::sfc_writer(promote_multi = promote_to_multi))
-		st_set_crs(x, crs)	
-	})
-
-	# Prefer "geometry" as the geometry column name instead of "wkb_geometry",
-	# which is what happens when the geometry column doesn't have a name
-	if (any(is_geometry_column) && !("geometry" %in% names(df))) {
-		geometry_column_name <- names(df)[which(is_geometry_column)[1]]
-		if (identical(geometry_column_name, "wkb_geometry")) {
-			names(df)[which(is_geometry_column)[1]] = "geometry"
-		}
+		column_wkb = df[[index]]
+		attributes(column_wkb) = NULL
+		column_sfc = wk::wk_handle(
+			wk::new_wk_wkb(column_wkb),
+			wk::sfc_writer(promote_multi = promote_to_multi)
+		)
+		
+		df[[index]] = st_set_crs(column_sfc, crs)
+		names(df)[index] = name
 	}
 	
 	# Rename OGC_FID to fid_column_name and move to end
 	if (length(fid_column_name) == 1 && "OGC_FID" %in% names(df)) {
-		df <- df[c(setdiff(names(df), "OGC_FID"), "OGC_FID")]
+		df = df[c(setdiff(names(df), "OGC_FID"), "OGC_FID")]
 		names(df)[names(df) == "OGC_FID"] = fid_column_name
 	}
 	
-	# Move geometry to the end
-#	if ("geometry" %in% names(df)) {
-#		df <- df[c(setdiff(names(df), "geometry"), "geometry")]
-#	}
 	gc1 = which(is_geometry_column)[1]
 	df = df[c(setdiff(seq_along(df), gc1), gc1)]
 
@@ -301,7 +301,8 @@ st_read.character = function(dsn, layer, ..., query = NA, options = NULL, quiet 
 		stream = nanoarrow::nanoarrow_allocate_array_stream()
 		info = CPL_read_gdal_stream(stream, dsn, layer, query, as.character(options), quiet,
 		    drivers, wkt_filter, dsn_exists, dsn_isdb, fid_column_name, getOption("width"))
-		process_cpl_read_ogr_stream(stream, default_crs = info[[1]], num_features = info[[2]],
+		geom_column_info = data.frame(name = info[[1]], crs = info[[2]], stringsAsFactors = FALSE)
+		process_cpl_read_ogr_stream(stream, geom_column_info, num_features = info[[3]],
 			fid_column_name = fid_column_name, stringsAsFactors = stringsAsFactors, quiet = quiet,
 			promote_to_multi = promote_to_multi, ...)
 	} else {

--- a/R/read.R
+++ b/R/read.R
@@ -239,9 +239,12 @@ process_cpl_read_ogr_stream = function(x, default_crs, num_features, fid_column_
 		st_set_crs(x, crs)	
 	})
 
-	# Prefer "geometry" as the geometry column name
+	# Prefer "geometry" as the geometry column name instead of "wkb_geometry"
 	if (any(is_geometry_column) && !("geometry" %in% names(df))) {
-		names(df)[which(is_geometry_column)[1]] = "geometry"
+		geometry_column_name <- names(df)[which(is_geometry_column)[1]]
+		if (identical(geometry_column_name, "wkb_geometry")) {
+			names(df)[which(is_geometry_column)[1]] = "geometry"
+		}
 	}
 	
 	# Rename OGC_FID to fid_column_name and move to end

--- a/R/read.R
+++ b/R/read.R
@@ -239,10 +239,10 @@ process_cpl_read_ogr_stream = function(x, default_crs, num_features, fid_column_
 		st_set_crs(x, crs)	
 	})
 
-#	# Prefer "geometry" as the geometry column name
-#	if (any(is_geometry_column) && !("geometry" %in% names(df))) {
-#		names(df)[which(is_geometry_column)[1]] = "geometry"
-#	}
+	# Prefer "geometry" as the geometry column name
+	if (any(is_geometry_column) && !("geometry" %in% names(df))) {
+		names(df)[which(is_geometry_column)[1]] = "geometry"
+	}
 	
 	# Rename OGC_FID to fid_column_name and move to end
 	if (length(fid_column_name) == 1 && "OGC_FID" %in% names(df)) {


### PR DESCRIPTION
This PR seeks to eliminate differences between `use_stream = TRUE` and `use_stream = FALSE`. It (1) uses wk's WKB -> sfc conversion when using `use_stream = TRUE` because it (now) supports `promote_multi = TRUE`, and (2) prefers "geometry" as the geometry column name.

@edzer I know you commented this out on the last PR, but it seems that when using the usual `read_sf()` we always get "geometry" as the geometry column name for shapefiles and flatgeobuf (but not for gpkg?). I think I am just missing where exactly this value gets set, but the hack I have here just converts "wkb_geometry" to "geometry".

Before this PR:

``` r
library(sf)
#> Linking to GEOS 3.12.0, GDAL 3.7.2, PROJ 9.3.0; sf_use_s2() is TRUE

nc_file <- system.file("shape/nc.shp", package = "sf")
waldo::compare(
    read_sf(nc_file, use_stream = TRUE),
    read_sf(nc_file, use_stream = FALSE),
    ignore_attr = "crs"
)
#> `names(old)[12:15]`: "BIR79" "SID79" "NWBIR79" "wkb_geometry"
#> `names(new)[12:15]`: "BIR79" "SID79" "NWBIR79" "geometry"    
#> 
#> `attr(old, 'sf_column')`: "wkb_geometry"
#> `attr(new, 'sf_column')`: "geometry"    
#> 
#> `old$wkb_geometry` is an S3 object of class <sfc_GEOMETRY/sfc>, a list
#> `new$wkb_geometry` is absent
#> 
#> `old$geometry` is absent
#> `new$geometry` is an S3 object of class <sfc_MULTIPOLYGON/sfc>, a list
```

After this PR:

``` r
library(sf)
#> Linking to GEOS 3.12.0, GDAL 3.7.2, PROJ 9.3.0; sf_use_s2() is TRUE

nc_file <- system.file("shape/nc.shp", package = "sf")
waldo::compare(
    read_sf(nc_file, use_stream = TRUE),
    read_sf(nc_file, use_stream = FALSE),
    ignore_attr = "crs"
)
#> ✔ No differences

nc_file <- system.file("gpkg/nc.gpkg", package = "sf")
waldo::compare(
    read_sf(nc_file, use_stream = TRUE),
    read_sf(nc_file, use_stream = FALSE),
    ignore_attr = "crs"
)
#> ✔ No differences
```

This seems to improve performance for points, but decrease performance for polygons with many vertices. A better long-term solution would be to support `promote_multi` in sf's WKB reader, or, even better, optimize the Arrow WKB representation (basically: one big long buffer with all the wkb packed together rather than many tiny buffers all within their own raw vector) -> sfc. From the benchmark provided by @kadyb in https://github.com/r-spatial/sf/pull/2036#issuecomment-1742711406 :

``` r
library("sf")
#> Linking to GEOS 3.12.0, GDAL 3.7.2, PROJ 9.3.0; sf_use_s2() is TRUE

n = 500000
df = data.frame(x = rnorm(n), y = rnorm(n),
                col_1 = sample(c(TRUE, FALSE), n, replace = TRUE), # logical
                col_2 = sample(letters, n, replace = TRUE),        # character
                col_3 = runif(n),                                  # double
                col_4 = sample(1:100, n, replace = TRUE))          # integer

## points ##
pts = st_as_sf(df, coords = c("x", "y"), crs = "EPSG:2180")
write_sf(pts, "pts.gpkg")

bench::mark(
    check = FALSE, iterations = 10,
    stream = read_sf("pts.gpkg", use_stream = TRUE),
    non_stream = read_sf("pts.gpkg", use_stream = FALSE)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 stream     743.26ms    1.13s     0.947    53.2MB     2.75
#> 2 non_stream    1.13s    1.36s     0.751    75.9MB     4.58

## buffers ##
buff = st_buffer(pts, dist = 1000)
write_sf(buff, "buffers.gpkg")

bench::mark(
    check = FALSE, iterations = 5,
    stream = read_sf("buffers.gpkg", use_stream = TRUE),
    non_stream = read_sf("buffers.gpkg", use_stream = FALSE)
)
#> Warning: Some expressions had a GC in every iteration; so filtering is
#> disabled.
#> # A tibble: 2 × 6
#>   expression      min   median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <bch:tm> <bch:tm>     <dbl> <bch:byt>    <dbl>
#> 1 stream         4.5s    6.31s     0.127     1.9GB    0.152
#> 2 non_stream    3.91s    4.52s     0.112    1.91GB    0.269
```

As a side note, I find these benchmark numbers to be rather variable, perhaps due to the garbage collection of tens of thousands of geometries, or perhaps due to my computer running on battery.


