### PR TITLE
CSLConstList compat for GDAL 3.1.3

### DIFF
--- a/src/stars.cpp
+++ b/src/stars.cpp
@@ -505,7 +505,7 @@ void CPL_write_gdal(NumericMatrix x, CharacterVector fname, CharacterVector driv
 		stop("driver not recognized."); // #nocov
 
 	// can this driver Create()?
-	char **papszMetadata = poDriver->GetMetadata();
+	CSLConstList papszMetadata = poDriver->GetMetadata();
 	if (!CSLFetchBoolean( papszMetadata, GDAL_DCAP_CREATE, FALSE ) && !CSLFetchBoolean( papszMetadata, GDAL_DCAP_CREATECOPY, FALSE ) )
 		stop("driver does not support Create() or CreateCopy() method."); // #nocov
 


### PR DESCRIPTION
GDAL 3.13 requires  `CSLConstList` for `GetMetadata`

https://github.com/OSGeo/gdal/pull/13658


```R
library(sf)
#Linking to GEOS 3.12.1, GDAL 3.13.0dev-7924dc998e, PROJ 9.8.0; sf_use_s2() is TRUE
```

🙏 