### PR TITLE
Speed up st_crs for SpatVector objects

### DIFF
--- a/R/terra.R
+++ b/R/terra.R
@@ -11,14 +11,17 @@ st_as_sf.SpatVector = function(x, ..., hex = TRUE) {
 }
 
 #' @export
-st_crs.SpatRaster = function(x, ...) {
+st_crs.SpatRaster = function(x) {
 	if (!requireNamespace("terra", quietly = TRUE))
 		stop("package terra required, please install it first") # nocov
-	string = terra::crs(x)
-	if (string == "") 
+	ctr <- terra::crs(x)
+	if (ctr == "") {
 		NA_crs_
-	else
-		st_crs(string)
+	} else {
+		crs <- sf:::CPL_crs_from_input(ctr)
+		crs$input <- crs$Name
+		crs
+	}
 }
 
 #' @export

--- a/R/terra.R
+++ b/R/terra.R
@@ -18,7 +18,7 @@ st_crs.SpatRaster = function(x) {
 	if (ctr == "") {
 		NA_crs_
 	} else {
-		crs <- sf:::CPL_crs_from_input(ctr)
+		crs <- CPL_crs_from_input(ctr)
 		crs$input <- crs$Name
 		crs
 	}

--- a/tests/testthat/test-crs.R
+++ b/tests/testthat/test-crs.R
@@ -110,3 +110,17 @@ test_that("crs.Raster works", {
   x = st_crs(r)
   expect_s3_class(x, "crs", exact = TRUE)
 })
+
+
+test_that("SpatVector crs reads correctly", {
+	skip_if_not_installed("terra")
+	library(terra)
+	lux <- terra::vect(system.file("ex/lux.shp", package="terra"))
+	expect_s3_class(st_crs(lux), "crs", exact = TRUE)
+	expect_equal(st_crs(crs(lux)), st_crs(lux))
+	
+	crs(lux) <- NA
+	expect_s3_class(st_crs(lux), "crs", exact = TRUE)
+	expect_equal(st_crs(lux), NA_crs_)
+	
+})


### PR DESCRIPTION
Hey, guys.

Consider updating the `st_crs()` function for the `SpatVector` objects. The trick is `terra::crs()` always returns a character vector, therefore we can skip some checks implemented in `st_crs()` and we can gain a 2x speed increase in CRS extraction. When there is no CRS in `SpatVector` object, then the transition happens 1.2 times faster. When it comes to `st_as_sf()`, then it works 10% faster.

See examples below:

``` r
library(sf)
#> Linking to GEOS 3.12.1, GDAL 3.8.4, PROJ 9.3.1; sf_use_s2() is TRUE
library(terra)
#> terra 1.7.71

f <- system.file("ex/lux.shp", package="terra")
v <- vect(f)


st_crs2 = function(x) {
  if (!requireNamespace("terra", quietly = TRUE))
    stop("package terra required, please install it first") # nocov
  ctr <- terra::crs(x)
  if (ctr == "") {
    NA_crs_
  } else {
    crs <- sf:::CPL_crs_from_input(ctr)
    crs$input <- crs$Name
    crs
  }
}

bench::mark(
  original = st_crs(v),
  PR = st_crs2(v),
  check = T,
  relative = T,
  max_iterations = 1000L
)
#> # A tibble: 2 × 6
#>   expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <dbl>  <dbl>     <dbl>     <dbl>    <dbl>
#> 1 original    1.93   1.83      1         296.     1.00
#> 2 PR          1      1         1.86        1      1

crs(v) <- NA_character_

bench::mark(
  original = st_crs(v),
  PR = st_crs2(v),
  check = T,
  relative = T,
  max_iterations = 1000L
)
#> # A tibble: 2 × 6
#>   expression   min median `itr/sec` mem_alloc `gc/sec`
#>   <bch:expr> <dbl>  <dbl>     <dbl>     <dbl>    <dbl>
#> 1 original    1.24   1.20      1          Inf      NaN
#> 2 PR          1      1         1.11       NaN      NaN
```

<sup>Created on 2024-05-09 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
