### PR TITLE
Add gdal_footprint support to gdal_utils

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * add `st_line_interpolate()` to obtain a point at a certain distance along a line; #2291
 
+* add support for the GDAL footprint utility (requiring GDAL >=3.8.0) to gdal_utils; #2305
+
 # version 1.0-15
 
 * add `st_perimeter()` to cover both geographic and projected coordinates; #268, #2279, by @JosiahParry

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -133,6 +133,10 @@ CPL_gdaltranslate <- function(src, dst, options, oo, co, quiet = TRUE) {
     .Call(`_sf_CPL_gdaltranslate`, src, dst, options, oo, co, quiet)
 }
 
+CPL_gdalfootprint <- function(src, dst, options, oo, co, quiet = TRUE) {
+    .Call(`_sf_CPL_gdalfootprint`, src, dst, options, oo, co, quiet)
+}
+
 CPL_gdalvectortranslate <- function(src, dst, options, oo, doo, co, quiet = TRUE) {
     .Call(`_sf_CPL_gdalvectortranslate`, src, dst, options, oo, doo, co, quiet)
 }

--- a/R/gdal_utils.R
+++ b/R/gdal_utils.R
@@ -23,7 +23,7 @@ resampling_method = function(option = "near") {
 
 #' Native interface to gdal utils
 #' @name gdal_utils
-#' @param util character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7)
+#' @param util character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7), \code{gdalfootprint} (requiring GDAL 3.8)
 #' @param source character; name of input layer(s); for \code{warp}, \code{buidvrt} or \code{mdimtranslate} this can be more than one
 #' @param destination character; name of output layer
 #' @param options character; options for the utility

--- a/R/gdal_utils.R
+++ b/R/gdal_utils.R
@@ -112,6 +112,7 @@ gdal_utils = function(util = "info", source, destination, options = character(0)
 						"-te", "-tr", "-tap", "-ts", "-ot")) # https://gdal.org/programs/gdal_rasterize.html
 				CPL_gdalrasterize(source, destination, options, oo, doo, config_options, overwrite, quiet)
 			}, # nocov end
+			gdalfootprint = CPL_gdalfootprint(source, destination, options, oo, config_options, quiet),
 			translate = CPL_gdaltranslate(source, destination, options, oo, config_options, quiet),
 			vectortranslate = CPL_gdalvectortranslate(source, destination, options, oo, doo, config_options, quiet),
 			buildvrt = CPL_gdalbuildvrt(if (missing(source)) character(0) else source, destination, options, oo, config_options, quiet),

--- a/R/gdal_utils.R
+++ b/R/gdal_utils.R
@@ -23,7 +23,7 @@ resampling_method = function(option = "near") {
 
 #' Native interface to gdal utils
 #' @name gdal_utils
-#' @param util character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7), \code{gdalfootprint} (requiring GDAL 3.8)
+#' @param util character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7), \code{footprint} (requiring GDAL 3.8)
 #' @param source character; name of input layer(s); for \code{warp}, \code{buidvrt} or \code{mdimtranslate} this can be more than one
 #' @param destination character; name of output layer
 #' @param options character; options for the utility
@@ -112,7 +112,7 @@ gdal_utils = function(util = "info", source, destination, options = character(0)
 						"-te", "-tr", "-tap", "-ts", "-ot")) # https://gdal.org/programs/gdal_rasterize.html
 				CPL_gdalrasterize(source, destination, options, oo, doo, config_options, overwrite, quiet)
 			}, # nocov end
-			gdalfootprint = CPL_gdalfootprint(source, destination, options, oo, config_options, quiet),
+			footprint = CPL_gdalfootprint(source, destination, options, oo, config_options, quiet),
 			translate = CPL_gdaltranslate(source, destination, options, oo, config_options, quiet),
 			vectortranslate = CPL_gdalvectortranslate(source, destination, options, oo, doo, config_options, quiet),
 			buildvrt = CPL_gdalbuildvrt(if (missing(source)) character(0) else source, destination, options, oo, config_options, quiet),

