### PR TITLE
added `...` to function call for sf names

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -269,7 +269,7 @@ rename_with.sf = function(.data, .fn, .cols, ...) {
 		ret = dplyr::as_tibble(ret)
 	ret = st_as_sf(ret, sf_column_name = names(ret)[sf_column_loc])
 	
-	names(agr) = .fn(names(agr))
+	names(agr) = .fn(names(agr), ...)
 	st_agr(ret) = agr
 	ret
 }


### PR DESCRIPTION
Closes #2310 by passing the `...` of the `rename_with` functional to the relevant function when applied to `names(agr)` at https://github.com/r-spatial/sf/blob/99d6565a95e293b61f59002e8518dc3141ff1404/R/tidyverse.R#L272

This now works:

``` r
library(stringr)
library(dplyr)
nc <- sf::st_read(system.file("shape/nc.shp", package = "sf"), quiet = TRUE)

nc |> 
    rename_with(str_remove, pattern = "\\d")
#> Simple feature collection with 100 features and 14 fields
#> Geometry type: MULTIPOLYGON
#> Dimension:     XY
#> Bounding box:  xmin: -84.32385 ymin: 33.88199 xmax: -75.45698 ymax: 36.58965
#> Geodetic CRS:  NAD27
#> First 10 features:
#> ...
```
