### PR TITLE
Add bbox method to st_sample()

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -139,6 +139,19 @@ st_sample.sfg = function(x, size, ...) {
 	st_sample(st_geometry(x), size, ...)
 }
 
+#' @export
+#' @name st_sample
+#' @examples
+#' bbox = st_bbox(
+#'	c(xmin = 16.1, xmax = 16.6, ymax = 48.6, ymin = 47.9),
+#' 	crs = st_crs(4326)
+#' )
+#' 
+#' st_sample(bbox, 5)
+st_sample.bbox = function(x, size, ...) {
+	st_sample(st_as_sfc(x), size, ...)
+}
+
 st_poly_sample = function(x, size, ..., type = "random",
                           offset = st_sample(st_as_sfc(st_bbox(x)), 1)[[1]],
 						  by_polygon = FALSE) {


### PR DESCRIPTION
This PR adds `st_sample.bbox()` to provide an S3 method to st_sample() for bbox class object. 

Very often I find myself wanting sample random points over the extent of an sfc object. This requires me to write code such as 

```r
st_bbox(nc) |> 
  st_as_sfc() |> 
  st_sample(42)
```

It would be quite nice to simplify this to `st_sample(st_bbox(nc), 42)`. This PR makes it possible. 

Again, sorry for not updating `man/st_sample.Rd`. I used to be able to compile sf. I'll figure it out again at some point.