### PR TITLE
CPL_length(): fix unchecked cast to OGRGeometryCollection

### DIFF
--- a/src/gdal_geom.cpp
+++ b/src/gdal_geom.cpp
@@ -63,8 +63,12 @@ Rcpp::NumericVector CPL_length(Rcpp::List sfc) {
 				}
 				break;
 			default: {
-					OGRGeometryCollection *a = (OGRGeometryCollection *) g[i];
-					out[i] = a->get_Length();
+					if (OGR_GT_IsSubClassOf(gt, wkbGeometryCollection)) {
+						OGRGeometryCollection *a = (OGRGeometryCollection *) g[i];
+						out[i] = a->get_Length();
+					} else {
+						out[i] = 0.0;
+					}
 				}
 		}
 		OGRGeometryFactory f;


### PR DESCRIPTION
The current implementation would likely crash on things like OGRPolyhedralSurface.