### PR TITLE
Skip requireNamespace check for s2, which is Imports

### DIFF
--- a/R/geom-measures.R
+++ b/R/geom-measures.R
@@ -119,8 +119,6 @@ message_longlat = function(caller) {
 st_perimeter = function(x, ...) {
 	x = st_geometry(x)
 	if (sf_use_s2() && isTRUE(st_is_longlat(x))) { # for spherical geometries we use s2 
-		if (!requireNamespace("s2", quietly = TRUE))
-			stop("package s2 required to calculate the perimeter of spherical geometries")
 		# ensure units are set to meters 
 		units::set_units(
 			s2::s2_perimeter(x, ...), 

--- a/tests/testthat/test-s2.R
+++ b/tests/testthat/test-s2.R
@@ -1,4 +1,3 @@
-skip_if_not_installed("s2")
 test_that("s2 roundtrips work", {
   library(s2)
   nc = st_geometry(st_read(system.file("shape/nc.shp", package="sf")))


### PR DESCRIPTION
This is superfluous since {s2} is a required package -- it's probably vestigial from when {s2} was previously `Suggests`.