### PR TITLE
Fix GDAL 3.13 compatibility

### DIFF
--- a/src/gdal.cpp
+++ b/src/gdal.cpp
@@ -456,7 +456,7 @@ std::vector<char *> create_options(Rcpp::CharacterVector lco, bool quiet) {
 }
 
 // convert NULL-terminated array of strings to Rcpp::CharacterVector
-Rcpp::CharacterVector charpp2CV(char **cp) {
+Rcpp::CharacterVector charpp2CV(CSLConstList cp) {
 	int n = 0;
 	while (cp && cp[n] != NULL)
 		n++; // count

--- a/src/gdal_sf_pkg.h
+++ b/src/gdal_sf_pkg.h
@@ -7,4 +7,4 @@ Rcpp::List create_crs(const OGRSpatialReference *ref, bool set_input = true);
 
 void handle_error(OGRErr err);
 std::vector<char *> create_options(Rcpp::CharacterVector lco, bool quiet = true);
-Rcpp::CharacterVector charpp2CV(char **cp);
+Rcpp::CharacterVector charpp2CV(CSLConstList cp);


### PR DESCRIPTION
GDALGetMetadata has changed signature
in GDAL 3.13, so change the signature
of charpp2CV to be compatible with
that.

https://github.com/OSGeo/gdal/blob/9159b2538a36062318104e585ecc77a0c81e6de3/doc/source/user/migration_guide.rst?plain=1#L19-L23