### PR TITLE
address #2436

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Package: sf
-Version: 1.0-17
+Version: 1.0-18
 Title: Simple Features for R
 Authors@R:
     c(person(given = "Edzer",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# version 1.0-18
+
+* fix build failure with GDAL < 3.4.0 #2436
+
 # version 1.0-17
 
 * add `st_transform()` method for `bbox` objects; this uses OGRCoordinateTransformation::TransformBounds(), densifying first and antemeridian proof; #2415

--- a/R/transform.R
+++ b/R/transform.R
@@ -170,7 +170,10 @@ st_transform.sfg = function(x, crs = st_crs(x), ...) {
 #' @param densify integer, number of points for discretizing lines between bounding box corner points; see Details
 #' @details the method for `bbox` objects densifies lines for geographic coordinates along Cartesian lines, not great circle arcs
 st_transform.bbox = function(x, crs, ..., densify = 21) {
-	st_bbox(CPL_transform_bounds(x, st_crs(crs), densify), crs = crs)
+        if (sf_extSoftVersion()["GDAL"] >= "3.4.0")
+		st_bbox(CPL_transform_bounds(x, st_crs(crs), densify), crs = crs)
+	else
+		stop("method not available for GDAL: ", sf_extSoftVersion()["GDAL"])
 }
 
 #' @name st_transform

--- a/src/gdal.cpp
+++ b/src/gdal.cpp
@@ -673,6 +673,17 @@ Rcpp::List CPL_transform(Rcpp::List sfc, Rcpp::List crs,
 Rcpp::NumericVector CPL_transform_bounds(Rcpp::NumericVector bb, Rcpp::List crs_dst,
 		int densify_pts = 21) {
 
+	Rcpp::NumericVector ret(4);
+	ret[0] = 0.0;
+	ret[1] = 0.0;
+	ret[2] = 0.0;
+	ret[3] = 0.0;
+	Rcpp::CharacterVector names(4);
+	names(0) = "xmin";
+	names(1) = "ymin";
+	names(2) = "xmax";
+	names(3) = "ymax";
+	ret.attr("names") = names;
 #if GDAL_VERSION_NUM >= 3040000
 	if (bb.size() != 4)
 		Rcpp::stop("bb should have length 4");
@@ -693,17 +704,10 @@ Rcpp::NumericVector CPL_transform_bounds(Rcpp::NumericVector bb, Rcpp::List crs_
 	int success = ct->TransformBounds(bb[0], bb[1], bb[2], bb[3], &xmin, &ymin, &xmax, &ymax, densify_pts);
 	if (!success)
 		Rcpp::stop("transform_bounds(): failures encountered"); // #nocov
-	Rcpp::NumericVector ret(4);
 	ret[0] = xmin;
 	ret[1] = ymin;
 	ret[2] = xmax;
 	ret[3] = ymax;
-	Rcpp::CharacterVector names(4);
-	names(0) = "xmin";
-	names(1) = "ymin";
-	names(2) = "xmax";
-	names(3) = "ymax";
-	ret.attr("names") = names;
 	ct->DestroyCT(ct);
 	dst->Release();
 	src->Release();


### PR DESCRIPTION
Quick fix for `ret` not being allocated in-scope in `CPL_transform_bounds`, added note to NEWS, bumped version number and added test in R code so that compiled code shouldn't be reached with GDAL < 3.4.0 - #2436 