### PR TITLE
Restore graphics state after plot key errors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 * guess Parquet driver from `.parquet` file extension; #2506
 
+* restore the graphics state after a failed `plot.sf()` key; #2611
+
 * move dependency `classInt` to Suggests:
 
 # version 1.1-2

--- a/R/plot.R
+++ b/R/plot.R
@@ -114,6 +114,7 @@ plot.sf <- function(x, y, ..., main, pal = NULL, nbreaks = 10, breaks = "pretty"
 	col_missing = is.null(dots$col)
 	breaks_numeric = is.numeric(breaks)
 	reset_layout_needed = reset
+	plot_completed = FALSE
 
 	x = swap_axes_if_needed(x)
 	
@@ -125,9 +126,11 @@ plot.sf <- function(x, y, ..., main, pal = NULL, nbreaks = 10, breaks = "pretty"
 	on.exit(
 		expr = {
 			if (!isTRUE(dots$add) && reset) { # reset device: 
+				par(opar)
+				if (reset_layout_needed && !plot_completed)
+					try(plot.new(), silent = TRUE)
 				if (reset_layout_needed) 
 					layout(matrix(1))
-				par(opar)
 			}
 		}, 
 		add = TRUE
@@ -345,6 +348,7 @@ plot.sf <- function(x, y, ..., main, pal = NULL, nbreaks = 10, breaks = "pretty"
 			localTitle(main, ...)
 		}
 	}
+	plot_completed = TRUE
 	invisible()
 }
 
@@ -1062,13 +1066,13 @@ xy_from_r = function(r, l, o) {
 	poly = vector(mode="list", length(col))
 	for (i in seq(poly))
 		poly[[i]] = c(breaks[i], breaks[i+1], breaks[i+1], breaks[i])
+	sz = cm(max(strwidth(z, "inches"))) * 1.3 + par("ps")/12 # cm
 
 	tryCatch({
 		plot(1, 1, type = "n", ylim = ylim, xlim = xlim, axes = FALSE,
 			xlab = "", ylab = "", xaxs = "i", yaxs = "i")
 		},
 		error = function(x) {
-			sz = cm(max(strwidth(z, "inches"))) * 1.3 + par("ps")/12 # cm
 			stop(paste0("key.width too small, try key.width = lcm(", signif(sz, 3), ")"), call. = FALSE)
 		}
 	)

--- a/tests/testthat/test-plot.R
+++ b/tests/testthat/test-plot.R
@@ -18,3 +18,20 @@ test_that("plot.sf deals with key.length in cm", {
   expect_silent(plot(nc["f"], key.length = lcm(5), key.pos = 2))
   expect_silent(plot(nc["f"], key.length = lcm(5), key.pos = 1))
 })
+
+test_that("plot.sf restores the graphics state after a key error", {
+	nc = st_read(system.file("shape/nc.shp", package="sf"), "nc", quiet = TRUE)
+	nc$toy = c("A,    B", rep("A", length.out = nrow(nc) - 1))
+
+	png_file = tempfile(fileext = ".png")
+	png(png_file, type = "cairo", width = 800, height = 600)
+	par(family = "sans")
+	on.exit({
+		dev.off()
+		unlink(png_file)
+	})
+
+	expect_silent(plot(nc["toy"]))
+	expect_error(plot(nc["toy"], key.pos = 2), "key.width too small")
+	expect_silent(plot(nc["toy"], key.pos = 2, key.width = lcm(6)))
+})


### PR DESCRIPTION
Summary

Handle the error path where plotting a key that is too narrow leaves the graphics device in an invalid state, and sync the PR branch with current `main` so it is reviewable again.

Thanks to maintainers

Thanks for maintaining sf and for the note on #2611. The reproducer there made this easier to narrow down.

Issue or motivation

Closes #2611. With long factor labels and `key.pos = 2`, `plot.sf()` can report an invalid graphics state. After that, retrying on the same device with a wider key can still fail because the previous error left the device/layout state broken.

Root cause

The failing key plot happens inside `.image_scale_factor()`. Its error handler then called `strwidth()` after the device was already in a bad state, which could mask the useful `key.width too small` message. Separately, `plot.sf()` reset the layout before restoring `par()`, so an error while resetting the layout could prevent restoration of the previous graphical parameters.

Change

This computes the fallback key width before the risky key plot, so the error handler does not query text widths after failure. It also restores `par()` before resetting the layout, and starts a new plot only on the incomplete error path to get the device back to a usable state. The latest update only merges current `main` and resolves the `NEWS.md` conflict.

Tests

- `R_LIBS_USER=... Rscript --vanilla -e '.libPaths(c(Sys.getenv("R_LIBS_USER"), .libPaths())); library(sf); testthat::test_file("tests/testthat/test-plot.R", reporter="summary")'` passed: 9 assertions.
- `git diff origin/main --check` passed for the final PR diff.
- `R_LIBS_USER=... R CMD build --no-manual --no-build-vignettes .` passed and built `sf_1.1-3.tar.gz`.
- `_R_CHECK_FORCE_SUGGESTS_=false _R_CHECK_CRAN_INCOMING_REMOTE_=false R CMD check --as-cran --no-manual --ignore-vignettes --no-build-vignettes sf_1.1-3.tar.gz` exited 0 with 2 NOTEs.

The NOTEs were the expected no-prebuilt-vignette-index note from not building vignettes locally, and saved-output numeric/platform differences in the spatial tests under my local GDAL 3.13.1, GEOS 3.14.1, and PROJ 9.8.1 stack. The new `plot.R` output matched.

Scope

This does not change key sizing policy, regenerate documentation, or try to make the automatically suggested key width wide enough for every device. It only keeps the error path recoverable, preserves the existing useful `key.width too small` guidance, and restores the PR branch to a mergeable state.
