### PR TITLE
Implement `promote_multi` when converting WKB to sfc

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -393,8 +393,8 @@ CPL_create <- function(file, nxy, value, wkt, xlim, ylim) {
     invisible(.Call(`_sf_CPL_create`, file, nxy, value, wkt, xlim, ylim))
 }
 
-CPL_read_wkb <- function(wkb_list, EWKB = FALSE, spatialite = FALSE) {
-    .Call(`_sf_CPL_read_wkb`, wkb_list, EWKB, spatialite)
+CPL_read_wkb <- function(wkb_list, EWKB = FALSE, spatialite = FALSE, promote_multi = FALSE) {
+    .Call(`_sf_CPL_read_wkb`, wkb_list, EWKB, spatialite, promote_multi)
 }
 
 CPL_write_wkb <- function(sfc, EWKB = FALSE) {

--- a/R/wkb.R
+++ b/R/wkb.R
@@ -32,7 +32,8 @@ skip0x = function(x) {
 #' wkb = structure(list("0x01010000204071000000000000801A064100000000AC5C1441"), class = "WKB")
 #' st_as_sfc(wkb, EWKB = TRUE)
 #' @export
-st_as_sfc.WKB = function(x, ..., EWKB = FALSE, spatialite = FALSE, pureR = FALSE, crs = NA_crs_) {
+st_as_sfc.WKB = function(x, ..., EWKB = FALSE, spatialite = FALSE, pureR = FALSE, crs = NA_crs_,
+					     promote_multi = FALSE) {
 	if (EWKB && spatialite)
 		stop("arguments EWKB and spatialite cannot both be TRUE")
 	if (spatialite && pureR)
@@ -49,7 +50,7 @@ st_as_sfc.WKB = function(x, ..., EWKB = FALSE, spatialite = FALSE, pureR = FALSE
 	ret = if (pureR)
 			R_read_wkb(x, readWKB, EWKB = EWKB)
 		else
-			CPL_read_wkb(x, EWKB, spatialite)
+			CPL_read_wkb(x, EWKB, spatialite, promote_multi)
 	if (is.na(crs) && (EWKB || spatialite) && !is.null(attr(ret, "srid")) && attr(ret, "srid") != 0)
 		crs = attr(ret, "srid")
 	if (! is.na(st_crs(crs))) {

--- a/inst/include/sf_RcppExports.h
+++ b/inst/include/sf_RcppExports.h
@@ -24,17 +24,17 @@ namespace sf {
         }
     }
 
-    inline Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB = false, bool spatialite = false) {
-        typedef SEXP(*Ptr_CPL_read_wkb)(SEXP,SEXP,SEXP);
+    inline Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB = false, bool spatialite = false, bool promote_multi = false) {
+        typedef SEXP(*Ptr_CPL_read_wkb)(SEXP,SEXP,SEXP,SEXP);
         static Ptr_CPL_read_wkb p_CPL_read_wkb = NULL;
         if (p_CPL_read_wkb == NULL) {
-            validateSignature("Rcpp::List(*CPL_read_wkb)(Rcpp::List,bool,bool)");
+            validateSignature("Rcpp::List(*CPL_read_wkb)(Rcpp::List,bool,bool,bool)");
             p_CPL_read_wkb = (Ptr_CPL_read_wkb)R_GetCCallable("sf", "_sf_CPL_read_wkb");
         }
         RObject rcpp_result_gen;
         {
             RNGScope RCPP_rngScope_gen;
-            rcpp_result_gen = p_CPL_read_wkb(Shield<SEXP>(Rcpp::wrap(wkb_list)), Shield<SEXP>(Rcpp::wrap(EWKB)), Shield<SEXP>(Rcpp::wrap(spatialite)));
+            rcpp_result_gen = p_CPL_read_wkb(Shield<SEXP>(Rcpp::wrap(wkb_list)), Shield<SEXP>(Rcpp::wrap(EWKB)), Shield<SEXP>(Rcpp::wrap(spatialite)), Shield<SEXP>(Rcpp::wrap(promote_multi)));
         }
         if (rcpp_result_gen.inherits("interrupted-error"))
             throw Rcpp::internal::InterruptedException();

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -1343,22 +1343,23 @@ BEGIN_RCPP
 END_RCPP
 }
 // CPL_read_wkb
-Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB, bool spatialite);
-static SEXP _sf_CPL_read_wkb_try(SEXP wkb_listSEXP, SEXP EWKBSEXP, SEXP spatialiteSEXP) {
+Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB, bool spatialite, bool promote_multi);
+static SEXP _sf_CPL_read_wkb_try(SEXP wkb_listSEXP, SEXP EWKBSEXP, SEXP spatialiteSEXP, SEXP promote_multiSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::traits::input_parameter< Rcpp::List >::type wkb_list(wkb_listSEXP);
     Rcpp::traits::input_parameter< bool >::type EWKB(EWKBSEXP);
     Rcpp::traits::input_parameter< bool >::type spatialite(spatialiteSEXP);
-    rcpp_result_gen = Rcpp::wrap(CPL_read_wkb(wkb_list, EWKB, spatialite));
+    Rcpp::traits::input_parameter< bool >::type promote_multi(promote_multiSEXP);
+    rcpp_result_gen = Rcpp::wrap(CPL_read_wkb(wkb_list, EWKB, spatialite, promote_multi));
     return rcpp_result_gen;
 END_RCPP_RETURN_ERROR
 }
-RcppExport SEXP _sf_CPL_read_wkb(SEXP wkb_listSEXP, SEXP EWKBSEXP, SEXP spatialiteSEXP) {
+RcppExport SEXP _sf_CPL_read_wkb(SEXP wkb_listSEXP, SEXP EWKBSEXP, SEXP spatialiteSEXP, SEXP promote_multiSEXP) {
     SEXP rcpp_result_gen;
     {
         Rcpp::RNGScope rcpp_rngScope_gen;
-        rcpp_result_gen = PROTECT(_sf_CPL_read_wkb_try(wkb_listSEXP, EWKBSEXP, spatialiteSEXP));
+        rcpp_result_gen = PROTECT(_sf_CPL_read_wkb_try(wkb_listSEXP, EWKBSEXP, spatialiteSEXP, promote_multiSEXP));
     }
     Rboolean rcpp_isInterrupt_gen = Rf_inherits(rcpp_result_gen, "interrupted-error");
     if (rcpp_isInterrupt_gen) {
@@ -1442,7 +1443,7 @@ END_RCPP
 static int _sf_RcppExport_validate(const char* sig) { 
     static std::set<std::string> signatures;
     if (signatures.empty()) {
-        signatures.insert("Rcpp::List(*CPL_read_wkb)(Rcpp::List,bool,bool)");
+        signatures.insert("Rcpp::List(*CPL_read_wkb)(Rcpp::List,bool,bool,bool)");
         signatures.insert("Rcpp::List(*CPL_write_wkb)(Rcpp::List,bool)");
     }
     return signatures.find(sig) != signatures.end();
@@ -1555,7 +1556,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_sf_CPL_write_gdal", (DL_FUNC) &_sf_CPL_write_gdal, 13},
     {"_sf_CPL_extract", (DL_FUNC) &_sf_CPL_extract, 3},
     {"_sf_CPL_create", (DL_FUNC) &_sf_CPL_create, 6},
-    {"_sf_CPL_read_wkb", (DL_FUNC) &_sf_CPL_read_wkb, 3},
+    {"_sf_CPL_read_wkb", (DL_FUNC) &_sf_CPL_read_wkb, 4},
     {"_sf_CPL_write_wkb", (DL_FUNC) &_sf_CPL_write_wkb, 2},
     {"_sf_CPL_get_z_range", (DL_FUNC) &_sf_CPL_get_z_range, 2},
     {"_sf_CPL_get_m_range", (DL_FUNC) &_sf_CPL_get_m_range, 2},

--- a/src/gdal.cpp
+++ b/src/gdal.cpp
@@ -330,7 +330,7 @@ Rcpp::List CPL_crs_parameters(Rcpp::List crs) {
 	Rcpp::IntegerVector orientation(ac);
 	for (int i = 0; i < ac; i++) {
 		OGRAxisOrientation peOrientation;
-		const char *ret = srs->GetAxis(srs->IsGeographic() ? "GEOGCS" : "PROJCS", 
+		const char *ret = srs->GetAxis(srs->IsGeographic() ? "GEOGCS" : "PROJCS",
 						i, &peOrientation);
 		if (ret != NULL) {
 			nms[i] = ret;
@@ -497,7 +497,7 @@ Rcpp::List sfc_from_ogr(std::vector<OGRGeometry *> g, bool destroy = false) {
 		if (destroy)
 			OGRGeometryFactory::destroyGeometry(g[i]);
 	}
-	Rcpp::List ret = CPL_read_wkb(lst, false, false);
+	Rcpp::List ret = CPL_read_wkb(lst, false, false, false);
 	ret.attr("crs") = crs;
 	ret.attr("class") = "sfc";
 	return ret;

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -252,7 +252,7 @@ Rcpp::List sfc_from_geometry(GEOSContextHandle_t hGEOSCtxt, std::vector<GeomPtr>
 		}
 	}
 	GEOSWKBWriter_destroy_r(hGEOSCtxt, wkb_writer);
-	return CPL_read_wkb(out, true, false);
+	return CPL_read_wkb(out, true, false, false);
 }
 
 Rcpp::NumericVector get_dim(double dim0, double dim1) {
@@ -871,7 +871,7 @@ Rcpp::List CPL_geos_op(std::string op, Rcpp::List sfc,
 #ifdef HAVE310
 	if (op == "triangulate_constrained") {
 		for (size_t i = 0; i < g.size(); i++)
-			out[i] = geos_ptr(chkNULL(GEOSConstrainedDelaunayTriangulation_r(hGEOSCtxt, g[i].get())), 
+			out[i] = geos_ptr(chkNULL(GEOSConstrainedDelaunayTriangulation_r(hGEOSCtxt, g[i].get())),
 							hGEOSCtxt);
 	} else
 #endif
@@ -1307,14 +1307,14 @@ Rcpp::List CPL_nary_intersection(Rcpp::List sfc) {
 							errors++;
 						else if (!chk_(GEOSisEmpty_r(hGEOSCtxt, inters.get()))) { // i and k intersection
 							// cut out inters from geom:
-							geom = geos_ptr(GEOSDifference_r(hGEOSCtxt, geom.get(), inters.get()), hGEOSCtxt); 
+							geom = geos_ptr(GEOSDifference_r(hGEOSCtxt, geom.get(), inters.get()), hGEOSCtxt);
 							if (geom == nullptr)
 								Rcpp::stop("GEOS exception"); // #nocov
 							// cut out inters from out[k]:
 #ifndef HAVE_390
-							GeomPtr g = geos_ptr(GEOSDifference_r(hGEOSCtxt, out[k].get(), inters.get()), hGEOSCtxt); 
+							GeomPtr g = geos_ptr(GEOSDifference_r(hGEOSCtxt, out[k].get(), inters.get()), hGEOSCtxt);
 #else
-							GeomPtr g = geos_ptr(GEOSDifferencePrec_r(hGEOSCtxt, out[k].get(), inters.get(), grid_size), hGEOSCtxt); 
+							GeomPtr g = geos_ptr(GEOSDifferencePrec_r(hGEOSCtxt, out[k].get(), inters.get(), grid_size), hGEOSCtxt);
 #endif
 							if (g == nullptr)
 								Rcpp::warning("GEOS difference returns NULL"); // #nocov

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -496,7 +496,7 @@ static void read_wkb_promote_multi_if_possible(Rcpp::List output, int64_t* all_t
 }
 
 // [[Rcpp::export]]
-Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB = false, bool spatialite = false) {
+Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB = false, bool spatialite = false, bool promote_multi = false) {
 	Rcpp::List output(wkb_list.size());
 
 	int type = 0, n_empty = 0;
@@ -521,8 +521,6 @@ Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB = false, bool spatialite 
 		// Rcpp::Rcout << "type is " << type << "\n";
 		all_types |= sf_type_bitmask(type);
 	}
-
-	bool promote_multi = false;
 
 	if (promote_multi) {
 		read_wkb_promote_multi_if_possible(output, &all_types);

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -407,7 +407,7 @@ static int64_t sf_type_bitmask(int sf_type) {
 static Rcpp::NumericMatrix read_wkb_promote_sfg_multipoint(Rcpp::NumericVector item) {
 	SEXP cls_old = Rf_getAttrib(item, R_ClassSymbol);
 	Rcpp::CharacterVector cls_new = Rf_duplicate(cls_old);
-	cls_new[0] = "MULTIPOINT";
+	cls_new[1] = "MULTIPOINT";
 
 	bool is_empty = true;
 	for (const auto ordinate : item) {
@@ -434,7 +434,7 @@ static Rcpp::List read_wkb_promote_sfg_multipolygon_or_linestring(SEXP item, con
 	// safer to not make this assumption.
 	SEXP cls_old = Rf_getAttrib(item, R_ClassSymbol);
 	Rcpp::CharacterVector cls_new = Rf_duplicate(cls_old);
-	cls_new[0] = cls_multi;
+	cls_new[1] = cls_multi;
 
 	Rcpp::List multi;
 	if (Rf_length(item) == 0) {

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -492,7 +492,7 @@ static void read_wkb_promote_multi_if_possible(Rcpp::List output, int64_t* all_t
 		}
 	}
 
-	*all_types = sf_type_multi;
+	*all_types = sf_type_bitmask(sf_type_multi);
 }
 
 // [[Rcpp::export]]

--- a/src/wkb.h
+++ b/src/wkb.h
@@ -17,6 +17,7 @@
 #define SF_PolyhedralSurface  15
 #define SF_TIN                16
 #define SF_Triangle           17
+#define SF_Type_Max           17
 
 Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB, bool spatialite);
 Rcpp::List CPL_write_wkb(Rcpp::List sfc, bool EWKB);

--- a/src/wkb.h
+++ b/src/wkb.h
@@ -19,7 +19,7 @@
 #define SF_Triangle           17
 #define SF_Type_Max           17
 
-Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB, bool spatialite);
+Rcpp::List CPL_read_wkb(Rcpp::List wkb_list, bool EWKB, bool spatialite, bool promote_multi);
 Rcpp::List CPL_write_wkb(Rcpp::List sfc, bool EWKB);
 unsigned int make_type(const char *cls, const char *dim, bool EWKB, int *tp, int srid);
 Rcpp::List get_dim_sfc(Rcpp::List sfc);


### PR DESCRIPTION
Apologies for taking so long to circle back here, but this is one approach to ensuring that `R CMD check` passes when `R_SF_ST_READ_USE_STREAM=true`. It also has the nice side-effect that `use_stream = TRUE` no longer uses the wk package to construct sfc objects and that all users of `st_as_sfc(<WKB>)` can now use `promote_multi = TRUE` to get the same read-ogr-like behaviour.

Marked as a draft since this needs a few low-level tests, but I did check that all read tests pass with `R_SF_ST_READ_USE_STREAM=true`

I do still see:

```
Failure (test-tm.R:20:3): st_read and write handle date and time
x[["tm"]] not equal to x2[["tm"]].
Attributes: < Component “tzone”: 1 string mismatch >

Failure (test-tm.R:40:3): st_read and write handle date and time
x[["tm"]] not equal to x2[["tm"]].
Attributes: < Component “tzone”: 1 string mismatch >
```

...when running `testthat::test_local()` with `R_SF_ST_READ_USE_STREAM=true`. I think this happens because of how nanoarrow converts timestamps without an explicit timezone to R objects: nanoarrow assigns UTC as opposed to setting `tzone = ""` or omitting it. I copied this behaviour from readr because it is more reproducible between systems, but I'm not sure it's any more or less correct.