### PR TITLE
Preserve Z/M range attributes in st_cast

### DIFF
--- a/R/cast_sfc.R
+++ b/R/cast_sfc.R
@@ -132,7 +132,8 @@ st_cast_sfc_default = function(x) {
 
 copy_sfc_attributes_from = function(x, ret) {
 	structure(ret, precision = attr(x, "precision"),
-		bbox = attr(x, "bbox"), crs = attr(x, "crs"), n_empty = attr(x, "n_empty"))
+		bbox = attr(x, "bbox"), crs = attr(x, "crs"), n_empty = attr(x, "n_empty"), 
+		z_range = attr(x, "z_range"), m_range = attr(x, "m_range"))
 }
 
 empty_sfg <- function(to) {


### PR DESCRIPTION
After this change, `st_cast()` should preserve `z_range` and `m_range` attributes when they are present. Fixes #2565. 

Reprex: 

``` r
library(sf)
#> Linking to GEOS 3.13.0, GDAL 3.10.1, PROJ 9.5.1; sf_use_s2() is TRUE
# Just X and Y
p1 <- c(0, 0)
p2 <- c(1, 1)
st_multipoint(rbind(p1, p2)) |> st_sfc() |> st_cast("POINT") |> attributes()
#> $precision
#> [1] 0
#> 
#> $bbox
#> xmin ymin xmax ymax 
#>    0    0    1    1 
#> 
#> $crs
#> Coordinate Reference System: NA
#> 
#> $n_empty
#> [1] 0
#> 
#> $class
#> [1] "sfc_POINT" "sfc"      
#> 
#> $ids
#> [1] 2

# Add Z
p1 <- c(0, 0, 0)
p2 <- c(1, 1, 1)
st_multipoint(rbind(p1, p2)) |> st_sfc() |> st_cast("POINT") |> attributes()
#> $precision
#> [1] 0
#> 
#> $bbox
#> xmin ymin xmax ymax 
#>    0    0    1    1 
#> 
#> $crs
#> Coordinate Reference System: NA
#> 
#> $n_empty
#> [1] 0
#> 
#> $z_range
#> zmin zmax 
#>    0    1 
#> 
#> $class
#> [1] "sfc_POINT" "sfc"      
#> 
#> $ids
#> [1] 2

# Add Z and M
p1 <- c(0, 0, 0, 0)
p2 <- c(1, 1, 1, 1)
st_multipoint(rbind(p1, p2)) |> st_sfc() |> st_cast("POINT") |> attributes()
#> $precision
#> [1] 0
#> 
#> $bbox
#> xmin ymin xmax ymax 
#>    0    0    1    1 
#> 
#> $crs
#> Coordinate Reference System: NA
#> 
#> $n_empty
#> [1] 0
#> 
#> $z_range
#> zmin zmax 
#>    0    1 
#> 
#> $m_range
#> mmin mmax 
#>    0    1 
#> 
#> $class
#> [1] "sfc_POINT" "sfc"      
#> 
#> $ids
#> [1] 2
```

With the current Github version, the `z_range` and `m_range` attributes are lost when `st_cast`ing. I didn't add tests or NEWS bullets since it's very minor. 

<sup>Created on 2025-12-22 with [reprex v2.1.1.9000](https://reprex.tidyverse.org)</sup>

<details style="margin-bottom:10px;">
<summary>
Session info
</summary>

``` r
sessioninfo::session_info()
#> Warning in system2("quarto", "-V", stdout = TRUE, env = paste0("TMPDIR=", :
#> running command '"quarto"
#> TMPDIR=C:/Users/andre/AppData/Local/Temp/Rtmp4sicdu/file4e14611f146e -V' had
#> status 1
#> ─ Session info ───────────────────────────────────────────────────────────────
#>  setting  value
#>  version  R version 4.4.2 (2024-10-31 ucrt)
#>  os       Windows 11 x64 (build 26200)
#>  system   x86_64, mingw32
#>  ui       RTerm
#>  language (EN)
#>  collate  Italian_Italy.utf8
#>  ctype    Italian_Italy.utf8
#>  tz       Europe/Rome
#>  date     2025-12-22
#>  pandoc   3.2 @ C:/Program Files/RStudio/resources/app/bin/quarto/bin/tools/ (via rmarkdown)
#>  quarto   NA @ C:\\Users\\andre\\AppData\\Local\\Programs\\Quarto\\bin\\quarto.exe
#> 
#> ─ Packages ───────────────────────────────────────────────────────────────────
#>  package     * version    date (UTC) lib source
#>  class         7.3-22     2023-05-03 [2] CRAN (R 4.4.2)
#>  classInt      0.4-11     2025-01-08 [1] CRAN (R 4.4.2)
#>  cli           3.6.5      2025-04-23 [1] CRAN (R 4.4.2)
#>  DBI           1.2.3      2024-06-02 [1] CRAN (R 4.4.2)
#>  digest        0.6.37     2024-08-19 [1] CRAN (R 4.4.2)
#>  e1071         1.7-16     2024-09-16 [1] CRAN (R 4.4.2)
#>  evaluate      1.0.3      2025-01-10 [1] CRAN (R 4.4.2)
#>  fastmap       1.2.0      2024-05-15 [1] CRAN (R 4.4.2)
#>  fs            1.6.5      2024-10-30 [1] CRAN (R 4.4.2)
#>  glue          1.8.0      2024-09-30 [1] CRAN (R 4.4.2)
#>  htmltools     0.5.8.1    2024-04-04 [1] CRAN (R 4.4.2)
#>  KernSmooth    2.23-24    2024-05-17 [2] CRAN (R 4.4.2)
#>  knitr         1.50.4     2025-07-11 [1] https://yihui.r-universe.dev (R 4.4.2)
#>  lifecycle     1.0.4      2023-11-07 [1] CRAN (R 4.4.2)
#>  magrittr      2.0.3      2022-03-30 [1] CRAN (R 4.4.2)
#>  proxy         0.4-27     2022-06-09 [1] CRAN (R 4.4.2)
#>  Rcpp          1.1.0      2025-07-02 [1] CRAN (R 4.4.2)
#>  reprex        2.1.1.9000 2025-02-25 [1] Github (tidyverse/reprex@07cd5d7)
#>  rlang         1.1.6      2025-04-11 [1] CRAN (R 4.4.3)
#>  rmarkdown     2.29       2024-11-04 [1] CRAN (R 4.4.2)
#>  rstudioapi    0.17.1     2024-10-22 [1] CRAN (R 4.4.2)
#>  sessioninfo   1.2.3      2025-02-05 [1] CRAN (R 4.4.2)
#>  sf          * 1.0-24     2025-12-22 [1] local
#>  units         1.0-0.1    2025-11-15 [1] Github (r-quantities/units@942fb9c)
#>  withr         3.0.2      2024-10-28 [1] CRAN (R 4.4.2)
#>  xfun          0.52       2025-04-02 [1] CRAN (R 4.4.2)
#>  yaml          2.3.10     2024-07-26 [1] CRAN (R 4.4.2)
#> 
#>  [1] C:/Users/andre/AppData/Local/R/win-library/4.4
#>  [2] C:/Program Files/R/R-4.4.2/library
#>  * ── Packages attached to the search path.
#> 
#> ──────────────────────────────────────────────────────────────────────────────
```

</details>
