### PR TITLE
Fix compilation error on gcc 14.2

### DIFF
--- a/src/gdal.h
+++ b/src/gdal.h
@@ -1,3 +1,6 @@
+#include <Rcpp.h>
+class OGRSpatialReference;
+
 void set_error_handler(void);
 void unset_error_handler(void);
 OGRSpatialReference *handle_axis_order(OGRSpatialReference *sr);


### PR DESCRIPTION
R
> devtools::install()

Compilation error encountered with gcc 14.2:

```
In file included from gdal.cpp:1:
./gdal.h:3:1: error: ‘OGRSpatialReference’ does not name a type; did you mean ‘DEFINED_OGRSpatialReferenc
eH’?
    3 | OGRSpatialReference *handle_axis_order(OGRSpatialReference *sr);
      | ^~~~~~~~~~~~~~~~~~~
      | DEFINED_OGRSpatialReferenceH
./gdal.h:4:1: error: ‘Rcpp’ does not name a type
    4 | Rcpp::List create_crs(const OGRSpatialReference *ref, bool set_input);
      | ^~~~
```

This commit forward declares `OGRSpatialReference` to fix the first error above, and it includes `Rcpp.h` explicitly to fix the second error.

```
$ R --version
R version 4.4.1 (2024-06-14) -- "Race for Your Life"

$ gcc --version
gcc (GCC) 14.2.1 20240802

$ uname -a
Linux durus 6.10.3-arch1-1 #1 SMP PREEMPT_DYNAMIC Sun, 04 Aug 2024 05:11:32 +0000 x86_64 GNU/Linux
```