### PR TITLE
POC for mixed type ptype2 and cast methods

### DIFF
--- a/R/tidyverse-vctrs.R
+++ b/R/tidyverse-vctrs.R
@@ -34,6 +34,9 @@ register_vctrs_methods = function() {
 	s3_register("vctrs::vec_ptype2", "sfc_MULTIPOLYGON.sfc_MULTIPOLYGON")
 	s3_register("vctrs::vec_ptype2", "sfc_GEOMETRY.sfc_GEOMETRY")
 
+	s3_register("vctrs::vec_ptype2", "sfc_POINT.sfc_LINESTRING")
+	s3_register("vctrs::vec_ptype2", "sfc_LINESTRING.sfc_POINT")
+
 	s3_register("vctrs::vec_cast", "sfc_POINT.sfc_POINT")
 	s3_register("vctrs::vec_cast", "sfc_MULTIPOINT.sfc_MULTIPOINT")
 	s3_register("vctrs::vec_cast", "sfc_LINESTRING.sfc_LINESTRING")
@@ -41,6 +44,9 @@ register_vctrs_methods = function() {
 	s3_register("vctrs::vec_cast", "sfc_POLYGON.sfc_POLYGON")
 	s3_register("vctrs::vec_cast", "sfc_MULTIPOLYGON.sfc_MULTIPOLYGON")
 	s3_register("vctrs::vec_cast", "sfc_GEOMETRY.sfc_GEOMETRY")
+
+	s3_register("vctrs::vec_cast", "sfc_GEOMETRY.sfc_POINT")
+	s3_register("vctrs::vec_cast", "sfc_GEOMETRY.sfc_LINESTRING")
 }
 #nocov end
 
@@ -155,6 +161,22 @@ vec_ptype2_sfc_sfc = function(x, y) {
 	x
 }
 
+vec_ptype2.sfc_POINT.sfc_LINESTRING = function(x, y, ...) {
+	vec_ptype2_geometry(x, y)
+}
+vec_ptype2.sfc_LINESTRING.sfc_POINT = function(x, y, ...) {
+	vec_ptype2_geometry(x, y)
+}
+vec_ptype2_geometry = function(x, y) {
+	check_same_crs(x, y)
+	check_same_precision(x, y)
+	# Returns `sfc_GEOMETRY` abstract class
+	st_sfc(
+		crs = st_crs(x),
+		precision = st_precision(x)
+	)
+}
+
 vec_cast.sfc_POINT.sfc_POINT = function(x, to, ...) {
 	vec_cast_sfc_sfc(x, to)
 }
@@ -180,6 +202,19 @@ vec_cast_sfc_sfc = function(x, to) {
 	check_same_crs(x, to)
 	check_same_precision(x, to)
 	x
+}
+
+vec_cast.sfc_GEOMETRY.sfc_POINT = function(x, to, ...) {
+	vec_cast_geometry(x, to)
+}
+vec_cast.sfc_GEOMETRY.sfc_LINESTRING = function(x, to, ...) {
+	vec_cast_geometry(x, to)
+}
+vec_cast_geometry <- function(x, to) {
+	check_same_crs(x, to)
+	check_same_precision(x, to)
+	x <- sf_unstructure(x)
+	st_sfc(x) # TODO: This needs to FORCE `sfc_GEOMETRY`, regardless of values in `x`
 }
 
 sf_unstructure = function(x) {


### PR DESCRIPTION
Merges into the `vctrs` branch
Building on https://github.com/r-spatial/sf/pull/2574

Replying to https://github.com/r-spatial/sf/pull/2574#issuecomment-3768655531

> After a lot of experimentation, and re-reading your comment, I come to the conclusion that vctrs doesn't let us create a sfc_GEOMETRY when joining a sfc_POINT with a sfc_LINESTRING, following the path you sketch with this PR. If that is the case, that I'm afraid we're at a dead end here, as one cannot meaningfully convert a POINT geometry into a LINESTRING geometry or vice versa. How do you suggest we proceed?

This is the restriction I mentioned in this comment
https://github.com/r-spatial/sf/pull/2574#issuecomment-3756850111

You _can_ do this with additional ptype2 and cast methods, but it is going to result in a very large number of ptype2 methods. That might be okay, we can just force an LLM to generate them if we think we really need this feature.

This PR has a POC of this idea.

I've added some symmetric ptype2 functions:

```r
vec_ptype2.sfc_POINT.sfc_LINESTRING
vec_ptype2.sfc_LINESTRING.sfc_POINT
```

This lets vctrs figure out that the common type of an `sfc_POINT` and `sfc_LINESTRING` is a fallback type of `sfc_GEOMETRY` (regardless of the order they are combined in). This is where the combinatorics of the methods is going to explode though.

You then have to support this by providing cast methods from each of these types to `sfc_GEOMETRY`, so I've added:

```r
vec_cast.sfc_GEOMETRY.sfc_POINT
vec_cast.sfc_GEOMETRY.sfc_LINESTRING
```

You'd add one of these for each of the big 7.

It's _almost_ right, but `vec_cast()` isn't quite right yet (I added a big TODO in there about the problem). We really need a way to _force_ an `sfc_POINT` or `sfc_LINESTRING` into an `sfc_GEOMETRY`, regardless of the underlying data in there (i.e. even though it is a homogenous vector of `POINT`s, we need it to say `sfc_GEOMETRY` on the way out from the `vec_cast()` method). I can't figure out a way to do that. If we could do that, then we could write out the huge number of methods required to ensure that combining mixed sfc classes would always fall back to `sfc_GEOMETRY`.

Here's the state of things with these methods:

``` r
library(sf)
library(vctrs)

x <- st_sfc(
  st_point(c(1, 2)),
  st_point(c(3, 4))
)
y <- st_sfc(
  st_linestring(matrix(c(5, 6), nrow = 1)),
  st_linestring(matrix(c(7, 8), nrow = 1))
)

x
#> Geometry set for 2 features 
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 1 ymin: 2 xmax: 3 ymax: 4
#> CRS:           NA
#> POINT (1 2)
#> POINT (3 4)
y
#> Geometry set for 2 features 
#> Geometry type: LINESTRING
#> Dimension:     XY
#> Bounding box:  xmin: 5 ymin: 6 xmax: 7 ymax: 8
#> CRS:           NA
#> LINESTRING (5 6)
#> LINESTRING (7 8)

# Common type is abstract sfc_GEOMETRY
vec_ptype2(x, y)
#> Geometry set for 0 features 
#> Bounding box:  xmin: NA ymin: NA xmax: NA ymax: NA
#> CRS:           NA
class(vec_ptype2(x, y))
#> [1] "sfc_GEOMETRY" "sfc"

# But casting to that doesn't quite work yet.
# These need to return `sfc_GEOMETRY`, not the specific type.
ptype <- vec_ptype2(x, y)

# Wrong, needs to be `sfc_GEOMETRY`
vec_cast(x, ptype)
#> Geometry set for 2 features 
#> Geometry type: POINT
#> Dimension:     XY
#> Bounding box:  xmin: 1 ymin: 2 xmax: 3 ymax: 4
#> CRS:           NA
#> POINT (1 2)
#> POINT (3 4)
class(vec_cast(x, ptype))
#> [1] "sfc_POINT" "sfc"

# Wrong, needs to be `sfc_GEOMETRY`
vec_cast(y, ptype)
#> Geometry set for 2 features 
#> Geometry type: LINESTRING
#> Dimension:     XY
#> Bounding box:  xmin: 5 ymin: 6 xmax: 7 ymax: 8
#> CRS:           NA
#> LINESTRING (5 6)
#> LINESTRING (7 8)
class(vec_cast(y, ptype))
#> [1] "sfc_LINESTRING" "sfc"

# By chance, this happens to work now due to the fact that
# the internal structures of sfc_GEOMETRY and sfc_POINT and
# sfc_LINESTRING are all the same, but we really need to fix
# the vec_cast() methods first for me to feel good about it.
vec_c(x, y)
#> Geometry set for 4 features 
#> Geometry type: GEOMETRY
#> Dimension:     XY
#> Bounding box:  xmin: 1 ymin: 2 xmax: 7 ymax: 8
#> CRS:           NA
#> POINT (1 2)
#> POINT (3 4)
#> LINESTRING (5 6)
#> LINESTRING (7 8)
```