### PR TITLE
ensure vctrs operations work

### DIFF
--- a/R/tidyverse-vctrs.R
+++ b/R/tidyverse-vctrs.R
@@ -3,14 +3,13 @@
 # time, this declares `sfc` lists as vectors which is necessary
 # because vctrs generally treats S3 lists as scalars.
 vec_proxy.sfc = function(x, ...) {
-	x
+	x[]
 }
 # This restores `sfc` attributes after manipulation of the proxy
 # (e.g. slicing or combination)
 vec_restore.sfc = function(x, to, ...) {
 	# Ensure restoration of `n_empty` by `st_sfc()`
 	attr(x, "n_empty") = NULL
-
 	st_sfc(x, crs = st_crs(to), precision = st_precision(to))
 }
 

--- a/tests/testthat/test_vctrs.R
+++ b/tests/testthat/test_vctrs.R
@@ -8,6 +8,12 @@ test_that("`sfc` vectors can be sliced", {
 	expect_identical(vctrs::vec_slice(x, 0), x[0])
 })
 
+test_that("`sfc` vectors with point matrix can be sliced", {
+	x = st_geometry(st_as_sf(data.frame(x=1:2, y=4:3), coords = 1:2))
+	expect_identical(vctrs::vec_slice(x, 1), x[1])
+	expect_equal(vctrs::vec_slice(x, 0), st_sfc(x[0], recompute_bbox=TRUE))
+})
+
 test_that("`n_empty` attribute of `sfc` vectors is restored", {
 	pt1 = st_sfc(st_point(c(NA_real_, NA_real_)))
 	pt2 = st_sfc(st_point(0:1))


### PR DESCRIPTION
I noticed `dplyr::bind_rows` failed due to `vctrs` returning empty subsets for point matrixes. The quick solution I could find was realize in `vec_proxy`, more elegant would be to keep the point matrix but I'm not sure how to do that as `vctrs` indexes the list. 

Note for the test the bbox needs to be recomputed as `x[0]` produces a bbox without CRS while `vec_slice` has one.