### PR TITLE
print.sfg() returns the input sfg, not its formatted string

### DIFF
--- a/R/sfg.R
+++ b/R/sfg.R
@@ -198,7 +198,7 @@ POLYGON2MULTIPOLYGON = function(x, dim = "XYZ") {
 print.sfg = function(x, ..., width = 0) { # avoids having to write print methods for 68 classes:
 	f = format(x, ..., width = width)
 	message(f)
-	invisible(f)
+	invisible(x)
 }
 
 #' @name st

--- a/tests/testthat/test-sfg.R
+++ b/tests/testthat/test-sfg.R
@@ -38,6 +38,11 @@ test_that("xx2multixx works", {
   expect_identical(sf:::POLYGON2MULTIPOLYGON(st_polygon(pts)), st_multipolygon(list(pts)))
 })
 
+test_that("print.sfg returns sfg", {
+  x = st_point(1:2)
+  expect_identical(print(x), x)
+})
+
 test_that("format works", {
 	digits = options("digits")[[1]]
 	options(digits = 16)

--- a/tests/testthat/test-wkt.R
+++ b/tests/testthat/test-wkt.R
@@ -2,7 +2,7 @@ test_that("well-known text", {
   gcol <- st_geometrycollection(list(st_point(1:2), st_linestring(matrix(1:4,2))))
   expect_message(x <- print(gcol), 
                  "GEOMETRYCOLLECTION \\(POINT \\(1 2\\), LINESTRING \\(1 3, 2 4\\)\\)", all = TRUE)
-  expect_equal(x, "GEOMETRYCOLLECTION (POINT (1 2), LINESTRING (1 3, 2 4))")
+  expect_equal(x, gcol)
   
   p1 = st_point(1:3)
   p2 = st_point(5:7)


### PR DESCRIPTION
The current behavior of `print.sfg()` is surprising because it returns a formatted string, which prevents the usage in a pipeline, e.g.,

```r
sf::st_point(1:2) |>
  print() |>
  sf::st_sfc() |>
  print()
# POINT (1 2)
# Error in UseMethod("st_bbox"): no applicable method for 'st_bbox' applied to an object of class "character"
```

As the vast majority of `print()` methods do, side-effect functions should return the original object (see <https://design.tidyverse.org/out-invisible.html>). Actually, `print.sf()` and `print.sfc()` already do this:

https://github.com/r-spatial/sf/blob/5567b747c8e5ad5aafc41ff0cfa103188fdb48e1/R/sf.R#L422-L445
https://github.com/r-spatial/sf/blob/5567b747c8e5ad5aafc41ff0cfa103188fdb48e1/R/sfc.R#L202-L267
