### PR TITLE
Fix cross-compiling

### DIFF
--- a/configure
+++ b/configure
@@ -3662,6 +3662,10 @@ fi
 
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: checking GDAL: checking whether PROJ is available for running:" >&5
 printf %s "checking GDAL: checking whether PROJ is available for running:... " >&6; }
+if test "x$cross_compiling" = "xyes"; then
+{ printf "%s\n" "$as_me:${as_lineno-$LINENO}: result: cross compiling" >&5
+printf "%s\n" "cross compiling" >&6; }
+else
 ./gdal_proj
 if test `echo $?` -ne 0 ; then
 gdal_has_proj=no
@@ -3674,6 +3678,7 @@ printf "%s\n" "yes" >&6; }
 fi
 if test "${gdal_has_proj}" = no; then
    as_fn_error $? "OGRCoordinateTransformation() does not return a coord.trans: PROJ not available?" "$LINENO" 5
+fi
 fi
 rm -fr errors.txt gdal_proj.cpp gdal_proj
 { printf "%s\n" "$as_me:${as_lineno-$LINENO}: GDAL: ${GDAL_VERSION}" >&5

--- a/configure.ac
+++ b/configure.ac
@@ -289,6 +289,9 @@ if test "${gdal_has_proj}" = no; then
 fi
 
 AC_MSG_CHECKING(GDAL: checking whether PROJ is available for running:)
+if test "x$cross_compiling" = "xyes"; then
+AC_MSG_RESULT(cross compiling, assuming yes)
+else
 ./gdal_proj
 if test `echo $?` -ne 0 ; then
 gdal_has_proj=no
@@ -299,6 +302,7 @@ AC_MSG_RESULT(yes)
 fi
 if test "${gdal_has_proj}" = no; then
    AC_MSG_ERROR([OGRCoordinateTransformation() does not return a coord.trans: PROJ not available?])
+fi
 fi
 rm -fr errors.txt gdal_proj.cpp gdal_proj
 AC_MSG_NOTICE([GDAL: ${GDAL_VERSION}])


### PR DESCRIPTION
Small fix for when we are cross compiling, for example linux to macos or linux to webassembly.
In those cases we can't run test programs (because they are for another architecture).

Autoconf automatically sets the `cross_compiling` variable based on `--host` or `--build` arguments being passed (see the output configure for details).