### PR TITLE
st_join renames geom column to geometry if x is st_sf with only a st_sfc col

### DIFF
--- a/R/join.R
+++ b/R/join.R
@@ -174,7 +174,8 @@ st_join.sf = function(x, y, join = st_intersects, ..., suffix = c(".x", ".y"),
 	if (inherits(x, "tbl_df") && requireNamespace("dplyr", quietly = TRUE))
 		st_sf(dplyr::bind_cols(x[ix,], y[unlist(i), , drop = FALSE]))
   	else
-		st_sf(cbind(as.data.frame(x)[ix,], y[unlist(i), , drop = FALSE]))	
+	        st_sf(cbind(as.data.frame(x)[ix, ,drop=FALSE], y[unlist(i), , drop = FALSE]))
+	
 }
 
 #' @export


### PR DESCRIPTION
```r
z <- st_sf(pid=5, geom=st_sfc(st_polygon(list(matrix(c(0,0,4,0,4,4,0,4,0,0),ncol=2, byrow=T)))))
x <- st_sf(id=1:2, geom=st_sfc(st_point(1:2), st_point(2:3)), geom2=st_sfc(st_point(1:2), st_point(2:3)))
# OK
st_join(x,z)
Simple feature collection with 2 features and 2 fields
Active geometry column: geom
Geometry type: POINT
Dimension:     XY
Bounding box:  xmin: 1 ymin: 2 xmax: 2 ymax: 3
CRS:           NA
  id pid        geom       geom2
1  1   5 POINT (1 2) POINT (1 2)
2  2   5 POINT (2 3) POINT (2 3)

# No OK
st_join(x[,'geom'], z)
Simple feature collection with 2 features and 1 field
Geometry type: POINT
Dimension:     XY
Bounding box:  xmin: 1 ymin: 2 xmax: 2 ymax: 3
CRS:           NA
  pid    geometry
1   5 POINT (1 2)
2   5 POINT (2 3)

```