### PR TITLE
st_is_valid(), st_make_valid(): fix docs of x argument

### DIFF
--- a/R/valid.R
+++ b/R/valid.R
@@ -47,7 +47,7 @@ st_is_valid.sfg = function(x, ...) {
 #'
 #' Checks whether a geometry is valid, or makes an invalid geometry valid
 #' @name valid
-#' @param x object of class \code{sfg}, \code{sfg} or \code{sf}
+#' @param x object of class \code{sfg}, \code{sfc} or \code{sf}
 #' @return Object of the same class as \code{x}
 #' @details For projected geometries, \code{st_make_valid} uses the \code{lwgeom_makevalid} method also used by the PostGIS command \code{ST_makevalid} if the GEOS version linked to is smaller than 3.8.0, and otherwise the version shipped in GEOS; for geometries having ellipsoidal coordinates \code{s2::s2_rebuild} is being used.
 #' @examples

--- a/man/dbWriteTable.Rd
+++ b/man/dbWriteTable.Rd
@@ -32,17 +32,19 @@
 \arguments{
 \item{conn}{DBIObject}
 
-\item{name}{
-   character vector of names (table names, fields, keywords).
-}
+\item{name}{The table name, passed on to \code{\link[DBI:dbQuoteIdentifier]{dbQuoteIdentifier()}}. Options are:
+\itemize{
+\item a character string with the unquoted DBMS table name,
+e.g. \code{"table_name"},
+\item a call to \code{\link[DBI:Id]{Id()}} with components to the fully qualified table name,
+e.g. \code{Id(schema = "my_schema", table = "table_name")}
+\item a call to \code{\link[DBI:SQL]{SQL()}} with the quoted and fully qualified table name
+given verbatim, e.g. \code{SQL('"my_schema"."table_name"')}
+}}
 
-\item{value}{
-   a data.frame.
-}
+\item{value}{a \link{data.frame} (or coercible to data.frame).}
 
-\item{...}{
-   placeholder for future use.
-}
+\item{...}{Other parameters passed on to methods.}
 
 \item{row.names}{Add a \code{row.name} column, or a vector of length \code{nrow(obj)}
 containing row.names; default \code{FALSE}.}

--- a/man/valid.Rd
+++ b/man/valid.Rd
@@ -33,7 +33,7 @@ st_make_valid(x, ...)
 )
 }
 \arguments{
-\item{x}{object of class \code{sfg}, \code{sfg} or \code{sf}}
+\item{x}{object of class \code{sfg}, \code{sfc} or \code{sf}}
 
 \item{...}{passed on to \link[s2]{s2_options}}
 


### PR DESCRIPTION
The sfg class was listed twice, while sfc was not listed.

Meanwhile `dbWriteTable.Rd` has been brought in-sync.