--- a/man/gdal_utils.Rd
+++ b/man/gdal_utils.Rd
@@ -17,7 +17,7 @@ gdal_utils(
 )
 }
 \arguments{
-\item{util}{character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7)}
+\item{util}{character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7), \code{gdalfootprint} (requiring GDAL 3.8)}
 
 \item{source}{character; name of input layer(s); for \code{warp}, \code{buidvrt} or \code{mdimtranslate} this can be more than one}
 

--- a/man/gdal_utils.Rd
+++ b/man/gdal_utils.Rd
@@ -17,7 +17,7 @@ gdal_utils(
 )
 }
 \arguments{
-\item{util}{character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7), \code{gdalfootprint} (requiring GDAL 3.8)}
+\item{util}{character; one of \code{info}, \code{warp}, \code{rasterize}, \code{translate}, \code{vectortranslate} (for ogr2ogr), \code{buildvrt}, \code{demprocessing}, \code{nearblack}, \code{grid}, \code{mdiminfo} and \code{mdimtranslate} (the last two requiring GDAL 3.1), \code{ogrinfo} (requiring GDAL 3.7), \code{footprint} (requiring GDAL 3.8)}
 
 \item{source}{character; name of input layer(s); for \code{warp}, \code{buidvrt} or \code{mdimtranslate} this can be more than one}
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -443,6 +443,22 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// CPL_gdalfootprint
+Rcpp::LogicalVector CPL_gdalfootprint(Rcpp::CharacterVector src, Rcpp::CharacterVector dst, Rcpp::CharacterVector options, Rcpp::CharacterVector oo, Rcpp::CharacterVector co, bool quiet);
+RcppExport SEXP _sf_CPL_gdalfootprint(SEXP srcSEXP, SEXP dstSEXP, SEXP optionsSEXP, SEXP ooSEXP, SEXP coSEXP, SEXP quietSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::RNGScope rcpp_rngScope_gen;
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type src(srcSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type dst(dstSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type options(optionsSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type oo(ooSEXP);
+    Rcpp::traits::input_parameter< Rcpp::CharacterVector >::type co(coSEXP);
+    Rcpp::traits::input_parameter< bool >::type quiet(quietSEXP);
+    rcpp_result_gen = Rcpp::wrap(CPL_gdalfootprint(src, dst, options, oo, co, quiet));
+    return rcpp_result_gen;
+END_RCPP
+}
 // CPL_gdalvectortranslate
 Rcpp::LogicalVector CPL_gdalvectortranslate(Rcpp::CharacterVector src, Rcpp::CharacterVector dst, Rcpp::CharacterVector options, Rcpp::CharacterVector oo, Rcpp::CharacterVector doo, Rcpp::CharacterVector co, bool quiet);
 RcppExport SEXP _sf_CPL_gdalvectortranslate(SEXP srcSEXP, SEXP dstSEXP, SEXP optionsSEXP, SEXP ooSEXP, SEXP dooSEXP, SEXP coSEXP, SEXP quietSEXP) {
@@ -1356,7 +1372,7 @@ RcppExport SEXP _sf_CPL_read_wkb(SEXP wkb_listSEXP, SEXP EWKBSEXP, SEXP spatiali
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -1391,7 +1407,7 @@ RcppExport SEXP _sf_CPL_write_wkb(SEXP sfcSEXP, SEXP EWKBSEXP) {
     if (rcpp_isError_gen) {
         SEXP rcpp_msgSEXP_gen = Rf_asChar(rcpp_result_gen);
         UNPROTECT(1);
-        Rf_error("%s", CHAR(rcpp_msgSEXP_gen));
+        Rf_error(CHAR(rcpp_msgSEXP_gen));
     }
     UNPROTECT(1);
     return rcpp_result_gen;
@@ -1473,6 +1489,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_sf_CPL_gdalwarp", (DL_FUNC) &_sf_CPL_gdalwarp, 8},
     {"_sf_CPL_gdalrasterize", (DL_FUNC) &_sf_CPL_gdalrasterize, 8},
     {"_sf_CPL_gdaltranslate", (DL_FUNC) &_sf_CPL_gdaltranslate, 6},
+    {"_sf_CPL_gdalfootprint", (DL_FUNC) &_sf_CPL_gdalfootprint, 6},
     {"_sf_CPL_gdalvectortranslate", (DL_FUNC) &_sf_CPL_gdalvectortranslate, 7},
     {"_sf_CPL_gdalbuildvrt", (DL_FUNC) &_sf_CPL_gdalbuildvrt, 6},
     {"_sf_CPL_gdaldemprocessing", (DL_FUNC) &_sf_CPL_gdaldemprocessing, 8},

--- a/src/gdal_utils.cpp
+++ b/src/gdal_utils.cpp
@@ -254,18 +254,16 @@ Rcpp::LogicalVector CPL_gdalfootprint(Rcpp::CharacterVector src, Rcpp::Character
         bool quiet = true) {
 	
 #if GDAL_VERSION_NUM < 3080000
-	Rcpp::CharacterVector ret;
-	Rcpp::stop("gdalfootprint util requires GDAL >= 3.8.0");
-#endif
-	
-	set_config_options(co);
+	Rcpp::stop("footprint util requires GDAL >= 3.8.0");
+#else
 	int err = 0;
+	set_config_options(co);
 	std::vector <char *> options_char = create_options(options, true);
 	std::vector <char *> oo_char = create_options(oo, true);
 	GDALFootprintOptions* opt =  GDALFootprintOptionsNew(options_char.data(), NULL);
 	
 	if (opt == NULL)
-		Rcpp::stop("gdalfootprint: options error");
+		Rcpp::stop("footprint: options error");
 	
 	if (! quiet)
 		GDALFootprintOptionsSetProgress(opt, GDALRProgress, NULL);
@@ -282,7 +280,7 @@ Rcpp::LogicalVector CPL_gdalfootprint(Rcpp::CharacterVector src, Rcpp::Character
 		GDALClose(src_pt);
 	unset_config_options(co);
 	return result == NULL || err;
-	
+#endif
 }
 
 // [[Rcpp::export]]

--- a/src/gdal_utils.cpp
+++ b/src/gdal_utils.cpp
@@ -265,7 +265,7 @@ Rcpp::LogicalVector CPL_gdalfootprint(Rcpp::CharacterVector src, Rcpp::Character
 	GDALFootprintOptions* opt =  GDALFootprintOptionsNew(options_char.data(), NULL);
 	
 	if (opt == NULL)
-		Rcpp::stop("translate: options error");
+		Rcpp::stop("gdalfootprint: options error");
 	
 	if (! quiet)
 		GDALFootprintOptionsSetProgress(opt, GDALRProgress, NULL);

--- a/src/gdal_utils.cpp
+++ b/src/gdal_utils.cpp
@@ -247,6 +247,44 @@ Rcpp::LogicalVector CPL_gdaltranslate(Rcpp::CharacterVector src, Rcpp::Character
 	return result == NULL || err;
 }
 
+
+// [[Rcpp::export]]
+Rcpp::LogicalVector CPL_gdalfootprint(Rcpp::CharacterVector src, Rcpp::CharacterVector dst,
+        Rcpp::CharacterVector options, Rcpp::CharacterVector oo, Rcpp::CharacterVector co,
+        bool quiet = true) {
+	
+#if GDAL_VERSION_NUM < 3080000
+	Rcpp::CharacterVector ret;
+	Rcpp::stop("gdalfootprint util requires GDAL >= 3.8.0");
+#endif
+	
+	set_config_options(co);
+	int err = 0;
+	std::vector <char *> options_char = create_options(options, true);
+	std::vector <char *> oo_char = create_options(oo, true);
+	GDALFootprintOptions* opt =  GDALFootprintOptionsNew(options_char.data(), NULL);
+	
+	if (opt == NULL)
+		Rcpp::stop("translate: options error");
+	
+	if (! quiet)
+		GDALFootprintOptionsSetProgress(opt, GDALRProgress, NULL);
+	GDALDatasetH src_pt = GDALOpenEx((const char *) src[0], GDAL_OF_RASTER | GA_ReadOnly,
+                                  NULL, oo_char.data(), NULL);
+	if (src_pt == NULL)
+		return 1; // #nocov
+	GDALDatasetH result = GDALFootprint((const char *) dst[0], NULL,src_pt, opt, &err);
+	GDALFootprintOptionsFree(opt);
+	// see https://github.com/r-spatial/sf/issues/1352:
+	if (result != NULL)
+		GDALClose(result);
+	if (src_pt != NULL)
+		GDALClose(src_pt);
+	unset_config_options(co);
+	return result == NULL || err;
+	
+}
+
 // [[Rcpp::export]]
 Rcpp::LogicalVector CPL_gdalvectortranslate(Rcpp::CharacterVector src, Rcpp::CharacterVector dst,
 		Rcpp::CharacterVector options, Rcpp::CharacterVector oo, Rcpp::CharacterVector doo,

--- a/tests/testthat/test_gdal.R
+++ b/tests/testthat/test_gdal.R
@@ -89,7 +89,7 @@ test_that('gdal_utils work', {
   skip_if_not(sf_extSoftVersion()[["GDAL"]] >= "3.8.0")
   tif <- system.file("tif/geomatrix.tif", package="sf")
   tf4 <- tempfile(fileext = ".gpkg")
-  expect_true(gdal_utils("gdalfootprint", tif, tf4))
+  expect_true(gdal_utils("footprint", tif, tf4))
 })
 
 # gdalwarp -t_srs '+proj=utm +zone=11 +datum=WGS84' -overwrite NETCDF:avhrr-only-v2.19810901.nc:anom utm11.tif

--- a/tests/testthat/test_gdal.R
+++ b/tests/testthat/test_gdal.R
@@ -89,7 +89,6 @@ test_that('gdal_utils work', {
   skip_if_not(sf_extSoftVersion()[["GDAL"]] >= "3.8.0")
   tif <- system.file("tif/geomatrix.tif", package="sf")
   tf4 <- tempfile(fileext = ".gpkg")
-  expect_true(gdal_utils("gdalfootprint", sd2, tf4))
   expect_true(gdal_utils("gdalfootprint", tif, tf4))
 })
 

--- a/tests/testthat/test_gdal.R
+++ b/tests/testthat/test_gdal.R
@@ -85,6 +85,12 @@ test_that('gdal_utils work', {
   expect_warning(gdal_utils("buildvrt", sd2, tf3, c("-oo", "FOO=BAR"))) # fake opening options
   expect_error(gdal_utils("buildvrt", "foo.tif", tf3, c("-oo", "FOO=BAR")), "cannot open source dataset")
   expect_true(gdal_utils("demprocessing", sd2, tf, processing = "hillshade"))
+  # check gdalfootprint
+  skip_if_not(sf_extSoftVersion()[["GDAL"]] >= "3.8.0")
+  tif <- system.file("tif/geomatrix.tif", package="sf")
+  tf4 <- tempfile(fileext = ".gpkg")
+  expect_true(gdal_utils("gdalfootprint", sd2, tf4))
+  expect_true(gdal_utils("gdalfootprint", tif, tf4))
 })
 
 # gdalwarp -t_srs '+proj=utm +zone=11 +datum=WGS84' -overwrite NETCDF:avhrr-only-v2.19810901.nc:anom utm11.tif


### PR DESCRIPTION
Hi,
as discussed in #2304 this PR adds support for the gdal_footprint utility requiring GDAL >= 3.8.0.
I am very new to C++, so please double-check if everything is ok. I used the script below to check the functionality:

``` r
# remotes::install_github("https://github.com/goergen95/sf", ref = "gdalfootprint")
library(sf)
#> Linking to GEOS 3.11.1, GDAL 3.8.1, PROJ 9.1.1; sf_use_s2() is TRUE
tif <- system.file("tif/geomatrix.tif", package = "sf")
t1 <- tempfile(fileext = ".gpkg")
t2 <- tempfile(fileext = ".json")
t3 <- tempfile(fileext = ".gpkg")
t4 <- tempfile(fileext = ".gpkg")
t5 <- tempfile(fileext = ".gpkg")
t6 <- tempfile(fileext = ".gpkg")

# GPKG output
gdal_utils("gdalfootprint", tif, t1)
(s1 <- st_read(t1))
#> Reading layer `footprint' from data source `/tmp/RtmpS1pM0Y/file27bf77437ef6.gpkg' using driver `GPKG'
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#>                             geom
#> 1 MULTIPOLYGON (((1841002 114...
# GeoJSON output
gdal_utils("gdalfootprint", tif, t2, options = c("-of", "GeoJSON"))
(s2 <- st_read(t2))
#> Reading layer `footprint' from data source `/tmp/RtmpS1pM0Y/file27bf1a8c155b.json' using driver `GeoJSON'
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#>                         geometry
#> 1 MULTIPOLYGON (((1841002 114...
# gdal_footprint options
gdal_utils("gdalfootprint", tif, t3, options = c("-t_srs", "EPSG:4326"))
(s3 <- st_read(t3))
#> Reading layer `footprint' from data source `/tmp/RtmpS1pM0Y/file27bf33b7643b.gpkg' using driver `GPKG'
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -104.8474 ymin: 10.11931 xmax: -104.8463 ymax: 10.12043
#> Geodetic CRS:  WGS 84
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -104.8474 ymin: 10.11931 xmax: -104.8463 ymax: 10.12043
#> Geodetic CRS:  WGS 84
#>                             geom
#> 1 MULTIPOLYGON (((-104.8465 1...
# opening options
gdal_utils("gdalfootprint", tif, t4, options = c("-oo", "NUM_THREADS=1"))
(s4 <- st_read(t4))
#> Reading layer `footprint' from data source `/tmp/RtmpS1pM0Y/file27bf1086b216.gpkg' using driver `GPKG'
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#>                             geom
#> 1 MULTIPOLYGON (((1841002 114...
# data set creation options
gdal_utils("gdalfootprint", tif, t5, options = c("-dsco", "CRS_WKT_EXTENSION=Yes"))
(s5 <- st_read(t5))
#> Reading layer `footprint' from data source `/tmp/RtmpS1pM0Y/file27bf1d7b91f7.gpkg' using driver `GPKG'
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: 1840902 ymin: 1143873 xmax: 1841032 ymax: 1144003
#> Projected CRS: WGS 84 / UTM zone 11N
#>                             geom
#> 1 MULTIPOLYGON (((1841002 114...
# remote file with overview option
tif2 <- paste0("/vsicurl/https://deafrica-input-datasets.s3.af-south-1.amazonaws.com/", 
               "cci_landcover/1992/cci_landcover_1992_v2.0.7cds.tif")
gdal_utils("gdalfootprint", tif2, t6, options = c("-ovr", "4"))
(s6 <- st_read(t6))
#> Reading layer `footprint' from data source `/tmp/RtmpS1pM0Y/file27bf6fbdb9e1.gpkg' using driver `GPKG'
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -26.36111 ymin: -47.96944 xmax: 64.5 ymax: 38.35
#> Geodetic CRS:  WGS 84
#> Simple feature collection with 1 feature and 0 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -26.36111 ymin: -47.96944 xmax: 64.5 ymax: 38.35
#> Geodetic CRS:  WGS 84
#>                             geom
#> 1 MULTIPOLYGON (((-26.36111 3...
```

<sup>Created on 2024-01-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>
