### PR TITLE
Update geos_unary docs to correct wrong function name (st_use_s2() -> sf_use_s2())

### DIFF
--- a/R/geom-transformers.R
+++ b/R/geom-transformers.R
@@ -21,7 +21,7 @@
 #' @details \code{st_buffer} computes a buffer around this geometry/each geometry. If any of \code{endCapStyle},
 #' \code{joinStyle}, or \code{mitreLimit} are set to non-default values ('ROUND', 'ROUND', 1.0 respectively) then
 #' the underlying 'buffer with style' GEOS function is used.
-#' If a negative buffer returns empty polygons instead of shrinking, set st_use_s2() to FALSE
+#' If a negative buffer returns empty polygons instead of shrinking, set sf_use_s2() to FALSE
 #' See \href{https://postgis.net/docs/ST_Buffer.html}{postgis.net/docs/ST_Buffer.html} for details.
 #' 
 #' \code{nQuadSegs}, \code{endCapsStyle}, \code{joinStyle}, \code{mitreLimit} and \code{singleSide} only

--- a/man/geos_unary.Rd
+++ b/man/geos_unary.Rd
@@ -124,7 +124,7 @@ Geometric unary operations on simple feature geometries. These are all generics,
 \code{st_buffer} computes a buffer around this geometry/each geometry. If any of \code{endCapStyle},
 \code{joinStyle}, or \code{mitreLimit} are set to non-default values ('ROUND', 'ROUND', 1.0 respectively) then
 the underlying 'buffer with style' GEOS function is used.
-If a negative buffer returns empty polygons instead of shrinking, set st_use_s2() to FALSE
+If a negative buffer returns empty polygons instead of shrinking, set sf_use_s2() to FALSE
 See \href{https://postgis.net/docs/ST_Buffer.html}{postgis.net/docs/ST_Buffer.html} for details.
 
 \code{nQuadSegs}, \code{endCapsStyle}, \code{joinStyle}, \code{mitreLimit} and \code{singleSide} only


### PR DESCRIPTION
I noticed that the geos_unary docs refer to `sf_use_s2()` as `st_use_s2()`: this PR fixes that incorrect reference.