### PR TITLE
merge.sf renames geometry column name to 'geometry' arbitrarily

### DIFF
--- a/R/sf.R
+++ b/R/sf.R
@@ -132,16 +132,13 @@ st_geometry.sfg = function(obj, ...) st_sfc(obj)
 		st_sf(x, sf_column_name = value)
 	else {
 		a = vapply(x, function(v) inherits(v, "sfc"), TRUE)
-		if (any(a)) {
-			w = which(a)
-			sf_col = attr(x, "sf_column")
-			if (! is.null(sf_col))
-				x[[ sf_col ]] = value
-			else {
-				if (length(w) > 1)
-					warning("overwriting first sfc column")
-				x[[ which(a)[1L] ]] = value
-			}
+		if (!is.null(sf_col))
+	          x[[sf_col]] = value
+	        else if (any(a)) { 
+	          w = which(a)
+	          if (length(w) > 1)
+	            warning("overwriting first sfc column")
+	          x[[which(a)[1L]]] = value
 		} else
 			x$geometry = value
 		st_sf(x)
@@ -457,6 +454,7 @@ merge.sf = function(x, y, ...) {
 	class(ret) = setdiff(class(ret), "sf")
 	g = ret[[sf_column]] # may have NULL values in it
 	ret[[sf_column]] = NULL
+	attr(ret, "sf_column") <- sf_column
 	st_set_geometry(ret, st_sfc(g)) # FIXME: set agr
 }
 


### PR DESCRIPTION
```r
x <- st_sf(id=1:2, geom=st_sfc(st_point(1:2), st_point(2:3)))
y <- data.frame(id=2:3, name=letters[2:3])
merge(x,y) # renames geom to geometry
```