### PR TITLE
add OSGeo software DOIs to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -48,10 +48,12 @@ Authors@R:
              comment = c(ORCID = "0000-0002-9415-4582"))
 			 )
 Description: Support for simple features, a standardized way to
-    encode spatial vector data. Binds to 'GDAL' for reading and writing
-    data, to 'GEOS' for geometrical operations, and to 'PROJ' for
-    projection conversions and datum transformations. Uses by default the 's2'
-    package for spherical geometry operations on ellipsoidal (long/lat) coordinates.
+    encode spatial vector data. Binds to 'GDAL' <doi: 10.5281/zenodo.5884351> 
+    for reading and writing data, to 'GEOS' <doi: 10.5281/zenodo.11396894> 
+    for geometrical operations, and to 'PROJ' <doi: 10.5281/zenodo.5884394> 
+    for projection conversions and datum transformations. Uses by default 
+    the 's2' package for spherical geometry operations on ellipsoidal 
+    (long/lat) coordinates.
 License: GPL-2 | MIT + file LICENSE
 URL: https://r-spatial.github.io/sf/, https://github.com/r-spatial/sf
 BugReports: https://github.com/r-spatial/sf/issues


### PR DESCRIPTION
OSGeo now provides DOI for (some) projects. This PR is to add the "all version" DOI for GDAL, GEOS and PROJ to DESCRIPTION. I'm not sure how to feed through to getting authors to cite software. @rhijmans probably relevant for `terra` too.