### PR TITLE
Use GEOSGridIntersectionFractions_r() directly in st_interpolate_aw

### DIFF
--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -281,6 +281,10 @@ CPL_line_interpolate <- function(lines, dists, normalized) {
     .Call(`_sf_CPL_line_interpolate`, lines, dists, normalized)
 }
 
+CPL_grid_intersection_fractions <- function(p, geoms) {
+    .Call(`_sf_CPL_grid_intersection_fractions`, p, geoms)
+}
+
 CPL_hex_to_raw <- function(cx) {
     .Call(`_sf_CPL_hex_to_raw`, cx)
 }

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -225,11 +225,29 @@ st_interpolate_aw.stars = function(x, to, extensive, ...) {
 			if (inherits(to, "try-error"))
 				stop("st_interpolate_aw requires geometries in argument to")
 		}
-		# stop("not yet implemented")
+		# check x and y are first two dimensions:
 		if (!identical(match(attr(st_dimensions(x), "raster")$dimensions, names(dim(x))), 1:2))
 			stop("raster dimensions need to be as position 1 and 2; use aperm to rearrange")
-		w = CPL_grid_intersection_fractions(c(st_bbox(x), dim(x)), to)
-		w
+		if (st_dimensions(x)[[2]]$delta > 0)
+			stop("only implemented for negative N-S cellsize")
+		w = CPL_grid_intersection_fractions(c(st_bbox(x), dim(x)), st_geometry(to))
+		weight = function(a, w, extensive) {
+			d = dim(a)
+			dim(a) = c(prod(d[1:2]), prod(d[-(1:2)]))
+			ret = t(w) %*% a
+			if (!extensive) {
+				cs = colSums(w)
+				cs[cs == 0] = 1
+				ret = ret / cs
+			}
+			dim(ret) = c(ncol(w), d[-(1:2)])
+			ret
+		}
+		ret = lapply(x, weight, w, extensive)
+		dm = st_dimensions(x)
+		dm[[1]] = NULL
+		dm[[2]] = create_dimension(values = st_geometry(to))
+		st_as_stars(ret, dimensions = dm)
 	} else {
 		ret = st_interpolate_aw(st_as_sf(x), to, extensive, ...)
 		geom = attr(ret, "sf_column")

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -246,7 +246,9 @@ st_interpolate_aw.stars = function(x, to, extensive, ...) {
 		ret = lapply(x, weight, w, extensive)
 		dm = st_dimensions(x)
 		dm[[1]] = NULL
-		dm[[2]] = create_dimension(values = st_geometry(to))
+		g = st_geometry(to)
+		dm[[2]] = structure(list(from = 1L, to = length(g), offset = NA_real_, delta = NA_real_,
+								 refsys = st_crs(g), point = any(st_dimension(g) > 0), values = g), class = "dimension")
 		st_as_stars(ret, dimensions = dm)
 	} else {
 		ret = st_interpolate_aw(st_as_sf(x), to, extensive, ...)

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -246,9 +246,11 @@ st_interpolate_aw.stars = function(x, to, extensive, ...) {
 		ret = lapply(x, weight, w, extensive)
 		dm = st_dimensions(x)
 		dm[[1]] = NULL
+		attr(dm, "raster") = NULL
 		g = st_geometry(to)
-		dm[[2]] = structure(list(from = 1L, to = length(g), offset = NA_real_, delta = NA_real_,
+		dm[[1]] = structure(list(from = 1L, to = length(g), offset = NA_real_, delta = NA_real_,
 								 refsys = st_crs(g), point = any(st_dimension(g) > 0), values = g), class = "dimension")
+		names(dm)[1] = "geometry"
 		st_as_stars(ret, dimensions = dm)
 	} else {
 		ret = st_interpolate_aw(st_as_sf(x), to, extensive, ...)

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -246,7 +246,7 @@ st_interpolate_aw.stars = function(x, to, extensive, ...) {
 		ret = lapply(x, weight, w, extensive)
 		dm = st_dimensions(x)
 		dm[[1]] = NULL
-		attr(dm, "raster") = NULL
+		attr(dm, "raster")$dimensions = c(NA_character_, NA_character_)
 		g = st_geometry(to)
 		dm[[1]] = structure(list(from = 1L, to = length(g), offset = NA_real_, delta = NA_real_,
 								 refsys = st_crs(g), point = any(st_dimension(g) > 0), values = g), class = "dimension")

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -216,17 +216,29 @@ st_interpolate_aw.sf = function(x, to, extensive, ..., keep_NA = FALSE, na.rm = 
 st_interpolate_aw.stars = function(x, to, extensive, ...) {
 	if (! requireNamespace("stars", quietly = TRUE))
 		stop("package stars required, please install it first")
-	ret = st_interpolate_aw(st_as_sf(x), to, extensive, ...)
-	geom = attr(ret, "sf_column")
-	dx = dim(x)
-	if (length(dx) > 2 && length(x) == 1 && length(ret) > 2) {
-		ret = merge(stars::st_as_stars(ret))
-		nd = names(stars::st_dimensions(x))
-		ret = stars::st_set_dimensions(ret, seq_along(dx), 
-								names = c(geom, paste0(nd[-(1:2)], collapse = ".")))
-		setNames(ret, names(x))
-	} else
-		ret
+
+	if (st_raster_type(x) == "regular" && 
+			compareVersion(gsub("[a-zA-Z].+$", "", sf_extSoftVersion()[["GEOS"]]), "3.14.0") > -1) {
+		# we HAVE_GEOS_3_14_0
+		if (!inherits(to, "sf") && !inherits(to, "sfc")) {
+			to <- try(st_as_sf(to))
+			if (inherits(to, "try-error"))
+				stop("st_interpolate_aw requires geometries in argument to")
+		}
+		stop("not yet implemented")
+	} else {
+		ret = st_interpolate_aw(st_as_sf(x), to, extensive, ...)
+		geom = attr(ret, "sf_column")
+		dx = dim(x)
+		if (length(dx) > 2 && length(x) == 1 && length(ret) > 2) {
+			ret = merge(stars::st_as_stars(ret))
+			nd = names(stars::st_dimensions(x))
+			ret = stars::st_set_dimensions(ret, seq_along(dx), 
+									names = c(geom, paste0(nd[-(1:2)], collapse = ".")))
+			setNames(ret, names(x))
+		} else
+			ret
+	}
 }
 
 dasymetric = function(x, to, extensive, keep_NA, include_non_intersected) {

--- a/R/aggregate.R
+++ b/R/aggregate.R
@@ -225,7 +225,11 @@ st_interpolate_aw.stars = function(x, to, extensive, ...) {
 			if (inherits(to, "try-error"))
 				stop("st_interpolate_aw requires geometries in argument to")
 		}
-		stop("not yet implemented")
+		# stop("not yet implemented")
+		if (!identical(match(attr(st_dimensions(x), "raster")$dimensions, names(dim(x))), 1:2))
+			stop("raster dimensions need to be as position 1 and 2; use aperm to rearrange")
+		w = CPL_grid_intersection_fractions(c(st_bbox(x), dim(x)), to)
+		w
 	} else {
 		ret = st_interpolate_aw(st_as_sf(x), to, extensive, ...)
 		geom = attr(ret, "sf_column")

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -897,6 +897,17 @@ BEGIN_RCPP
     return rcpp_result_gen;
 END_RCPP
 }
+// CPL_grid_intersection_fractions
+Rcpp::NumericVector CPL_grid_intersection_fractions(Rcpp::NumericVector p, Rcpp::List geoms);
+RcppExport SEXP _sf_CPL_grid_intersection_fractions(SEXP pSEXP, SEXP geomsSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject rcpp_result_gen;
+    Rcpp::traits::input_parameter< Rcpp::NumericVector >::type p(pSEXP);
+    Rcpp::traits::input_parameter< Rcpp::List >::type geoms(geomsSEXP);
+    rcpp_result_gen = Rcpp::wrap(CPL_grid_intersection_fractions(p, geoms));
+    return rcpp_result_gen;
+END_RCPP
+}
 // CPL_hex_to_raw
 Rcpp::List CPL_hex_to_raw(Rcpp::CharacterVector cx);
 RcppExport SEXP _sf_CPL_hex_to_raw(SEXP cxSEXP) {
@@ -1497,6 +1508,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_sf_CPL_nary_intersection", (DL_FUNC) &_sf_CPL_nary_intersection, 1},
     {"_sf_CPL_line_project", (DL_FUNC) &_sf_CPL_line_project, 3},
     {"_sf_CPL_line_interpolate", (DL_FUNC) &_sf_CPL_line_interpolate, 3},
+    {"_sf_CPL_grid_intersection_fractions", (DL_FUNC) &_sf_CPL_grid_intersection_fractions, 2},
     {"_sf_CPL_hex_to_raw", (DL_FUNC) &_sf_CPL_hex_to_raw, 1},
     {"_sf_CPL_raw_to_hex", (DL_FUNC) &_sf_CPL_raw_to_hex, 1},
     {"_sf_CPL_read_mdim", (DL_FUNC) &_sf_CPL_read_mdim, 8},

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -38,6 +38,9 @@
 # if GEOS_VERSION_MINOR >= 12
 #  define HAVE312
 # endif
+# if GEOS_VERSION_MINOR >= 14
+#  define HAVE314
+# endif
 #else
 # if GEOS_VERSION_MAJOR > 3
 #  define HAVE340
@@ -49,6 +52,8 @@
 #  define HAVE310
 #  define HAVE3101
 #  define HAVE311
+#  define HAVE312
+#  define HAVE314
 # endif
 #endif
 
@@ -1607,5 +1612,28 @@ Rcpp::List CPL_line_interpolate(Rcpp::List lines, Rcpp::NumericVector dists, boo
 			p[i] = geos_ptr(GEOSInterpolate_r(hGEOSCtxt, l[i].get(), dists[i]), hGEOSCtxt);
 	}
 	Rcpp::List ret(sfc_from_geometry(hGEOSCtxt, p, dim));
+	return ret;
+}
+
+// [[Rcpp::export(rng=false)]]
+Rcpp::NumericVector CPL_grid_intersection_fractions(Rcpp::NumericVector p, Rcpp::List geoms) {
+	GEOSContextScope hGEOSCtxt;
+	int dim = 2;
+	unsigned ncell = p[4] * p[5];
+	std::vector<GeomPtr> g = geometries_from_sfc(hGEOSCtxt, geoms, &dim);
+	std::vector<float> buf(ncell); // nx * ny * n.geoms
+	Rcpp::NumericVector ret(ncell * g.size());
+	for (int i = 0; i < (int) g.size(); i++) {
+#ifdef HAVE314
+		if (GEOSGridIntersectionFractions_r(hGEOSCtxt, g[i].get(), p[0], p[1], p[2], p[3], (unsigned) p[4], (unsigned) p[5], buf.data()))
+#else
+			Rcpp::stop("GEOS >= 3.14.0 required");
+#endif
+		for (int j = 0; j < ncell; j++)
+			ret[i * ncell + j] = buf[j];
+	}
+	Rcpp::IntegerVector d(2);
+	d[0] = ncell; d[1] = g.size();
+	ret.attr("dim") = d;
 	return ret;
 }

--- a/src/geos.cpp
+++ b/src/geos.cpp
@@ -1624,13 +1624,15 @@ Rcpp::NumericVector CPL_grid_intersection_fractions(Rcpp::NumericVector p, Rcpp:
 	std::vector<float> buf(ncell); // nx * ny * n.geoms
 	Rcpp::NumericVector ret(ncell * g.size());
 	for (int i = 0; i < (int) g.size(); i++) {
+		for (int j = 0; j < ncell; j++)
+			buf[j] = 0.0; // initialize, needed for i > 0!
 #ifdef HAVE314
 		if (GEOSGridIntersectionFractions_r(hGEOSCtxt, g[i].get(), p[0], p[1], p[2], p[3], (unsigned) p[4], (unsigned) p[5], buf.data()))
 #else
 			Rcpp::stop("GEOS >= 3.14.0 required");
 #endif
 		for (int j = 0; j < ncell; j++)
-			ret[i * ncell + j] = buf[j];
+			ret[i * ncell + j] = (double) buf[j];
 	}
 	Rcpp::IntegerVector d(2);
 	d[0] = ncell; d[1] = g.size();


### PR DESCRIPTION
`st_interpolate_aw()` is for area-weighted interpolation, estimating attribute values from geometry set A to an arbitrary geometry set B, by using averaging (intensive variables) or summing/redistributing (extensive variables). The naive implementation computes all A-B intersections, and uses their areas for weighting. Since GEOS 3.14, `GEOSGridIntersectionFractions_r` (migrated from @dbaston's  [exactextracter](https://github.com/isciences/exactextractr)) computes such weights much more efficiently in case A or B is (regularly) gridded; and tbh that is probably a very common, if not dominant, use case. The current PR implements this both for `x` (source geoms) being a regularly gridded `stars` object, as well as `to` (target geoms).

The  `st_interpolated_aw.stars()` has been added to `sf` in the current CRAN release for that reason, and needs to be removed from `stars` (which happened in https://github.com/r-spatial/stars/commit/50ad7e859cab09e8e38a10f3ebc132a1643d9bdc).