### PR TITLE
gdal.h: align create_crs declarations

### DIFF
--- a/src/gdal.h
+++ b/src/gdal.h
@@ -1,7 +1,7 @@
 void set_error_handler(void);
 void unset_error_handler(void);
 OGRSpatialReference *handle_axis_order(OGRSpatialReference *sr);
-Rcpp::List create_crs(const OGRSpatialReference *ref, bool set_input);
+Rcpp::List create_crs(const OGRSpatialReference *ref, bool set_input = true);
 Rcpp::CharacterVector wkt_from_spatial_reference(const OGRSpatialReference *srs);
 int srid_from_crs(Rcpp::List crs);
 void   set_config_options(Rcpp::CharacterVector ConfigOptions);


### PR DESCRIPTION
The other declaration of create_crs
has a default value for the second
parameter, so align this declaration
with the other declaration.