### PR TITLE
gdal.h: align declaration and definition

### DIFF
--- a/src/gdal.h
+++ b/src/gdal.h
@@ -3,6 +3,6 @@ void unset_error_handler(void);
 OGRSpatialReference *handle_axis_order(OGRSpatialReference *sr);
 Rcpp::List create_crs(const OGRSpatialReference *ref, bool set_input);
 Rcpp::CharacterVector wkt_from_spatial_reference(const OGRSpatialReference *srs);
-int srid_form_crs(Rcpp::List crs);
+int srid_from_crs(Rcpp::List crs);
 void   set_config_options(Rcpp::CharacterVector ConfigOptions);
 void unset_config_options(Rcpp::CharacterVector ConfigOptions);


### PR DESCRIPTION
This seems like a typo, so declare
the function that has a definition
in gdal.cpp.