### PR TITLE
update roxygen2 configuration and CI workflows for recent r-lib/actions changes

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -39,6 +39,10 @@ jobs:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
 
+      - name: Install macOS system dependencies
+        if: runner.os == 'macos'
+        run: brew install gdal proj
+
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches: [main, master]
   pull_request:
+  schedule:
+    - cron: "0 4 * * *"
 
 name: R-CMD-check
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -4,11 +4,10 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
-  schedule:
-    - cron: "0 4 * * *"
 
 name: R-CMD-check
+
+permissions: read-all
 
 jobs:
   R-CMD-check:
@@ -25,14 +24,13 @@ jobs:
           - {os: ubuntu-latest,   r: 'devel', http-user-agent: 'release'}
           - {os: ubuntu-latest,   r: 'release'}
           - {os: ubuntu-latest,   r: 'oldrel-1'}
-          - {os: ubuntu-latest,   r: 'oldrel-2'}
 
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       R_KEEP_PKG_SOURCE: yes
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
@@ -40,11 +38,6 @@ jobs:
         with:
           r-version: ${{ matrix.config.r }}
           http-user-agent: ${{ matrix.config.http-user-agent }}
-          use-public-rspm: true
-
-      - name: Install macOS system dependencies
-        if: runner.os == 'macos'
-        run: brew install gdal proj
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -54,3 +47,4 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+          build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -4,12 +4,13 @@ on:
   push:
     branches: [main, master]
   pull_request:
-    branches: [main, master]
   release:
     types: [published]
   workflow_dispatch:
 
 name: pkgdown
+
+permissions: read-all
 
 jobs:
   pkgdown:
@@ -22,13 +23,11 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: r-lib/actions/setup-pandoc@v2
 
       - uses: r-lib/actions/setup-r@v2
-        with:
-          use-public-rspm: true
 
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
@@ -41,7 +40,7 @@ jobs:
 
       - name: Deploy to GitHub pages 🚀
         if: github.event_name != 'pull_request'
-        uses: JamesIves/github-pages-deploy-action@v4.5.0
+        uses: JamesIves/github-pages-deploy-action@d92aa235d04922e8f08b40ce78cc5442fcfbfa2f # v4.8.0
         with:
           clean: false
           branch: gh-pages

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -118,9 +118,10 @@ LinkingTo:
 VignetteBuilder: 
     knitr
 Encoding: UTF-8
-Roxygen: list(markdown = TRUE)
 Config/testthat/edition: 2
 Config/needs/coverage: XML
+Config/roxygen2/markdown: TRUE
+Config/roxygen2/version: 8.0.0
 SystemRequirements: GDAL (>= 2.0.1), GEOS (>= 3.4.0),
     PROJ (>= 4.8.0), sqlite3
 Collate: 
@@ -177,4 +178,3 @@ Collate:
     'terra.R'
     'geos-overlayng.R'
     'break_antimeridian.R'
-Config/roxygen2/version: 8.0.0


### PR DESCRIPTION
This PR updates roxygen2 configuration and CI workflows to align with recent upstream changes.

## Changes

- Switch to the new configuration style introduced in roxygen2 8.0.0, see https://opensource.posit.co/blog/2026-05-01_roxygen2-8-0-0/#a-cleaner-home-for-configuration
- Update GitHub Actions workflows to versions using node 24 (`actions/checkout@v6` and `JamesIves/github-pages-deploy-action@v4.8.0`)
- Adapt to changes in `r-lib/actions`, including updated `setup-r` defaults for RSPM
- CI workflows: Run `pull_request` on all branches 