### PR TITLE
Stop casting away const

### DIFF
--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -1087,7 +1087,7 @@ Rcpp::NumericMatrix CPL_geos_dist(Rcpp::List sfc0, Rcpp::List sfc1,
 typedef struct { GEOSGeom g; size_t id; } item_g;
 
 int distance_fn(const void *item1, const void *item2, double *distance, void *userdata) {
-	return GEOSDistance_r( (GEOSContextHandle_t) userdata, ((item_g *)item1)->g, ((item_g *)item2)->g, distance);
+	return GEOSDistance_r( (GEOSContextHandle_t) userdata, ((const item_g *)item1)->g, ((const item_g *)item2)->g, distance);
 }
 
 // [[Rcpp::export(rng=false)]]
@@ -1112,11 +1112,12 @@ Rcpp::IntegerVector CPL_geos_nearest_feature(Rcpp::List sfc0, Rcpp::List sfc1) {
 	Rcpp::IntegerVector out(gmv0.size());
 	for (size_t i = 0; i < gmv0.size(); i++) {
 		if (!GEOSisEmpty_r(hGEOSCtxt, gmv0[i].get()) && !tree_is_empty) {
-			item_g item, *ret_item;
+			item_g item;
 			item.id = 0; // is irrelevant
 			item.g = gmv0[i].get();
+			const item_g *ret_item;
 			// now query tree for nearest GEOM at item:
-			ret_item = (item_g *) GEOSSTRtree_nearest_generic_r(hGEOSCtxt, tree.get(), &item,
+			ret_item = (const item_g *) GEOSSTRtree_nearest_generic_r(hGEOSCtxt, tree.get(), &item,
 					gmv0[i].get(), distance_fn, hGEOSCtxt);
 			if (ret_item != NULL)
 				out[i] = ret_item->id; // the index (1-based) of nearest GEOM

--- a/src/polygonize.cpp
+++ b/src/polygonize.cpp
@@ -80,12 +80,12 @@ Rcpp::List CPL_polygonize(Rcpp::CharacterVector raster, Rcpp::CharacterVector ma
 	if (wkt != NULL && *wkt != '\0') {
 		sr = new OGRSpatialReference;
 		sr = handle_axis_order(sr);
-		char **ppt = (char **) &wkt;
 #if GDAL_VERSION_NUM < 2030000
-		sr->importFromWkt(ppt);
+		char **ppt = (char **) &wkt;
 #else
-		sr->importFromWkt( (const char**) ppt);
+		const char **ppt = (const char **) &wkt;
 #endif
+		sr->importFromWkt(ppt);
 	}
 	OGRLayer *poLayer = poDS->CreateLayer("raster", sr, wkbMultiPolygon, NULL);
 	delete sr;

--- a/src/wkb.cpp
+++ b/src/wkb.cpp
@@ -396,7 +396,7 @@ Rcpp::List read_data(wkb_buf *wkb, bool EWKB = false, bool spatialite = false,
 
 int native_endian(void) {
 	const int one = 1;
-	unsigned char *cp = (unsigned char *) &one;
+	const unsigned char *cp = (const unsigned char *) &one;
 	return (int) *cp;
 }
 
@@ -505,7 +505,7 @@ void add_byte(std::ostringstream& os, char c) {
 }
 
 void add_int(std::ostringstream& os, unsigned int i) {
-  const char *cp = (char *)&i;
+  char *cp = (char *)&i;
   os.write((char*) cp, sizeof(int));
 }
 
@@ -521,7 +521,7 @@ double make_precise(double d, double precision) {
 
 void add_double(std::ostringstream& os, double d, double prec = 0.0) {
   d = make_precise(d, prec); // doubles are ALWAYS coordinates
-  const char *cp = (char *)&d;
+  char *cp = (char *)&d;
   os.write((char*) cp, sizeof(double));
 }
 


### PR DESCRIPTION
The compiler might use this information
for optimization, so adjust the code
so the const isn't lost.