### PR TITLE
Remove name renaming

### DIFF
--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -269,8 +269,6 @@ rename_with.sf = function(.data, .fn, .cols, ...) {
 		ret = dplyr::as_tibble(ret)
 	ret = st_as_sf(ret, sf_column_name = names(ret)[sf_column_loc])
 	
-	names(agr) = .fn(names(agr), ...)
-	st_agr(ret) = agr
 	ret
 }
 

--- a/R/tidyverse.R
+++ b/R/tidyverse.R
@@ -269,7 +269,7 @@ rename_with.sf = function(.data, .fn, .cols, ...) {
 		ret = dplyr::as_tibble(ret)
 	ret = st_as_sf(ret, sf_column_name = names(ret)[sf_column_loc])
 	
-	names(agr) = .fn(names(agr))
+	names(agr) = .fn(names(agr), ...)
 	st_agr(ret) = agr
 	ret
 }

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -269,11 +269,22 @@ test_that("`rename_with()` correctly changes the sf_column attribute (#2215)", {
 test_that("`rename_with()` works for unquoted `.cols` (#2220)", {
 	skip_if_not_installed("dplyr")
 	
-	sf_column = attr(nc, "sf_column")
 	fn = function(x) paste0(x, "_renamed")
 	
 	expect_identical(nc %>% rename_with(fn, c(FIPS, FIPSNO)), 
 					 nc %>% rename_with(fn, c("FIPS", "FIPSNO")))
+	
+	expect_identical(nc %>% rename_with(fn, c(FIPS, FIPSNO)), 
+					 nc %>% rename(FIPS_renamed = FIPS, FIPSNO_renamed = FIPSNO))
+})
+
+test_that("`rename_with()` accepts arguments in `...` (#2310)", {
+	skip_if_not_installed("dplyr")
+	
+	fn = function(x, y) paste0(x, y)
+	
+	expect_identical(nc %>% rename_with(fn, FIPS, y = "_renamed"), 
+					 nc %>% rename(FIPS_renamed = FIPS))
 })
 
 test_that("`select()` and `transmute()` observe back-stickiness of geometry column (#1425)", {


### PR DESCRIPTION
An alternative fix which would also close #2310 - these lines actually don't seem to matter with the new `dplyr::rename_with` functionality:

https://github.com/r-spatial/sf/blob/99d6565a95e293b61f59002e8518dc3141ff1404/R/tidyverse.R#L272-L273

They re-run the `.fn` function in `rename_with` across all columns. The tests aren't currently picking up that the `"agr"` attribute is being changed by the inner function:

``` r
fn = function(x) paste0(x, "_renamed")
nc %>% attr("agr")
#>      AREA PERIMETER     CNTY_   CNTY_ID      NAME      FIPS    FIPSNO  CRESS_ID 
#>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA> 
#>     BIR74     SID74   NWBIR74     BIR79     SID79   NWBIR79 
#>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA> 
#> Levels: constant aggregate identity
nc %>% rename_with(fn, c(FIPS, FIPSNO)) %>% attr("agr")
#>           <NA>           <NA>           <NA>           <NA>           <NA> 
#>           <NA>           <NA>           <NA>           <NA>           <NA> 
#>   FIPS_renamed FIPSNO_renamed           <NA>           <NA>           <NA> 
#>           <NA>           <NA>           <NA>           <NA>           <NA> 
#>           <NA>           <NA>           <NA>           <NA> 
#>           <NA>           <NA>           <NA>           <NA> 
#> Levels: constant aggregate identity
```

Removing lines 272-273 works as expected:

``` r
nc %>% attr("agr")
#>      AREA PERIMETER     CNTY_   CNTY_ID      NAME      FIPS    FIPSNO  CRESS_ID 
#>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA> 
#>     BIR74     SID74   NWBIR74     BIR79     SID79   NWBIR79 
#>      <NA>      <NA>      <NA>      <NA>      <NA>      <NA> 
#> Levels: constant aggregate identity
nc %>% rename_with(fn, c(FIPS, FIPSNO)) %>% attr("agr")
#>           AREA      PERIMETER          CNTY_        CNTY_ID           NAME 
#>           <NA>           <NA>           <NA>           <NA>           <NA> 
#>   FIPS_renamed FIPSNO_renamed       CRESS_ID          BIR74          SID74 
#>           <NA>           <NA>           <NA>           <NA>           <NA> 
#>        NWBIR74          BIR79          SID79        NWBIR79 
#>           <NA>           <NA>           <NA>           <NA> 
#> Levels: constant aggregate identity
```

Added new test for arguments to `rename_with` and altered test for previous update to more robustly test that the renaming function is applied properly. Would recommend this over #2311 