### PR TITLE
Weaken test for case of missing driver

### DIFF
--- a/tests/testthat/test-read.R
+++ b/tests/testthat/test-read.R
@@ -141,7 +141,7 @@ test_that("guess_driver_can_write", {
 
 test_that("driver operations", {
   # These tests are driver specifics to GDAL version and OS.
-  expect_error(guess_driver_can_write("x.e00"), "cannot write")
+  expect_error(guess_driver_can_write("x.e00"), "AVCE00 driver not available|cannot write")
   # expect_error(guess_driver_can_write("x.gdb"), "cannot write") -> no longer the case when GDAL >= 3.6.0
 
   expect_equal(guess_driver_can_write("x.geojson"), c("geojson" = "GeoJSON"))


### PR DESCRIPTION
Alternatively, we can do a `skip_if_not()`, but that would also skip the other 3 tests here, which could still be useful even for users lacking the AVCE00 driver. We could also branch this test (`if ("AVCE00" %in% ...) expect_error() else skip(...)`).